### PR TITLE
feat(pap): Add agent marketplace UI

### DIFF
--- a/app/(sidebar-layout)/(container)/agents/marketplace/page.tsx
+++ b/app/(sidebar-layout)/(container)/agents/marketplace/page.tsx
@@ -33,29 +33,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  AGENT_CATEGORIES,
+  type AgentTemplate,
   DEFAULT_TEMPLATES_LIMIT,
   isValidImageUrl,
   SWR_MARKETPLACE_CONFIG,
 } from '@/lib/pap-ui-utils';
-
-interface AgentTemplate {
-  uuid: string;
-  namespace: string;
-  name: string;
-  version: string;
-  display_name: string;
-  description: string;
-  icon_url?: string;
-  banner_url?: string;
-  category?: string;
-  tags?: string[];
-  is_verified: boolean;
-  is_featured: boolean;
-  install_count: number;
-  repository_url?: string;
-  documentation_url?: string;
-  created_at: string;
-}
 
 interface TemplatesResponse {
   templates: AgentTemplate[];
@@ -70,14 +53,6 @@ const fetcher = async (url: string) => {
   return response.json();
 };
 
-const CATEGORIES = [
-  { value: 'all', label: 'All Categories' },
-  { value: 'research', label: 'Research' },
-  { value: 'productivity', label: 'Productivity' },
-  { value: 'development', label: 'Development' },
-  { value: 'communication', label: 'Communication' },
-  { value: 'automation', label: 'Automation' },
-];
 
 export default function MarketplacePage() {
   const router = useRouter();
@@ -156,7 +131,7 @@ export default function MarketplacePage() {
               <SelectValue placeholder="Category" />
             </SelectTrigger>
             <SelectContent>
-              {CATEGORIES.map((cat) => (
+              {AGENT_CATEGORIES.map((cat) => (
                 <SelectItem key={cat.value} value={cat.value}>
                   {cat.label}
                 </SelectItem>

--- a/scripts/seed-compass-template.ts
+++ b/scripts/seed-compass-template.ts
@@ -97,13 +97,32 @@ async function seedCompassTemplate() {
       console.log(`   Version: ${existingTemplate.version}`);
       console.log(`   Image: ${existingTemplate.docker_image}`);
 
-      // Update to latest version
-      console.log('\n📝 Updating template to latest version...');
+      // Update only content fields, preserve metadata (install_count, is_verified, etc.)
+      console.log('\n📝 Updating template content...');
       await db
         .update(agentTemplatesTable)
         .set({
-          ...COMPASS_TEMPLATE,
+          // Content updates
+          version: COMPASS_TEMPLATE.version,
+          display_name: COMPASS_TEMPLATE.display_name,
+          description: COMPASS_TEMPLATE.description,
+          long_description: COMPASS_TEMPLATE.long_description,
+          // Deployment config
+          docker_image: COMPASS_TEMPLATE.docker_image,
+          container_port: COMPASS_TEMPLATE.container_port,
+          health_endpoint: COMPASS_TEMPLATE.health_endpoint,
+          env_schema: COMPASS_TEMPLATE.env_schema,
+          // Presentation
+          icon_url: COMPASS_TEMPLATE.icon_url,
+          banner_url: COMPASS_TEMPLATE.banner_url,
+          tags: COMPASS_TEMPLATE.tags,
+          category: COMPASS_TEMPLATE.category,
+          // Links
+          repository_url: COMPASS_TEMPLATE.repository_url,
+          documentation_url: COMPASS_TEMPLATE.documentation_url,
+          // Timestamp
           updated_at: new Date(),
+          // NOTE: Preserves: install_count, is_verified, is_featured, is_public, created_at
         })
         .where(eq(agentTemplatesTable.uuid, existingTemplate.uuid));
 


### PR DESCRIPTION
## Summary
Marketplace UI for discovering and deploying agent templates.

## Pages Added
| Route | Description |
|-------|-------------|
| `/agents/marketplace` | Browse available agent templates |
| `/agents/marketplace/[ns]/[name]` | Template detail and deployment |

## Features
- Grid view of agent templates with icons and descriptions
- Template detail page with:
  - Description and metadata
  - Environment variables configuration
  - Resource requirements (CPU, memory)
  - Version history
- One-click deployment from template
- Seed script for Compass agent template

## Dependencies
- Depends on PR #121 (templates API)
- Depends on PR #122 (agent UI for navigation)

## Test plan
- [ ] Navigate to /agents/marketplace
- [ ] Verify templates are displayed
- [ ] Click template, verify detail page
- [ ] Deploy agent from template

## Summary by Sourcery

Introduce an agent marketplace UI for browsing templates and deploying agents from template detail pages, along with a seed script for the initial Compass agent template.

New Features:
- Add Agent Marketplace page for searching, filtering, and browsing available agent templates.
- Add template detail page showing metadata, configuration, technical details, and version history with a guided deploy flow for creating agents from templates.
- Implement one-click agent deployment from templates with validation for agent names and access level selection.
- Add a seed script to create or update the Compass agent template as the initial marketplace entry.