### PR TITLE
fix: Analytics showing 0 documents due to missing projectUuid parameter

### DIFF
--- a/app/actions/analytics.ts
+++ b/app/actions/analytics.ts
@@ -42,16 +42,16 @@ export type {
 };
 
 // Re-export functions as server actions
-export async function getOverviewMetrics(profileUuid: string, period: TimePeriod = '7d') {
-  return _getOverviewMetrics(profileUuid, period);
+export async function getOverviewMetrics(profileUuid: string, period: TimePeriod = '7d', projectUuid?: string) {
+  return _getOverviewMetrics(profileUuid, period, projectUuid);
 }
 
 export async function getToolAnalytics(profileUuid: string, period: TimePeriod = '7d', serverUuid?: string) {
   return _getToolAnalytics(profileUuid, period, serverUuid);
 }
 
-export async function getRagAnalytics(profileUuid: string, period: TimePeriod = '7d') {
-  return _getRagAnalytics(profileUuid, period);
+export async function getRagAnalytics(profileUuid: string, period: TimePeriod = '7d', projectUuid?: string) {
+  return _getRagAnalytics(profileUuid, period, projectUuid);
 }
 
 export async function getProductivityMetrics(profileUuid: string, period: TimePeriod = '30d') {
@@ -62,6 +62,6 @@ export async function getRecentToolCalls(profileUuid: string, limit: number = 50
   return _getRecentToolCalls(profileUuid, limit);
 }
 
-export async function getRecentDocuments(profileUuid: string, limit: number = 10) {
-  return _getRecentDocuments(profileUuid, limit);
+export async function getRecentDocuments(profileUuid: string, limit: number = 10, projectUuid?: string) {
+  return _getRecentDocuments(profileUuid, limit, projectUuid);
 }

--- a/app/actions/analytics/tools.ts
+++ b/app/actions/analytics/tools.ts
@@ -167,9 +167,9 @@ export const getToolAnalytics = withAnalytics(
       count: h.count,
     }));
 
-    // Get activity heatmap (last 90 days)
+    // Get activity heatmap (last 12 months)
     const heatmapCutoff = new Date();
-    heatmapCutoff.setDate(heatmapCutoff.getDate() - 90);
+    heatmapCutoff.setMonth(heatmapCutoff.getMonth() - 12);
 
     const heatmapData = await db
       .select({

--- a/hooks/useDocxContent.ts
+++ b/hooks/useDocxContent.ts
@@ -1,4 +1,4 @@
-import { useEffect,useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { isDocxFile } from '@/lib/file-utils';
 import type { Doc } from '@/types/library';
@@ -6,48 +6,82 @@ import type { Doc } from '@/types/library';
 export function useDocxContent(doc: Doc | null, open: boolean, projectUuid?: string) {
   const [docxContent, setDocxContent] = useState<string | null>(null);
   const [isLoadingDocx, setIsLoadingDocx] = useState(false);
+  const fetchControllerRef = useRef<AbortController | null>(null);
 
   useEffect(() => {
-    if (!doc || !open) {
+    if (!doc || !doc.uuid || !open) {
+      fetchControllerRef.current?.abort();
+      fetchControllerRef.current = null;
       setDocxContent(null);
+      setIsLoadingDocx(false);
       return;
     }
 
     if (!isDocxFile(doc.mime_type, doc.name)) {
+      fetchControllerRef.current?.abort();
+      fetchControllerRef.current = null;
       setDocxContent(null);
+      setIsLoadingDocx(false);
       return;
     }
+
+    const controller = new AbortController();
+    fetchControllerRef.current?.abort();
+    fetchControllerRef.current = controller;
 
     setIsLoadingDocx(true);
     setDocxContent(null);
 
+    let isActive = true;
+
     const downloadUrl = `/api/library/download/${doc.uuid}${projectUuid ? `?projectUuid=${projectUuid}` : ''}`;
-    fetch(downloadUrl)
-      .then(res => {
+
+    const loadDocx = async () => {
+      try {
+        const res = await fetch(downloadUrl, { signal: controller.signal });
         if (!res.ok) {
           throw new Error('Failed to fetch DOCX file');
         }
-        return res.arrayBuffer();
-      })
-      .then(async arrayBuffer => {
+
+        const arrayBuffer = await res.arrayBuffer();
         const mammoth = await import('mammoth');
         const result = await mammoth.convertToHtml({ arrayBuffer });
-        
+
         const DOMPurify = (await import('dompurify')).default;
-        const sanitized = DOMPurify.sanitize(result.value, { 
+        const sanitized = DOMPurify.sanitize(result.value, {
           ALLOWED_TAGS: ['p', 'br', 'strong', 'em', 'u', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'ul', 'ol', 'li', 'table', 'tr', 'td', 'th', 'thead', 'tbody'],
-          ALLOWED_ATTR: []
+          ALLOWED_ATTR: [],
         });
-        
+
+        if (!isActive || controller.signal.aborted) {
+          return;
+        }
+
         setDocxContent(sanitized);
-        setIsLoadingDocx(false);
-      })
-      .catch(err => {
+      } catch (err) {
+        if (controller.signal.aborted || !isActive) {
+          return;
+        }
+
         console.error('Failed to fetch DOCX content:', err);
         setDocxContent(null);
-        setIsLoadingDocx(false);
-      });
-  }, [doc, open, projectUuid]);
+      } finally {
+        if (!controller.signal.aborted && isActive) {
+          setIsLoadingDocx(false);
+        }
+      }
+    };
+
+    void loadDocx();
+
+    return () => {
+      isActive = false;
+      controller.abort();
+      if (fetchControllerRef.current === controller) {
+        fetchControllerRef.current = null;
+      }
+    };
+  }, [doc?.uuid, doc?.mime_type, doc?.name, open, projectUuid]);
 
   return { docxContent, isLoadingDocx };
 } 


### PR DESCRIPTION
## Root Cause
Analytics wrapper functions in app/actions/analytics.ts were not passing the projectUuid parameter to the underlying analytics functions, causing all queries to fall back to profile_uuid filtering. Since documents are stored with project_uuid (and profile_uuid = NULL), this resulted in zero documents being returned.

## Changes

### Fixed Parameter Passing
- Updated getOverviewMetrics() to accept and pass projectUuid
- Updated getRagAnalytics() to accept and pass projectUuid
- Updated getRecentDocuments() to accept and pass projectUuid

### Unified Query Pattern
Applied consistent legacy document support across all analytics queries:
- overview.ts: Already had legacy support
- rag.ts: Added legacy document support (NULL project_uuid + user_id match)
- recent-documents.ts: Added legacy document support

All queries now use the pattern:
```
if (projectUuid && projectUserId) {
  where: or(
    eq(docsTable.project_uuid, projectUuid),
    and(isNull(docsTable.project_uuid), eq(docsTable.user_id, projectUserId))
  )
}
```

### Improved Cache Key Generation (analytics-hof.ts) Replaced simple string concatenation with robust parameter serialization:
- Properly handles null, undefined, and object values
- Includes ALL parameters (including projectUuid) in cache key
- Prevents cache collisions between different projects

### RAG Analytics Improvements (rag.ts)
- Added cacheVersion: 'rag-upload-stats-v2' to bust stale cache
- Changed from SQL aggregation to JavaScript aggregation
- Better NULL source handling (defaults to 'upload')

### Document Handling Improvements
- useDocxContent: Added AbortController for proper cleanup
- DocumentPreview: Fixed ReactMarkdown v10 props (transformLinkUri → urlTransform)
- DocumentPreview: Added URI sanitization for markdown links

### Other Fixes
- Ensured default projects are created for new users (OAuth + email signup)
- Added project requirement validation in document upload
- Added SWR cache invalidation for analytics after doc upload/delete
- Extended activity heatmap from 90 days to 12 months
- Improved analytics security test mocking

## Testing
- ✅ Build passes successfully
- ✅ All analytics queries now properly scoped to project_uuid
- ✅ Dashboard shows correct document counts
- ✅ Library & RAG tab shows correct upload counts
- ✅ All tabs show consistent data

🤖 Generated with [Claude Code](https://claude.com/claude-code)