### PR TITLE
feat: add multi-architecture Docker support (AMD64 + ARM64)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,15 +28,31 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Validate version input
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          VERSION="${{ github.event.inputs.version }}"
+          if [[ ! "$VERSION" =~ ^(latest|v[0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+            echo "❌ Error: Invalid version format '$VERSION'"
+            echo "Version must be 'latest' or 'vX.Y.Z' (e.g., v2.16.0)"
+            exit 1
+          fi
+          echo "✅ Version validation passed: $VERSION"
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3
         with:
           platforms: linux/amd64,linux/arm64
 
       - name: Set up Docker Buildx
+        id: buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
         with:
           platforms: linux/amd64,linux/arm64
+          # Use ephemeral builder for CI (auto-cleanup)
+          driver-opts: |
+            image=moby/buildkit:latest
+            network=host
 
       - name: Log in to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3
@@ -57,6 +73,7 @@ jobs:
             type=raw,value=${{ github.event.inputs.version }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push Docker image
+        id: build
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
@@ -66,9 +83,29 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Use mode=min to prevent cache from growing unbounded
+          cache-to: type=gha,mode=min
 
-      - name: Image digest
+      - name: Verify multi-arch manifest
+        run: |
+          echo "🔍 Verifying multi-arch manifest..."
+          # Extract first tag from metadata output
+          FIRST_TAG=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
+
+          # Verify manifest exists and contains both architectures
+          docker buildx imagetools inspect $FIRST_TAG
+
+          # Check for both platforms
+          MANIFEST=$(docker buildx imagetools inspect $FIRST_TAG)
+          if echo "$MANIFEST" | grep -q "linux/amd64" && echo "$MANIFEST" | grep -q "linux/arm64"; then
+            echo "✅ Manifest verification successful!"
+            echo "📋 Both AMD64 and ARM64 platforms confirmed"
+          else
+            echo "❌ Error: Missing expected platforms in manifest"
+            exit 1
+          fi
+
+      - name: Image digest and summary
         run: |
           echo "✅ Successfully pushed multi-arch image!"
           echo "📋 Image details:"
@@ -76,3 +113,4 @@ jobs:
           echo "   - ARM64 (aarch64): ✅"
           echo ""
           echo "Tags: ${{ steps.meta.outputs.tags }}"
+          echo "Digest: ${{ steps.build.outputs.digest }}"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ Security: AES-256-GCM encryption, Redis rate limiting
 
 #### **Supported Architectures**
 
-Plugged.in Docker images are multi-architecture (`amd64` and `arm64`) and will automatically select the correct platform for your system.  
+Plugged.in Docker images are multi-architecture (`amd64` and `arm64`) and will automatically select the correct platform for your system.
+
+**Important Notes:**
+- ✅ **Docker Compose automatically pulls the correct architecture** - no manual configuration needed
+- ✅ **Works seamlessly on mixed architectures** - run the same `docker-compose.yml` on any platform
+- ✅ **No performance penalty** - native builds for both AMD64 and ARM64
+
 To verify which platforms are available, run:
 ```bash
 docker manifest inspect veriteknik/pluggedin:latest --verbose | jq '.manifests[].platform'


### PR DESCRIPTION
- Update docker-build.sh to use Docker buildx for multi-platform builds
- Add GitHub Actions workflow for automated multi-arch builds
- Support both linux/amd64 and linux/arm64 platforms
- Fixes #84

## Summary by Sourcery

Add multi-architecture Docker support by enhancing the existing build script with Docker buildx and introducing a new GitHub Actions workflow for automated AMD64 and ARM64 builds and pushes.

New Features:
- Support multi-architecture (linux/amd64 and linux/arm64) Docker builds and pushes
- Add a --local flag to docker-build.sh for single-platform local builds
- Introduce a GitHub Actions workflow to automate multi-arch Docker builds, tagging, and pushes

Enhancements:
- Update docker-build.sh to create and manage a buildx builder instance and conditionally tag and push images

CI:
- Add .github/workflows/docker-publish.yml with steps for QEMU setup, buildx configuration, metadata tagging, build caching, and multi-arch deployment