### PR TITLE
refactor: replace AuthForm with AuthLayout in authentication pages

### DIFF
--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { AuthForm } from '@/components/auth/auth-form';
+import { AuthLayout } from '@/components/auth/auth-layout';
 
 export default function LoginPage() {
   return (
     <div className="animate-in fade-in duration-500">
-      <AuthForm type="login" />
+      <AuthLayout type="login" />
     </div>
   );
 } 

--- a/app/(auth)/register/page.tsx
+++ b/app/(auth)/register/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { AuthForm } from '@/components/auth/auth-form';
+import { AuthLayout } from '@/components/auth/auth-layout';
 
 export default function RegisterPage() {
   return (
     <div className="animate-in fade-in duration-500">
-      <AuthForm type="register" />
+      <AuthLayout type="register" />
     </div>
   );
 } 

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -1,5 +1,4 @@
 import { zodResolver } from '@hookform/resolvers/zod';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import React, { useEffect } from 'react';
@@ -468,17 +467,6 @@ export function AuthForm({ type, defaultValues, onSuccess }: AuthFormProps) {
           >
             {buttonText}
           </Button>
-
-          {type === 'login' && (
-            <div className="text-center mt-2">
-              <Link 
-                href="/forgot-password"
-                className="text-sm text-zinc-500 hover:text-zinc-600 dark:text-zinc-400 dark:hover:text-zinc-300 transition-colors"
-              >
-                {t('auth.login.forgotPassword')}
-              </Link>
-            </div>
-          )}
         </form>
       </Form>
 

--- a/components/auth/auth-form.tsx
+++ b/components/auth/auth-form.tsx
@@ -470,7 +470,7 @@ export function AuthForm({ type, defaultValues, onSuccess }: AuthFormProps) {
           </Button>
 
           {type === 'login' && (
-            <div className="text-center">
+            <div className="text-center mt-2">
               <Link 
                 href="/forgot-password"
                 className="text-sm text-zinc-500 hover:text-zinc-600 dark:text-zinc-400 dark:hover:text-zinc-300 transition-colors"
@@ -484,7 +484,7 @@ export function AuthForm({ type, defaultValues, onSuccess }: AuthFormProps) {
 
       {(type === 'login' || type === 'register') && (
         <>
-          <div className="relative">
+          <div className="relative my-6">
             <div className="absolute inset-0 flex items-center">
               <span className="w-full border-t border-zinc-200 dark:border-zinc-800" />
             </div>

--- a/components/auth/auth-layout.tsx
+++ b/components/auth/auth-layout.tsx
@@ -21,21 +21,14 @@ export function AuthLayout({ type, children }: AuthLayoutProps) {
   const { t } = useTranslation();
   
   // Define the link configuration for each auth type
-  const getLinkConfig = (): LinkConfigType | LinkConfigType[] => {
+  const getLinkConfig = (): LinkConfigType => {
     switch (type) {
       case 'login':
-        return [
-          {
-            text: t('auth.links.login.noAccount'),
-            linkText: t('auth.links.login.signUp'),
-            href: "/register",
-          },
-          {
-            text: "",
-            linkText: t('auth.links.login.forgotPassword'),
-            href: "/forgot-password",
-          },
-        ];
+        return {
+          text: t('auth.links.login.noAccount'),
+          linkText: t('auth.links.login.signUp'),
+          href: "/register",
+        };
       case 'register':
         return {
           text: t('auth.links.register.hasAccount'),
@@ -59,42 +52,23 @@ export function AuthLayout({ type, children }: AuthLayoutProps) {
   };
 
   const linkConfig = getLinkConfig();
-  const hasMultipleLinks = Array.isArray(linkConfig);
 
   return (
     <div className="space-y-6">
       <AuthForm type={type} />
       
-      <div className={`text-center ${hasMultipleLinks ? 'space-y-2' : ''}`}>
-        {hasMultipleLinks ? (
-          // Render multiple links (login page case)
-          linkConfig.map((config, index) => (
-            <p key={index} className="text-sm text-muted-foreground">
-              {config.text && (
-                <>{config.text}{' '}</>
-              )}
-              <Link
-                href={config.href}
-                className="underline underline-offset-4 hover:text-primary"
-              >
-                {config.linkText}
-              </Link>
-            </p>
-          ))
-        ) : (
-          // Render single link (register, forgot-password, reset-password)
-          <p className="text-sm text-muted-foreground">
-            {linkConfig.text && (
-              <>{linkConfig.text}{' '}</>
-            )}
-            <Link
-              href={linkConfig.href}
-              className="underline underline-offset-4 hover:text-primary"
-            >
-              {linkConfig.linkText}
-            </Link>
-          </p>
-        )}
+      <div className="text-center">
+        <p className="text-sm text-muted-foreground">
+          {linkConfig.text && (
+            <>{linkConfig.text}{' '}</>
+          )}
+          <Link
+            href={linkConfig.href}
+            className="underline underline-offset-4 hover:text-primary"
+          >
+            {linkConfig.linkText}
+          </Link>
+        </p>
       </div>
 
       {children}

--- a/components/auth/auth-layout.tsx
+++ b/components/auth/auth-layout.tsx
@@ -12,9 +12,16 @@ type AuthLayoutProps = {
 };
 
 type LinkConfigType = {
-  text: string;
-  linkText: string;
-  href: string;
+  primary: {
+    text: string;
+    linkText: string;
+    href: string;
+  };
+  secondary?: {
+    text?: string;
+    linkText: string;
+    href: string;
+  };
 };
 
 export function AuthLayout({ type, children }: AuthLayoutProps) {
@@ -25,28 +32,40 @@ export function AuthLayout({ type, children }: AuthLayoutProps) {
     switch (type) {
       case 'login':
         return {
-          text: t('auth.links.login.noAccount'),
-          linkText: t('auth.links.login.signUp'),
-          href: "/register",
+          primary: {
+            text: t('auth.links.login.noAccount'),
+            linkText: t('auth.links.login.signUp'),
+            href: "/register",
+          },
+          secondary: {
+            linkText: t('auth.login.forgotPassword'),
+            href: "/forgot-password",
+          }
         };
       case 'register':
         return {
-          text: t('auth.links.register.hasAccount'),
-          linkText: t('auth.links.register.signIn'),
-          href: "/login",
+          primary: {
+            text: t('auth.links.register.hasAccount'),
+            linkText: t('auth.links.register.signIn'),
+            href: "/login",
+          }
         };
       case 'forgot-password':
       case 'reset-password':
         return {
-          text: t('auth.links.forgotPassword.rememberPassword'),
-          linkText: t('auth.links.forgotPassword.backToLogin'),
-          href: "/login",
+          primary: {
+            text: t('auth.links.forgotPassword.rememberPassword'),
+            linkText: t('auth.links.forgotPassword.backToLogin'),
+            href: "/login",
+          }
         };
       default:
         return {
-          text: "",
-          linkText: "",
-          href: "/",
+          primary: {
+            text: "",
+            linkText: "",
+            href: "/",
+          }
         };
     }
   };
@@ -57,18 +76,32 @@ export function AuthLayout({ type, children }: AuthLayoutProps) {
     <div className="space-y-6">
       <AuthForm type={type} />
       
-      <div className="text-center">
+      <div className="space-y-2 text-center">
         <p className="text-sm text-muted-foreground">
-          {linkConfig.text && (
-            <>{linkConfig.text}{' '}</>
+          {linkConfig.primary.text && (
+            <>{linkConfig.primary.text}{' '}</>
           )}
           <Link
-            href={linkConfig.href}
+            href={linkConfig.primary.href}
             className="underline underline-offset-4 hover:text-primary"
           >
-            {linkConfig.linkText}
+            {linkConfig.primary.linkText}
           </Link>
         </p>
+
+        {linkConfig.secondary && (
+          <p className="text-sm text-muted-foreground">
+            {linkConfig.secondary.text && (
+              <>{linkConfig.secondary.text}{' '}</>
+            )}
+            <Link
+              href={linkConfig.secondary.href}
+              className="underline underline-offset-4 hover:text-primary"
+            >
+              {linkConfig.secondary.linkText}
+            </Link>
+          </p>
+        )}
       </div>
 
       {children}


### PR DESCRIPTION
- Updated Login and Register pages to use AuthLayout for improved structure and layout.
- Enhanced AuthLayout to handle link configurations for login and registration flows.
- Made minor styling adjustments in AuthForm for better spacing and alignment.

## Summary by Sourcery

Use AuthLayout as the wrapper for authentication pages, streamline link handling, and improve form spacing.

Enhancements:
- Migrate login and register pages to use AuthLayout instead of AuthForm
- Refactor AuthLayout to return a single link configuration and remove multi-link rendering logic
- Adjust AuthForm spacing by adding margin to the forgot-password link and vertical padding around the separator