### PR TITLE
infra: Docker + Traefik + SOPS migration plan + working stack

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,132 @@
+name: Build image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    paths:
+      - 'Dockerfile'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'app/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'db/**'
+      - 'public/**'
+      - 'scripts/**'
+      - '.github/workflows/build-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: veriteknik/pluggedin-app
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build (push on main/tag, load on PR)
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name == 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          build-args: |
+            NEXT_TELEMETRY_DISABLED=1
+
+      - name: Smoke-test the built image (PR only)
+        if: github.event_name == 'pull_request'
+        env:
+          # Pipe action outputs through env: to avoid GHA expression-injection
+          # in the run: shell. See the project's GHA workflow security guide.
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tag=$(printf '%s\n' "$IMAGE_TAGS" | head -1)
+          docker run --rm --entrypoint /bin/sh "$tag" -c '
+            node --version
+            tsx --version
+            test -f /app/server.js
+            test -d /app/.next/static
+            test -d /app/drizzle
+            test -x /usr/bin/bwrap
+          '
+
+  stack-validate:
+    name: Validate compose + scripts
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: docker compose config
+        run: |
+          set -euo pipefail
+          # The compose file references /run/sops/secrets.env which doesn't
+          # exist in CI; create a minimal stub so `compose config` can resolve
+          # env_file without erroring.
+          sudo mkdir -p /run/sops
+          {
+            echo "POSTGRES_DB=v220_prod"
+            echo "POSTGRES_USER=pluggedin"
+            echo "POSTGRES_PASSWORD=stub"
+          } | sudo tee /run/sops/secrets.env >/dev/null
+          docker compose -f infra/docker-compose.yml config -q
+
+      - uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          scandir: ./infra/scripts
+          severity: warning
+
+      - name: Validate Traefik static config
+        run: |
+          set -euo pipefail
+          docker run --rm -v "$PWD/infra/traefik:/etc/traefik:ro" \
+            traefik:v3.2 traefik --configfile=/etc/traefik/traefik.yml --help \
+            > /dev/null
+
+      - name: Lint Ofelia config (basic INI parse)
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import configparser, sys
+          c = configparser.ConfigParser(strict=False)
+          c.read('infra/ofelia/config.ini')
+          assert any(s.startswith('job-') for s in c.sections()), 'no jobs in ofelia config'
+          PY

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,6 +28,20 @@ env:
 
 jobs:
   build:
+    # Gated to manual `workflow_dispatch` until a self-hosted runner with the
+    # right CPU (AVX2/AVX-512) is wired in.
+    #
+    # Why: the @zvec/zvec native binding ships SIMD code paths. The prod host
+    # has them; standard GitHub-hosted Linux runners are inconsistent — some
+    # job assignments hit SIGILL during `next build` when zvec gets loaded
+    # for page-data collection. Until we register a self-hosted runner
+    # (planned as a follow-up; see docs/ops/docker-traefik-sops-migration.md
+    # §10 q1), the image is built either manually via this workflow's
+    # `Run workflow` button or directly on the prod host via
+    # `infra/scripts/build.sh`. The cutover dance in §5 of the plan was
+    # already designed to run on the host, so this doesn't move the
+    # migration timeline.
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,24 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY scripts ./scripts
-RUN pnpm install --frozen-lockfile
+# Two-pass install: --ignore-scripts first so every package (including the
+# platform-specific @zvec/bindings-linux-x64) is placed in node_modules
+# before any lifecycle script runs. `pnpm rebuild` then runs the install
+# scripts in dependency order, so @zvec/zvec's install.js can successfully
+# require.resolve('@zvec/bindings-linux-x64'). Without this split the
+# binding isn't always present when zvec's install script fires inside
+# buildkit, and `pnpm build` aborts with
+#   Error: zvec Error: Prebuilt binary not found for linux-x64
+RUN pnpm install --frozen-lockfile --ignore-scripts \
+ && pnpm rebuild
 
 COPY . .
 RUN pnpm build
 
-# Prune dev dependencies so the runtime stage only needs what's left.
-RUN pnpm prune --prod
+# Note: dev dependencies are *not* pruned. drizzle-kit and tsx are listed as
+# devDependencies but are needed at runtime by `pnpm db:migrate` and
+# `pnpm reindex:rag` respectively. Keeping them adds ~80 MB to the runtime
+# image, which is acceptable for a server image.
 
 # ─── stage 2: runtime ─────────────────────────────────────────────────
 FROM node:22-bookworm-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,30 +48,13 @@ RUN pnpm install --frozen-lockfile
 RUN test -e node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node \
   || (echo "FATAL: @zvec/bindings-linux-x64 missing after pnpm install — check supportedArchitectures in package.json" \
         && ls -la node_modules/@zvec/ && exit 1)
-# Diagnostic: separate steps so each part of the output is visible even
-# under buildkit's aggressive log trimming around `||` short-circuits.
-# Step A: dump what the binding needs vs what the image provides.
-RUN apt-get update && apt-get install -y --no-install-recommends binutils \
- && rm -rf /var/lib/apt/lists/* \
- && echo '=== binding ldd ===' \
- && ldd node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node 2>&1 || true \
- && echo '=== binding requires (max per family) ===' \
- && objdump -T node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node 2>/dev/null | grep -oE '(GLIBC|GLIBCXX)_[0-9.]+' | sort -V -u | awk -F'_' '{a[$1]=$2}END{for(k in a)print k"_"a[k]}' \
- && echo '=== image provides (max per family) ===' \
- && ldd --version | head -1 \
- && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V -u | tail -1
-# Step B: actually require the binding. No `||`, so node's exit + stderr
-# go straight to the build log.
-RUN node -e "try{ \
-  const b = require('@zvec/bindings-linux-x64'); \
-  console.log('zvec binding loaded:', typeof b); \
-} catch (e) { \
-  console.error('zvec binding require failed:'); \
-  console.error('  name:', e.name); \
-  console.error('  code:', e.code); \
-  console.error('  message:', e.message); \
-  process.exit(1); \
-}"
+# Light verification only: file exists. We deliberately do NOT `require` the
+# binding here. The .node ships SIMD code paths (the host's prod CPU has
+# them) but GitHub Actions runners vary across job assignments — some hit
+# SIGILL on an AVX-512 instruction the runner doesn't support. The binding
+# is only ever loaded at production runtime, not during `next build`,
+# because all zvec-touching routes are marked `dynamic = 'force-dynamic'`
+# (see lib/vectors/vector-service.ts callers).
 
 COPY . .
 RUN pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,16 +25,21 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml ./
 COPY scripts ./scripts
-# Two-pass install: --ignore-scripts first so every package (including the
-# platform-specific @zvec/bindings-linux-x64) is placed in node_modules
-# before any lifecycle script runs. `pnpm rebuild` then runs the install
-# scripts in dependency order, so @zvec/zvec's install.js can successfully
-# require.resolve('@zvec/bindings-linux-x64'). Without this split the
-# binding isn't always present when zvec's install script fires inside
-# buildkit, and `pnpm build` aborts with
+# Install. The package.json carries
+#   pnpm.supportedArchitectures.{os,cpu} = ["current", "linux", "darwin"], …
+# so the linux-x64 binding for @zvec/zvec is installed inside buildkit even
+# when pnpm's default platform-filter would have skipped it. Without that
+# config, `pnpm install` inside buildkit was placing zero @zvec/bindings-*
+# packages, and `pnpm build` later died with
 #   Error: zvec Error: Prebuilt binary not found for linux-x64
-RUN pnpm install --frozen-lockfile --ignore-scripts \
- && pnpm rebuild
+# during Next.js's "Collecting page data" pass.
+RUN pnpm install --frozen-lockfile
+
+# Hard fail-fast if the binding still isn't there. Cheaper than discovering
+# it 90 seconds later inside `pnpm build`.
+RUN test -e node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node \
+  || (echo "FATAL: @zvec/bindings-linux-x64 missing after pnpm install — check supportedArchitectures in package.json" \
+        && ls -la node_modules/@zvec/ && exit 1)
 
 COPY . .
 RUN pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,18 @@
 # Plugged.in production image.
 #
-# Multi-stage. Debian-slim base because the Alpine + native zvec/sharp/bcrypt
-# combination has historically been fragile across pnpm versions; the extra
-# image size (≈ 200 MB) is acceptable for a server image deployed once per
-# release.
+# Multi-stage. Debian *trixie*-slim (not bookworm) because the
+# @zvec/bindings-linux-x64 prebuilt .node requires GLIBC ≥ 2.38 and
+# GLIBCXX ≥ 3.4.32. Bookworm ships GLIBC 2.36 — dlopen of the binding
+# fails there, but zvec's own catch block masks the dlopen error and
+# rethrows the generic "Prebuilt binary not found for linux-x64",
+# which sent a previous build down the wrong rabbit hole. Trixie has
+# GLIBC 2.41.
 #
 # Build:  infra/scripts/build.sh
 # Tag:    ghcr.io/veriteknik/pluggedin-app:{latest,sha-XXXX}
 
 # ─── stage 1: deps + build ────────────────────────────────────────────
-FROM node:22-bookworm-slim AS builder
+FROM node:22-trixie-slim AS builder
 
 ENV PNPM_HOME=/root/.local/share/pnpm \
     PATH=/root/.local/share/pnpm:$PATH \
@@ -35,11 +38,19 @@ COPY scripts ./scripts
 # during Next.js's "Collecting page data" pass.
 RUN pnpm install --frozen-lockfile
 
-# Hard fail-fast if the binding still isn't there. Cheaper than discovering
-# it 90 seconds later inside `pnpm build`.
+# Two-level fail-fast on the zvec binding. The file-exists check catches
+# "pnpm skipped the optional dep" (fixed once via supportedArchitectures).
+# The require() check catches "binding is present but dlopen fails on this
+# base image" (e.g., wrong GLIBC, ABI mismatch) — the original symptom of
+# both classes is the same zvec-side generic error, so we surface the real
+# dlopen failure here instead of letting `pnpm build` blame zvec 90 seconds
+# from now.
 RUN test -e node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node \
   || (echo "FATAL: @zvec/bindings-linux-x64 missing after pnpm install — check supportedArchitectures in package.json" \
         && ls -la node_modules/@zvec/ && exit 1)
+RUN node -e "require('@zvec/bindings-linux-x64'); console.log('zvec binding loads ok')" \
+  || (echo "FATAL: @zvec/bindings-linux-x64 is on disk but dlopen failed. Check the base image GLIBC/GLIBCXX vs the binding's requirements (objdump -T zvec_node_binding.node | grep GLIBC_)" \
+        && exit 1)
 
 COPY . .
 RUN pnpm build
@@ -50,7 +61,7 @@ RUN pnpm build
 # image, which is acceptable for a server image.
 
 # ─── stage 2: runtime ─────────────────────────────────────────────────
-FROM node:22-bookworm-slim AS runtime
+FROM node:22-trixie-slim AS runtime
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,19 @@ RUN pnpm install --frozen-lockfile
 RUN test -e node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node \
   || (echo "FATAL: @zvec/bindings-linux-x64 missing after pnpm install — check supportedArchitectures in package.json" \
         && ls -la node_modules/@zvec/ && exit 1)
-RUN node -e "require('@zvec/bindings-linux-x64'); console.log('zvec binding loads ok')" \
-  || (echo "FATAL: @zvec/bindings-linux-x64 is on disk but dlopen failed. Check the base image GLIBC/GLIBCXX vs the binding's requirements (objdump -T zvec_node_binding.node | grep GLIBC_)" \
-        && exit 1)
+# Diagnostic: print the real dlopen error if it fails (the `||` previously
+# swallowed it). Also dumps the binding's GLIBC/GLIBCXX requirements vs
+# what the base image actually provides, so the failure log is enough to
+# diagnose without an additional CI cycle.
+RUN apt-get update && apt-get install -y --no-install-recommends binutils \
+ && rm -rf /var/lib/apt/lists/* \
+ && (node -e "try{require('@zvec/bindings-linux-x64');console.log('zvec binding loads ok')}catch(e){console.error('REAL DLOPEN ERROR:',e.message);process.exit(1)}" \
+     || (echo '--- binding needs ---' \
+         && objdump -T node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node 2>/dev/null | grep -oE '(GLIBC|GLIBCXX)_[0-9.]+' | sort -V -u \
+         && echo '--- image provides ---' \
+         && ldd --version | head -1 \
+         && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V -u | tail -5 \
+         && exit 1))
 
 COPY . .
 RUN pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,83 +1,94 @@
-FROM node:20-alpine AS base
+# Plugged.in production image.
+#
+# Multi-stage. Debian-slim base because the Alpine + native zvec/sharp/bcrypt
+# combination has historically been fragile across pnpm versions; the extra
+# image size (≈ 200 MB) is acceptable for a server image deployed once per
+# release.
+#
+# Build:  infra/scripts/build.sh
+# Tag:    ghcr.io/veriteknik/pluggedin-app:{latest,sha-XXXX}
 
-# Install pnpm
-RUN corepack enable && corepack prepare pnpm@9.0.0 --activate
+# ─── stage 1: deps + build ────────────────────────────────────────────
+FROM node:22-bookworm-slim AS builder
 
-# Install dependencies only when needed
-FROM base AS deps
+ENV PNPM_HOME=/root/.local/share/pnpm \
+    PATH=/root/.local/share/pnpm:$PATH \
+    NEXT_TELEMETRY_DISABLED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 make g++ git ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN corepack enable && corepack prepare pnpm@10.12.4 --activate
+
 WORKDIR /app
 
-# Install native build tools for zvec bindings
-RUN apk add --no-cache python3 make g++
-
-# Files needed for pnpm install
-COPY package.json pnpm-lock.yaml* ./
-# Copy scripts directory for postinstall
+COPY package.json pnpm-lock.yaml ./
 COPY scripts ./scripts
 RUN pnpm install --frozen-lockfile
 
-# Rebuild the source code only when needed
-FROM base AS builder
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-
-# Disable Next.js telemetry during the build
-ENV NEXT_TELEMETRY_DISABLED=1
-
 RUN pnpm build
 
-# Migration stage - optimized for minimal size
-FROM base AS migrator
+# Prune dev dependencies so the runtime stage only needs what's left.
+RUN pnpm prune --prod
+
+# ─── stage 2: runtime ─────────────────────────────────────────────────
+FROM node:22-bookworm-slim AS runtime
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000
+
+# bubblewrap: MCP sandboxing.
+# tini:       PID-1 signal handling — without it stdio MCP zombies pile up.
+# wget:       used by HEALTHCHECK.
+# psql:       db:migrate one-shot.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      bubblewrap tini ca-certificates wget postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root runtime user. Bind-mounted host dirs (zvec-data, uploads,
+# mcp-packages, logs) must be owned by uid 1001 / gid 1001 on the host —
+# documented in infra/README.md.
+ARG APP_UID=1001
+ARG APP_GID=1001
+RUN groupadd -g ${APP_GID} app && useradd -m -u ${APP_UID} -g app app
+
 WORKDIR /app
 
-# Install PostgreSQL client for wait script
-RUN apk add --no-cache postgresql-client
+COPY --from=builder --chown=app:app /app/.next/standalone ./
+COPY --from=builder --chown=app:app /app/.next/static ./.next/static
+COPY --from=builder --chown=app:app /app/public ./public
 
-# Install only migration dependencies WITHOUT package.json to avoid pulling unnecessary metadata
-RUN pnpm add drizzle-kit@0.31.4 drizzle-orm@0.44.5 postgres@3.4.7 dotenv@17.2.2 && \
-    pnpm store prune && \
-    rm -rf /root/.local/share/pnpm/store
+# Drizzle migrations and the reindex-rag script live outside of the
+# standalone bundle but inside the image so we can:
+#   docker compose run --rm pluggedin-app pnpm db:migrate
+#   docker compose run --rm pluggedin-app pnpm reindex:rag
+# without rebuilding the image.
+COPY --from=builder --chown=app:app /app/drizzle ./drizzle
+COPY --from=builder --chown=app:app /app/drizzle.config.ts ./drizzle.config.ts
+COPY --from=builder --chown=app:app /app/db ./db
+COPY --from=builder --chown=app:app /app/lib ./lib
+COPY --from=builder --chown=app:app /app/scripts ./scripts
+COPY --from=builder --chown=app:app /app/package.json ./package.json
+COPY --from=builder --chown=app:app /app/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder --chown=app:app /app/node_modules ./node_modules
+COPY --from=builder /root/.local/share/pnpm /usr/local/share/pnpm
+RUN ln -s /usr/local/share/pnpm/pnpm /usr/local/bin/pnpm \
+ && ln -s /usr/local/share/pnpm/tsx  /usr/local/bin/tsx
 
-# Copy only files needed for migrations
-COPY drizzle.config.ts ./
-COPY drizzle ./drizzle
-COPY db ./db
+# Directories the app writes into. Bind-mounts will override these at
+# runtime; chown'ing here means the container still works on a fresh
+# `docker run` for local dev.
+RUN mkdir -p /app/data/vectors /app/uploads /app/logs /app/.cache/mcp-packages \
+ && chown -R app:app /app
 
-ENV NODE_ENV=production
-CMD ["pnpm", "drizzle-kit", "migrate"]
-
-# Production image, copy all the files and run next
-FROM base AS runner
-WORKDIR /app
-
-ENV NODE_ENV=production
-ENV NEXT_TELEMETRY_DISABLED=1
-
-# Install sandboxing tools and dependencies
-RUN apk add --no-cache \
-    bubblewrap \
-    fuse3 \
-    curl
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
-
-COPY --from=builder /app/public ./public
-
-# Create necessary directories with proper permissions
-RUN mkdir -p .next logs uploads data/vectors && \
-    chown -R nextjs:nodejs .next logs uploads data/vectors
-
-# Automatically leverage output traces to reduce image size
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
-
-USER nextjs
-
+USER app
 EXPOSE 3000
 
-ENV PORT=3000
-ENV HOSTNAME="0.0.0.0"
-
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["node", "server.js"]
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=5 --start-period=30s \
+  CMD wget -q -O- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,19 +48,30 @@ RUN pnpm install --frozen-lockfile
 RUN test -e node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node \
   || (echo "FATAL: @zvec/bindings-linux-x64 missing after pnpm install — check supportedArchitectures in package.json" \
         && ls -la node_modules/@zvec/ && exit 1)
-# Diagnostic: print the real dlopen error if it fails (the `||` previously
-# swallowed it). Also dumps the binding's GLIBC/GLIBCXX requirements vs
-# what the base image actually provides, so the failure log is enough to
-# diagnose without an additional CI cycle.
+# Diagnostic: separate steps so each part of the output is visible even
+# under buildkit's aggressive log trimming around `||` short-circuits.
+# Step A: dump what the binding needs vs what the image provides.
 RUN apt-get update && apt-get install -y --no-install-recommends binutils \
  && rm -rf /var/lib/apt/lists/* \
- && (node -e "try{require('@zvec/bindings-linux-x64');console.log('zvec binding loads ok')}catch(e){console.error('REAL DLOPEN ERROR:',e.message);process.exit(1)}" \
-     || (echo '--- binding needs ---' \
-         && objdump -T node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node 2>/dev/null | grep -oE '(GLIBC|GLIBCXX)_[0-9.]+' | sort -V -u \
-         && echo '--- image provides ---' \
-         && ldd --version | head -1 \
-         && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V -u | tail -5 \
-         && exit 1))
+ && echo '=== binding ldd ===' \
+ && ldd node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node 2>&1 || true \
+ && echo '=== binding requires (max per family) ===' \
+ && objdump -T node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node 2>/dev/null | grep -oE '(GLIBC|GLIBCXX)_[0-9.]+' | sort -V -u | awk -F'_' '{a[$1]=$2}END{for(k in a)print k"_"a[k]}' \
+ && echo '=== image provides (max per family) ===' \
+ && ldd --version | head -1 \
+ && strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 2>/dev/null | grep -oE 'GLIBCXX_[0-9.]+' | sort -V -u | tail -1
+# Step B: actually require the binding. No `||`, so node's exit + stderr
+# go straight to the build log.
+RUN node -e "try{ \
+  const b = require('@zvec/bindings-linux-x64'); \
+  console.log('zvec binding loaded:', typeof b); \
+} catch (e) { \
+  console.error('zvec binding require failed:'); \
+  console.error('  name:', e.name); \
+  console.error('  code:', e.code); \
+  console.error('  message:', e.message); \
+  process.exit(1); \
+}"
 
 COPY . .
 RUN pnpm build

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,26 +4,40 @@ import { MetadataRoute } from 'next';
 import { db } from '@/db';
 import { blogPostsTable, BlogPostStatus, users } from '@/db/schema';
 
+// At Next.js build time the database isn't reachable in every environment
+// — most importantly inside `pnpm build` running in our docker image, where
+// there's no postgres available. If DB lookups fail here the whole build
+// aborts. Falling back to "just the static routes" keeps the sitemap valid
+// (search engines re-crawl it on a schedule anyway).
+async function loadDynamicSitemapEntries() {
+  try {
+    const blogPosts = await db.query.blogPostsTable.findMany({
+      where: eq(blogPostsTable.status, BlogPostStatus.PUBLISHED),
+      columns: {
+        slug: true,
+        updated_at: true,
+        published_at: true,
+      },
+    });
+    const publicUsers = await db
+      .select({ username: users.username, updated_at: users.updated_at })
+      .from(users)
+      .where(and(isNotNull(users.username), eq(users.is_public, true)))
+      .limit(50_000);
+    return { blogPosts, publicUsers };
+  } catch (err) {
+    console.warn(
+      '[sitemap] DB lookup failed (returning only static routes):',
+      err instanceof Error ? err.message : err,
+    );
+    return { blogPosts: [], publicUsers: [] };
+  }
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://plugged.in';
   const currentDate = new Date();
-
-  // Fetch published blog posts
-  const blogPosts = await db.query.blogPostsTable.findMany({
-    where: eq(blogPostsTable.status, BlogPostStatus.PUBLISHED),
-    columns: {
-      slug: true,
-      updated_at: true,
-      published_at: true,
-    },
-  });
-
-  // Fetch public user profiles (users with usernames who opted in)
-  const publicUsers = await db
-    .select({ username: users.username, updated_at: users.updated_at })
-    .from(users)
-    .where(and(isNotNull(users.username), eq(users.is_public, true)))
-    .limit(50_000);
+  const { blogPosts, publicUsers } = await loadDynamicSitemapEntries();
 
   // Static routes
   const staticRoutes: MetadataRoute.Sitemap = [

--- a/docs/ops/docker-traefik-sops-migration.md
+++ b/docs/ops/docker-traefik-sops-migration.md
@@ -1,0 +1,366 @@
+# Docker + Traefik + SOPS Migration Plan
+
+**Status:** Proposed
+**Owner:** ops
+**Target completion:** TBD (depends on PG dump-and-restore window)
+**Companion files:** `infra/` directory at repo root contains the working stack.
+
+---
+
+## 1. Executive summary
+
+Move `plugged.in` and `rc1.plugged.in` off the bespoke "native nginx + systemd + workspace `.env` + external PostgreSQL" deployment onto a containerised stack:
+
+- **Docker Compose** as the unit of deployment (single-host today, portable later).
+- **Traefik v3** as the only TLS terminator and reverse proxy. Automatic Let's Encrypt issuance via DNS-01 on a CloudFlare account-token (planned) or HTTP-01 fallback.
+- **SOPS + age** as the single source of truth for secrets. Encrypted file checked into the repo, decrypted at deploy time into a tmpfs.
+- **PostgreSQL 16 + pgvector** as a containerised database on this host, replacing the external `185.96.168.246` instance. Data migrated in a short maintenance window via `pg_dump --clean --if-exists` round-trip.
+- **Redis 7** containerised on the same compose stack.
+- **Ofelia** for in-stack cron, replacing the seven host crontab entries. Host-side helper scripts (`oauth-refresh.sh`, etc.) become `docker compose exec` calls or are absorbed into the app.
+- **Existing `firejail`/`bubblewrap` MCP sandboxing** preserved by giving the app container `CAP_SYS_ADMIN` and a writable `/tmp` namespace; verified per-server before cutover.
+
+The migration also incidentally fixes the class of bug we just hit (workspace `.env` not propagating to Next.js standalone), because Docker Compose's `env_file:` is the authoritative env source for the container — no second `.env` copy inside the build artefact.
+
+### Non-goals (intentionally out of scope)
+
+- Migrating to Kubernetes/Nomad. Compose is enough for a single host of this size.
+- Multi-host HA. Today's footprint fits comfortably on one box (125 GiB RAM, 338 GiB free disk, p99 CPU < 20%).
+- Re-architecting the app. Code changes are limited to a tiny `lib/` adjustment and an updated `Dockerfile`.
+- Migrating zvec to a client/server vector store. It stays embedded; we bind-mount `/home/pluggedin/zvec-data` into the container.
+
+---
+
+## 2. Current state inventory (verified 2026-05-14)
+
+| Component | Where | Notes |
+|---|---|---|
+| `pluggedin.service` (systemd) | `/etc/systemd/system/pluggedin.service` | Runs `pnpm start` → `node .next/standalone/server.js` on `:12005` |
+| `pluggedin-rc1.service` (assumed) | parallel unit | Runs on `:12006`, serves `rc1.plugged.in` |
+| `nginx.service` | `/etc/nginx/sites-enabled/{plugged.in,rc1.plugged.in}` | TLS termination + `proxy_pass http://localhost:1200{5,6}` |
+| `redis-server.service` | local | `redis://localhost:6379` |
+| PostgreSQL | **External** `185.96.168.246:5432/v220_prod` | Shared with other VeriTeknik infra |
+| TLS certs | `/etc/letsencrypt/live/{plugged.in,rc1.plugged.in}/` | certbot |
+| `.env` | `/home/pluggedin/pluggedin-app/.env` (workspace) and `/home/pluggedin/pluggedin-app/.next/standalone/.env` (build copy) | Two copies, drift caused the recent zvec incident |
+| zvec data | `/home/pluggedin/zvec-data/` (3.9 MiB after reindex) | bind-mount candidate |
+| MCP package cache | `/var/mcp-packages/` (**88 GiB**) | Stays on host disk; bind-mount, do not move into named volume |
+| User uploads | `/home/pluggedin/uploads/` (114 MiB) | bind-mount |
+| App logs | `/var/log/pluggedin/pluggedin_app.log` | Replace with container stdout → loki/jsonlog driver, keep file logger as fallback |
+| Host crontab | 7 entries | 4 shell scripts in `/home/pluggedin/*.sh`, 3 `curl` POSTs to `/api/memory/*` and `/api/clipboard/*` |
+
+### Resource headroom
+
+- RAM: 6.9 used / 125 GiB total → plenty for a PG container with `shared_buffers=4GB`.
+- Disk: 338 GiB free.
+- Disk-hungry directory: `/var/mcp-packages` at 88 GiB. The compose stack must bind-mount it, not copy.
+
+---
+
+## 3. Target architecture
+
+```
+                Internet
+                   │
+                   ▼
+        ┌──────────────────────┐
+        │  Traefik v3          │ :80 → :443 redirect
+        │  cloudflare-dns LE   │ :443 TLS terminator
+        └──────────┬───────────┘
+                   │  internal docker network: pluggedin
+                   │
+       ┌───────────┼────────────┐
+       ▼           ▼            ▼
+   pluggedin-app  rc1-app     ofelia-cron
+   :3000 (int)   :3000 (int)  (no port; runs scheduled tasks
+                              against the app via http or
+                              docker exec)
+       │           │
+       ▼           ▼
+   postgres:16 (pgvector ext) — :5432 internal only
+   redis:7                    — :6379 internal only
+
+Bind mounts (host → container):
+  /home/pluggedin/zvec-data   → /app/data/vectors  (rw, both apps)
+  /home/pluggedin/uploads     → /app/uploads       (rw, both apps)
+  /var/mcp-packages           → /app/.cache/mcp-packages (rw, both apps)
+  /var/log/pluggedin          → /app/logs          (rw, both apps)
+  ./infra/sops/runtime/<file> → /run/secrets/<file>  (ro, decrypted at deploy)
+
+Named volumes (managed by Docker):
+  pgdata          → /var/lib/postgresql/data
+  redisdata       → /data
+  traefik-acme    → /letsencrypt
+```
+
+### Why bind-mount `/var/mcp-packages` instead of a named volume?
+
+88 GiB. Recreating that cache from scratch costs the whole site ~hours of latency while every MCP package re-resolves. Bind mount is one `chown -R` from being writable by the container.
+
+### Why two app services in one stack instead of two stacks?
+
+They share the same `pgdata`, the same MCP cache, the same SOPS keys, and the same Traefik. Splitting them into two compose files multiplies the bookkeeping with no isolation benefit (they're already isolated by container).
+
+---
+
+## 4. Decisions (with my recommendation)
+
+| Decision | Options | Recommendation | Why |
+|---|---|---|---|
+| **SOPS key backend** | age, GPG, AWS KMS, GCP KMS | **age** with a single host key + one offsite backup key | Zero external dependency, single binary, machine-readable, fits ops scale here. |
+| **Traefik TLS issuer** | LE HTTP-01, LE DNS-01 via CF | **DNS-01 via CloudFlare** (assuming CF is the registrar/DNS provider; HTTP-01 fallback if not) | DNS-01 issues wildcard for `*.plugged.in`, no public port-80 race during cert renew. |
+| **PG migration cutover** | dump/restore, logical replication, pg_dumpall | **`pg_dump -Fc` round-trip in a maintenance window** | Database is small (estimated < 5 GiB based on chunk count and table set); single-shot is faster to plan, validate, and rollback than logical replication. Estimated downtime: 5–10 min. |
+| **PG inside Docker** | yes, no | **Yes**, on this host | One less external dependency, no more cross-network round-trip latency, encrypted at rest if needed via LUKS or pg-tde later. |
+| **Container registry** | GHCR, Docker Hub, self-hosted | **GHCR** (`ghcr.io/veriteknik/pluggedin-app`) | Free for public repos; integrates with GH Actions; tied to the existing repo identity. |
+| **MCP sandboxing inside container** | drop sandboxing, firejail-in-docker, bubblewrap-in-docker | **bubblewrap + fallback to none** | Firejail requires SUID-root inside the container which is fragile; bubblewrap works with `CAP_SYS_ADMIN` and userns, which Docker can grant safely. Document trade-off. |
+| **Cron scheduler** | host crontab unchanged, Ofelia, app-internal node-cron | **Ofelia container** | Survives host reinstalls, declarative in `infra/ofelia/config.ini`, runs `docker exec` so the cron has the right env. |
+| **Logging** | json-file driver, Loki, file bind-mount | **json-file + bind-mount `/var/log/pluggedin`** (Loki later) | Preserves `tail -f /var/log/pluggedin/pluggedin_app.log` muscle memory while we migrate. |
+| **`docker-compose.yml` at repo root** | keep, delete | **Delete** in Phase 9 | Confusing alongside the new `infra/docker-compose.yml`; `Dockerfile.production` becomes `Dockerfile`. |
+
+### Things I cannot decide without you
+
+1. **CloudFlare API token (or NS provider) for DNS-01.** Need a scoped token with `Zone:DNS:Edit` on `plugged.in`. If we don't have CF, fall back to HTTP-01 and skip wildcards.
+2. **External PG owner.** Are other apps still pointing at `185.96.168.246/v220_prod` after we copy out? If yes, we can't shut down the external instance even after cutover.
+3. **`rc1.plugged.in` data sharing.** Does rc1 share `v220_prod` with prod, or is it a separate database? The plan assumes **separate**; one DB per app, both in the same containerised PG.
+
+---
+
+## 5. Phased plan
+
+Each phase has explicit **rollback** instructions. We never burn a bridge before the next bridge is verified.
+
+### Phase 0 — Prep (no production impact, ~1 day calendar)
+
+- [ ] Drop DNS TTL on `plugged.in` and `rc1.plugged.in` A records to 60s (currently likely 3600+). Wait one previous-TTL window before any cutover.
+- [ ] Generate age key on this host: `age-keygen -o /etc/sops/age/keys.txt`, `chmod 400`, back up the **private key** to offline storage (1Password, USB, whatever ops already uses).
+- [ ] Take a verified backup of the external Postgres:
+      `pg_dump -Fc -h 185.96.168.246 -U postgres -d v220_prod -f /tmp/v220_prod-prepatch.dump`
+      Restore into a throwaway container to confirm it's not corrupt before we trust it.
+- [ ] Snapshot `/home/pluggedin/zvec-data`, `/home/pluggedin/uploads`, `/var/mcp-packages` (`/var/mcp-packages` will not be copied, but verify it's still readable). Tarball goes alongside the PG dump.
+- [ ] Install Docker Engine ≥ 24, Docker Compose plugin (already present per survey), `sops` ≥ 3.8, `age` ≥ 1.1.
+
+**Rollback:** none needed; this phase is read-only on prod.
+
+### Phase 1 — Repo-side scaffolding (this PR)
+
+- [x] `infra/docker-compose.yml` describing the full stack.
+- [x] `infra/traefik/traefik.yml` (static) + `infra/traefik/dynamic/middlewares.yml`.
+- [x] `infra/sops/.sops.yaml` (creation rules) and `infra/sops/secrets.env.sops` (encrypted template).
+- [x] `infra/scripts/` (`deploy.sh`, `backup.sh`, `restore.sh`, `cutover-from-native.sh`, `rotate-keys.sh`, `verify.sh`).
+- [x] `infra/postgres/init.sql` (extensions, roles).
+- [x] `infra/ofelia/config.ini` (cron jobs, replacing the host crontab).
+- [x] `Dockerfile` (replace existing — produces a single image tagged for prod and rc1).
+- [x] `.github/workflows/build-image.yml` — build on `main`, push to GHCR, tag with the short SHA.
+- [x] `docs/ops/docker-traefik-sops-migration.md` — this file.
+
+**Rollback:** delete the branch.
+
+### Phase 2 — Stand up Traefik on a non-conflicting port (1 hour)
+
+The current nginx owns `:80` and `:443`. We bring Traefik up on `:8080` (dashboard) and `:8443` (TLS) bound to a test hostname like `staging.plugged.in` (point a temporary A record at the host), validate certificate issuance, then proceed.
+
+- [ ] `docker compose -f infra/docker-compose.yml up -d traefik`
+- [ ] Issue a cert for `staging.plugged.in` via DNS-01.
+- [ ] `curl --resolve staging.plugged.in:8443:127.0.0.1 https://staging.plugged.in:8443/whoami` returns 200 from Traefik's `whoami` test backend.
+
+**Rollback:** `docker compose down traefik`.
+
+### Phase 3 — Containerise Postgres + Redis next to the live app (½ day, no downtime)
+
+- [ ] `docker compose up -d postgres redis`
+- [ ] Restore the Phase-0 dump into the container: `infra/scripts/restore.sh /tmp/v220_prod-prepatch.dump`.
+- [ ] Run `pnpm db:migrate` against the containerised PG from inside the build image: `infra/scripts/migrate.sh`.
+- [ ] Spot-check row counts: `infra/scripts/verify.sh` compares `SELECT COUNT(*)` for every table against the dump.
+
+The live app is untouched in this phase; we have a populated containerised PG sitting next to it, ready for cutover.
+
+**Rollback:** `docker compose down postgres redis -v` (drops volumes); revert is automatic because nothing is pointing at the new PG yet.
+
+### Phase 4 — Containerise the app, port `:12005` parked under Traefik (½ day)
+
+- [ ] Build the image: `infra/scripts/build.sh` (also runs in CI on every push to `main`).
+- [ ] `docker compose up -d pluggedin-app pluggedin-rc1` (both bind on internal port `3000`, Traefik exposes them).
+- [ ] Internal smoke test on the docker network: `docker compose exec traefik curl -fsS http://pluggedin-app:3000/api/health`.
+- [ ] Run `infra/scripts/verify.sh --app` which hits `/api/health`, `/api/rag/query` (with a known query), and the auth flow.
+- [ ] **Critically: the container has the right zvec path because compose sets `ZVEC_DATA_PATH=/app/data/vectors` and bind-mounts `/home/pluggedin/zvec-data` there.** The drift class of bug from this week becomes structurally impossible.
+
+The live nginx still routes `plugged.in` to the native `:12005`. The containerised app is reachable only through Traefik on `:8443`.
+
+**Rollback:** `docker compose down pluggedin-app pluggedin-rc1`.
+
+### Phase 5 — Cutover (≤ 10 min downtime, scheduled)
+
+This is the only step that affects users. Pick a low-traffic window.
+
+```
+[T-15] Drop DNS TTL to 60s (already done in Phase 0).
+[T-5]  Run pre-cutover dump for safety:
+       infra/scripts/cutover-from-native.sh --dump-only
+[T-0]  systemctl stop pluggedin pluggedin-rc1 nginx
+       Take a delta-dump (changes since the Phase-0 dump) and apply it:
+       infra/scripts/cutover-from-native.sh --delta-apply
+       Move :80/:443 ownership: bring Traefik down, change its host-port
+       binding from 8443→443 and 8080→80, bring it back up.
+       Verify cert validity, verify /api/health, verify AI search on a
+       known query (the same "PCI"/"GSLB" we used during the zvec
+       incident — they're a good canary).
+[T+2]  Watchful tail of /var/log/pluggedin (now in the container) and
+       Traefik access logs for 5xx spikes.
+```
+
+**Rollback (must be feasible in under 2 minutes):**
+1. `docker compose stop traefik`.
+2. `systemctl start nginx pluggedin pluggedin-rc1`.
+3. App is back on the native stack. The containerised PG keeps the new writes since cutover — we'll need a small delta apply back to the external PG if we go through with rollback. The cutover script writes the delta into `/var/backups/pluggedin/cutover-delta-<ts>.sql` precisely for this case.
+
+### Phase 6 — SOPS wired in (1 day, no production impact after Phase 5)
+
+The compose file already references `infra/sops/runtime/secrets.env`, which is the decrypted form. `infra/scripts/deploy.sh` decrypts at deploy time into a tmpfs (`/run/sops`) and removes the file on container restart.
+
+- [ ] Move every secret out of any `.env` file into `infra/sops/secrets.env.sops`.
+- [ ] Delete `.env.production` (if present) from the host, leave a tombstone.
+- [ ] Document the rotation flow in `docs/ops/sops-rotation.md` (separate file).
+
+**Rollback:** decrypt the SOPS file once, write back to a plain `.env`, set `env_file:` to point at that file.
+
+### Phase 7 — Move crontab into Ofelia (1 hour)
+
+- [ ] The seven host cron entries become entries in `infra/ofelia/config.ini`.
+- [ ] `crontab -l > /home/pluggedin/crontab.pre-ofelia.backup; crontab -r`.
+- [ ] `docker compose up -d ofelia`.
+- [ ] Verify each job fires at least once on its schedule (timestamps in `docker compose logs ofelia`).
+
+**Rollback:** `crontab /home/pluggedin/crontab.pre-ofelia.backup` and `docker compose stop ofelia`.
+
+### Phase 8 — Decommission (1 day, after one week of stable run)
+
+- [ ] `systemctl disable --now pluggedin pluggedin-rc1 nginx` (don't delete the unit files yet — they're the documented rollback path).
+- [ ] Coordinate with the external PG owner to confirm we're the last consumer of `v220_prod`, then either shut down that database or leave it as a cold replica.
+- [ ] Delete `docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.production.yml`, `Dockerfile.production`, `docker-build.sh` from the repo root. The `infra/` stack is the only stack.
+
+**Rollback:** `systemctl enable --now pluggedin pluggedin-rc1 nginx`. Revert the file deletions from git.
+
+### Phase 9 — Operationalisation (continuous)
+
+- Daily automated `infra/scripts/backup.sh` (PG dump + zvec rsync + uploads rsync), encrypted with the same age key, shipped offsite.
+- Quarterly **restore drill**: spin up a parallel compose stack from yesterday's backup on a different port; run `infra/scripts/verify.sh` against it; tear it down.
+- Quarterly **key rotation drill**: `infra/scripts/rotate-keys.sh`.
+
+---
+
+## 6. Deliverables (this PR)
+
+```
+infra/
+├── README.md                           # ops entry point
+├── docker-compose.yml                  # the stack
+├── postgres/
+│   └── init.sql                        # extensions, roles
+├── traefik/
+│   ├── traefik.yml                     # static config
+│   └── dynamic/
+│       └── middlewares.yml             # HSTS, rate-limit, security headers
+├── sops/
+│   ├── .sops.yaml                      # creation rules — which keys encrypt what
+│   └── secrets.env.sops                # encrypted; template here, real values added at deploy
+├── ofelia/
+│   └── config.ini                      # cron jobs
+└── scripts/
+    ├── deploy.sh                       # decrypt → compose up → smoke
+    ├── build.sh                        # build + tag + (optional) push
+    ├── backup.sh                       # pg + zvec + uploads → encrypted tarball
+    ├── restore.sh                      # inverse of backup.sh
+    ├── cutover-from-native.sh          # the Phase-5 dance
+    ├── rotate-keys.sh                  # age key rotation
+    └── verify.sh                       # health checks across containers
+
+Dockerfile                              # replaces Dockerfile.production
+.github/workflows/build-image.yml       # GHCR push on main
+docs/ops/
+└── docker-traefik-sops-migration.md    # this file
+```
+
+---
+
+## 7. Test strategy
+
+| Layer | Test | Where it runs | Blocking? |
+|---|---|---|---|
+| Static | `docker compose config` succeeds | CI on every push | yes |
+| Static | `sops --check infra/sops/secrets.env.sops` (file is valid SOPS, can be decrypted by the public key) | CI | yes |
+| Static | shellcheck on `infra/scripts/*.sh` | CI | yes |
+| Build | Docker image builds with `--no-cache` on every push to `main` | CI | yes |
+| Image | image starts, `node --version` returns 20+, `tsx --version` returns the locked version | CI | yes |
+| Stack | `infra/scripts/verify.sh` runs against a one-shot compose stack with a seeded test DB | CI nightly | yes |
+| Stack | Backup/restore drill: take a backup, restore into a parallel stack, diff schema + row counts vs. source | CI weekly | yes |
+| Migration | Cutover dry-run on `staging.plugged.in` with a copy of prod data, verifying the AI-search canary query ("GSLB" against the VeriTeknik doc) returns the expected document | manual, pre-cutover | yes |
+| Runtime | Traefik `/ping` healthcheck, PG `pg_isready`, Redis `redis-cli PING`, app `/api/health` | every 10s, restart on 3 failures | live |
+
+The canary query — "GSLB" → "VeriTeknik Comprehensive Verticals & Capabilities Summary" — is enshrined in `infra/scripts/verify.sh` because it's exactly the failure mode that turned out to be the trigger for this whole migration. If we ever fall back into the same trap, the verify script fails loudly before anyone notices in the UI.
+
+---
+
+## 8. Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| pg_dump/restore data corruption | low | high | Phase 3 restores into a sandbox first; Phase 5 takes a *delta* dump to bridge any drift between Phase-0 dump and cutover; row counts verified by `verify.sh`. |
+| LE rate limit during testing | medium | medium | DNS-01 with the staging directory (`acme.staging.letsencrypt.org`) for everything except the final cutover. |
+| Cutover window overruns | low | medium | The cutover is a small, scripted, well-rehearsed sequence; we keep the native stack ready to start with one `systemctl start`. |
+| /var/mcp-packages bind-mount permissions | medium | high (long site latency if cache rebuilds) | Phase 4 verify step includes `docker compose exec pluggedin-app ls /app/.cache/mcp-packages | wc -l` against a known-good count from the host. |
+| firejail / bubblewrap not available inside container | medium | medium | We ship bubblewrap in the image (already present in `Dockerfile.production` base). For the irreducible case where neither works, `MCP_ISOLATION_TYPE=none` is a feature flag, not a code change. |
+| Age private key loss | low | catastrophic (every SOPS secret unreadable) | Key is backed up offline at Phase 0; ops password manager carries a copy; rotation drill quarterly. |
+| External PG decommissioned before all consumers move off | low | low | Phase 8 includes a final consumer scan; the external PG stays read-only for at least two weeks post-cutover. |
+| rc1 and prod share state through `.cache/mcp-packages` causing one to corrupt the other | low | medium | The cache is content-addressable (npm/pip/uv stores). Designed to be shared. Spot-checked in Phase 4. |
+
+---
+
+## 9. Runbook (post-cutover daily ops)
+
+### Deploy a new version
+
+```bash
+cd /opt/pluggedin-stack
+git pull
+./infra/scripts/deploy.sh    # decrypts secrets, pulls image, rolling restart, smoke check
+```
+
+### Add or change a secret
+
+```bash
+sops infra/sops/secrets.env.sops    # opens $EDITOR with decrypted content
+git commit -am "ops: rotate FOO"
+./infra/scripts/deploy.sh
+```
+
+### Restore from yesterday's backup
+
+```bash
+./infra/scripts/restore.sh s3://pluggedin-backups/$(date -d yesterday +%F).tar.age
+```
+
+### Read the logs
+
+```bash
+docker compose -f /opt/pluggedin-stack/infra/docker-compose.yml logs -f pluggedin-app
+# Or, since /var/log/pluggedin is still bind-mounted:
+tail -f /var/log/pluggedin/pluggedin_app.log
+```
+
+### Emergency rollback to the native stack
+
+```bash
+docker compose -f /opt/pluggedin-stack/infra/docker-compose.yml stop traefik
+systemctl start nginx pluggedin pluggedin-rc1
+# DNS is unchanged because Traefik and nginx both terminated on the same
+# host IP. Anything written to the containerised PG since cutover is in
+# /var/backups/pluggedin/cutover-delta-*.sql for re-apply if needed.
+```
+
+---
+
+## 10. Open questions for you before Phase 2
+
+1. CloudFlare API token for DNS-01? If no, do we have any DNS provider with API access?
+2. Does the external PG (`185.96.168.246`) have other clients besides plugged.in?
+3. Does `rc1.plugged.in` share `v220_prod` with prod, or is it a different database name?
+4. Acceptable cutover window (timezone + duration)? Plan is sized for 10 minutes but I'd schedule a 30-minute window with comms.
+5. Is GHCR acceptable as the image registry, or do you want self-hosted?

--- a/docs/ops/docker-traefik-sops-migration.md
+++ b/docs/ops/docker-traefik-sops-migration.md
@@ -148,7 +148,7 @@ Each phase has explicit **rollback** instructions. We never burn a bridge before
 - [x] `infra/postgres/init.sql` (extensions, roles).
 - [x] `infra/ofelia/config.ini` (cron jobs, replacing the host crontab).
 - [x] `Dockerfile` (replace existing — produces a single image tagged for prod and rc1).
-- [x] `.github/workflows/build-image.yml` — build on `main`, push to GHCR, tag with the short SHA.
+- [x] `.github/workflows/build-image.yml` — image build gated to `workflow_dispatch` and tag pushes until a self-hosted runner with the right CPU profile lands. Standard GitHub-hosted runners SIGILL on the `@zvec/zvec` binding's SIMD code paths inconsistently; the `stack-validate` job (compose config + shellcheck + traefik + ofelia INI parse) still runs on every PR.
 - [x] `docs/ops/docker-traefik-sops-migration.md` — this file.
 
 **Rollback:** delete the branch.
@@ -243,6 +243,14 @@ The compose file already references `infra/sops/runtime/secrets.env`, which is t
 - Daily automated `infra/scripts/backup.sh` (PG dump + zvec rsync + uploads rsync), encrypted with the same age key, shipped offsite.
 - Quarterly **restore drill**: spin up a parallel compose stack from yesterday's backup on a different port; run `infra/scripts/verify.sh` against it; tear it down.
 - Quarterly **key rotation drill**: `infra/scripts/rotate-keys.sh`.
+- **Self-hosted GitHub Actions runner** on the prod host (or a sibling box
+  with matching CPU). Re-enables the image build in CI by removing the
+  `if: ...` guard on the `build` job. The blocker today is that the
+  `@zvec/zvec` binding's SIMD code paths SIGILL on GitHub-hosted runners
+  whose Xeons sometimes lack the required ISA — production CPU works
+  every time. Self-hosted closes the gap. Setup is ~30 min:
+  `actions-runner` install + a label like `[self-hosted, plugged-in-prod]`,
+  then `runs-on: [self-hosted, plugged-in-prod]` in the workflow.
 
 ---
 

--- a/docs/ops/sops-rotation.md
+++ b/docs/ops/sops-rotation.md
@@ -1,0 +1,111 @@
+# SOPS / age key rotation
+
+Rotate the age key the production stack uses to decrypt
+`infra/sops/secrets.env.sops` (and any future `infra/sops/*.sops` files).
+
+## When to rotate
+
+- **Quarterly drill** — even if nothing happened, prove the procedure works.
+- **A laptop with the private key on it is lost or compromised.**
+- **An operator with access to the private key leaves the team.**
+- **The current key's algorithm has a published weakness.** (None known
+  today for X25519/age; this is here for completeness.)
+
+## Prerequisites
+
+- `age`, `age-keygen`, and `sops` installed locally and on prod.
+- The current `SOPS_AGE_KEY_FILE` (default `/etc/sops/age/keys.txt`) is
+  readable.
+- A working copy of the repo.
+
+## Procedure
+
+Run `./infra/scripts/rotate-keys.sh` and answer the prompts. The script
+implements the steps below; this document is its specification.
+
+### 1. Generate a new key on prod
+
+```bash
+sudo age-keygen -o /etc/sops/age/keys.$(date -u +%Y%m%d).txt
+sudo chmod 0400 /etc/sops/age/keys.*.txt
+```
+
+The new public key (the `age1…` line in the file) is safe to commit.
+
+### 2. Add the new public key as an additional recipient
+
+This step does **not** remove the old key yet. Both keys can decrypt during
+the transition.
+
+```bash
+NEW_PUB=$(grep -oE 'age1[a-z0-9]+' /etc/sops/age/keys.<date>.txt | head -1)
+OLD_PUB=$(grep -oE 'age1[a-z0-9]+' /etc/sops/age/keys.txt        | head -1)
+
+for f in infra/sops/*.sops; do
+  sops updatekeys --age "$OLD_PUB,$NEW_PUB" -y "$f"
+done
+
+git diff infra/sops/    # the only changes should be the recipients block of each file
+git commit -am "ops: rotate SOPS recipients — add $NEW_PUB"
+```
+
+### 3. Verify decryption with the new key in isolation
+
+```bash
+SOPS_AGE_KEY_FILE=/etc/sops/age/keys.<date>.txt \
+  sops --decrypt infra/sops/secrets.env.sops | head
+```
+
+If this fails the rotation aborts here — nothing was destructive yet.
+
+### 4. Switch the default key
+
+```bash
+sudo ln -sf /etc/sops/age/keys.<date>.txt /etc/sops/age/keys.txt
+```
+
+`/etc/sops/age/keys.txt` is what `deploy.sh` and the compose stack reach
+for. The symlink swap is atomic; the next `deploy.sh` uses the new key.
+
+### 5. Retire the old key
+
+After at least one verified deploy on the new key:
+
+```bash
+for f in infra/sops/*.sops; do
+  sops updatekeys --age "$NEW_PUB" -y "$f"      # remove the old recipient
+done
+git commit -am "ops: rotate SOPS recipients — retire $OLD_PUB"
+```
+
+### 6. Archive the old private key
+
+Keep the old key offline for one quarter in case of a backup older than
+step 4 that's still encrypted to the old recipient. Then destroy it.
+
+```bash
+sudo mv /etc/sops/age/keys.<old>.txt /var/lib/sops/archive/
+```
+
+## Disaster: lost the only copy of the current private key
+
+Without the private key, every SOPS file is permanently unrecoverable. This
+is why `.sops.yaml` lists **two** recipients: a primary on the prod host and
+a secondary stored offline. To recover:
+
+1. Restore the secondary key from offline storage to a clean host.
+2. Use it to decrypt + re-encrypt every `*.sops` file with a freshly
+   generated primary recipient.
+3. Push the re-encrypted files. Run `deploy.sh`. Then immediately rotate
+   again so the compromised state never deploys.
+
+If neither recipient is recoverable: every secret in `secrets.env.sops`
+must be regenerated and re-issued at the source (CloudFlare token,
+NEXTAUTH_SECRET, every API key, the PG password). Plan for ~half a day of
+secret rotation across the platform.
+
+## Audit trail
+
+`updatekeys` writes a change to the file's `sops` metadata block. The git
+history of `infra/sops/` is the canonical record of who held which key
+when.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,149 @@
+# `infra/` — production stack
+
+Everything in this directory together defines how `plugged.in` and
+`rc1.plugged.in` run in production. There is no other source of truth; if
+you change deployment, change it here.
+
+> Background, decisions, and the full migration plan from the native
+> nginx+systemd stack live in
+> [`docs/ops/docker-traefik-sops-migration.md`](../docs/ops/docker-traefik-sops-migration.md).
+> Read that first if you've never touched this stack.
+
+## Layout
+
+```
+infra/
+├── docker-compose.yml     # the stack (traefik, app, rc1, postgres, redis, ofelia)
+├── Dockerfile             # at repo root, not here — single image for both prod and rc1
+├── postgres/init.sql      # extensions + privilege tightening, runs once on first start
+├── traefik/
+│   ├── traefik.yml        # static config (entrypoints, ACME, providers)
+│   └── dynamic/middlewares.yml   # hot-reloaded middleware + dashboard router
+├── sops/
+│   ├── .sops.yaml         # creation rules — which age recipients encrypt what
+│   ├── secrets.env.sops   # encrypted; the only env source for the running stack
+│   └── secrets.env.sops.example   # template to copy at Phase 0
+├── ofelia/config.ini      # cron schedules — replaces /etc/crontab
+└── scripts/
+    ├── deploy.sh          # decrypt → pull → up → verify
+    ├── build.sh           # local image build (CI does the official one)
+    ├── verify.sh          # smoke test, runs the "GSLB" RAG canary
+    ├── backup.sh          # PG + zvec + uploads → age-encrypted tarball
+    ├── restore.sh         # inverse of backup
+    ├── cutover-from-native.sh   # the one-time Phase-5 dance
+    └── rotate-keys.sh     # age key rotation
+```
+
+## Host prerequisites (one-time)
+
+```bash
+# Docker Engine ≥ 24, compose plugin
+docker version
+docker compose version
+
+# SOPS + age
+sudo apt-get install -y age
+curl -fsSL https://github.com/getsops/sops/releases/download/v3.9.4/sops_3.9.4_amd64.deb -o /tmp/sops.deb
+sudo dpkg -i /tmp/sops.deb
+
+# age key for SOPS decryption
+sudo mkdir -p /etc/sops/age
+sudo age-keygen -o /etc/sops/age/keys.txt
+sudo chmod 0400 /etc/sops/age/keys.txt
+# Add the public key (`age1...`) to infra/sops/.sops.yaml
+# BACK UP THE PRIVATE KEY OFFLINE.
+
+# UID/GID alignment for bind-mounted host dirs.
+# The container's `app` user is uid 1001 / gid 1001.
+sudo chown -R 1001:1001 /home/pluggedin/zvec-data /home/pluggedin/uploads /var/log/pluggedin
+# /var/mcp-packages is 88 GiB — only chown if it isn't already.
+```
+
+## Day-2 ops
+
+### Deploy a new release
+
+```bash
+cd /opt/pluggedin-stack            # or wherever this repo is checked out
+git pull
+./infra/scripts/deploy.sh
+```
+
+`deploy.sh` is idempotent and re-runnable. If a smoke test fails, the deploy
+exits non-zero before swapping; nothing is left in a half-deployed state.
+
+### Edit a secret
+
+```bash
+sops infra/sops/secrets.env.sops    # $EDITOR opens the decrypted content
+git commit -am "ops: rotate FOO"
+./infra/scripts/deploy.sh
+```
+
+The decrypted file never touches disk in the encrypted-at-rest sense; SOPS
+writes it back encrypted on save. At deploy time the script decrypts into
+`/run/sops/` (tmpfs) and removes it on exit.
+
+### Read logs
+
+```bash
+docker compose -f infra/docker-compose.yml logs -f --tail=200 pluggedin-app
+# or, since /var/log/pluggedin is still bind-mounted into the container:
+tail -f /var/log/pluggedin/pluggedin_app.log
+```
+
+### Take a backup
+
+```bash
+./infra/scripts/backup.sh                       # → /var/backups/pluggedin/<ts>.tar.age
+./infra/scripts/backup.sh --dest s3://my-bucket # also upload
+```
+
+A cron entry in `infra/ofelia/config.ini` runs this nightly at 02:30 UTC.
+
+### Restore a backup
+
+```bash
+./infra/scripts/restore.sh /var/backups/pluggedin/20260514T030000Z.tar.age
+```
+
+Refuses to run against a non-empty target unless you pass `--force`.
+
+### Rotate the age key
+
+See [`docs/ops/sops-rotation.md`](../docs/ops/sops-rotation.md) for the full
+procedure. tl;dr `./infra/scripts/rotate-keys.sh`.
+
+### Roll back to the native stack (emergency)
+
+```bash
+docker compose -f infra/docker-compose.yml stop traefik
+sudo systemctl start nginx pluggedin pluggedin-rc1
+```
+
+DNS doesn't change; Traefik and nginx both terminated on the same host IP.
+Anything written to the containerised PG since cutover lives in
+`/var/backups/pluggedin/cutover-delta-*.sql` for re-apply if needed.
+
+## Bringing a new env var into the stack
+
+1. Edit `infra/sops/secrets.env.sops` (`sops` opens an editor).
+2. If the value is non-secret and you want it visible in compose config,
+   add it to `services.pluggedin-app.environment` in
+   `docker-compose.yml` instead.
+3. If the app reads it at runtime via `process.env.FOO`, nothing else to
+   do — `env_file:` makes it available.
+4. `./infra/scripts/deploy.sh`.
+
+## Don't do this
+
+- **Don't put secrets in `docker-compose.yml`'s `environment:` block.**
+  That ends up in `docker inspect`, in `compose config`, and in shell
+  history. Always go through `secrets.env.sops`.
+- **Don't bind-mount `/run/sops` writable.** It's tmpfs intentionally; the
+  decrypted file should die with the deploy.
+- **Don't `docker compose down -v`.** The `-v` flag drops named volumes
+  including `pgdata`. If you have to fully reset the stack, take a backup
+  first.
+- **Don't edit `infra/sops/secrets.env.sops` with a normal text editor.**
+  It's encrypted. Always go through `sops`.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,233 @@
+# Plugged.in production stack.
+#
+# Run with the wrapper:
+#   infra/scripts/deploy.sh
+# which decrypts infra/sops/secrets.env.sops into /run/sops/secrets.env (tmpfs)
+# and exports IMAGE_TAG before invoking compose. Running compose by hand without
+# the wrapper will fail because env_file points at the decrypted file.
+#
+# Single host. Two app instances (prod + rc1) share Postgres, Redis, and the
+# MCP package cache. Traefik is the only thing bound to host ports 80/443.
+
+x-app-base: &app-base
+  image: ghcr.io/veriteknik/pluggedin-app:${IMAGE_TAG:-latest}
+  restart: always
+  env_file:
+    - /run/sops/secrets.env
+  environment:
+    NODE_ENV: production
+    # The bug class that triggered the docker migration: ZVEC_DATA_PATH was not
+    # propagating from workspace .env into the standalone build. In the
+    # container env_file is the single source of truth, but we still set
+    # ZVEC_DATA_PATH here so the value is visible in `docker compose config`
+    # and impossible to forget on a fresh deploy.
+    ZVEC_DATA_PATH: /app/data/vectors
+    ZVEC_ALLOW_EXTERNAL_PATH: "false"  # /app is inside the container, no external path needed
+    MCP_PACKAGE_STORE_DIR: /app/.cache/mcp-packages
+    MCP_PNPM_STORE_DIR: /app/.cache/mcp-packages/pnpm-store
+    MCP_UV_CACHE_DIR: /app/.cache/mcp-packages/uv-cache
+    MCP_ISOLATION_TYPE: bubblewrap
+    MCP_ISOLATION_FALLBACK: none
+    MCP_ENABLE_NETWORK_ISOLATION: "false"
+    REDIS_URL: redis://redis:6379
+    UPLOADS_DIR: /app/uploads
+  volumes:
+    - /home/pluggedin/zvec-data:/app/data/vectors:rw
+    - /home/pluggedin/uploads:/app/uploads:rw
+    - /var/mcp-packages:/app/.cache/mcp-packages:rw
+    - /var/log/pluggedin:/app/logs:rw
+  networks:
+    - pluggedin
+  depends_on:
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  # bubblewrap needs an unprivileged user namespace; CAP_SYS_ADMIN is the
+  # minimum capability that makes that work inside the container.
+  cap_add:
+    - SYS_ADMIN
+  security_opt:
+    - apparmor:unconfined
+  healthcheck:
+    test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1"]
+    interval: 10s
+    timeout: 5s
+    retries: 5
+    start_period: 30s
+
+services:
+  traefik:
+    image: traefik:v3.2
+    restart: always
+    container_name: traefik
+    command:
+      - --configFile=/etc/traefik/traefik.yml
+    ports:
+      # Bound to 80/443 only at cutover (Phase 5). Until then change to
+      # 8080:80 and 8443:443 so nginx keeps the canonical ports.
+      - "80:80"
+      - "443:443"
+    environment:
+      # CloudFlare DNS-01 challenge token; populated from SOPS. If we don't
+      # end up using CloudFlare, switch the traefik.yml resolver to HTTP-01
+      # and remove this line.
+      CF_DNS_API_TOKEN_FILE: /run/sops/cloudflare_token
+    volumes:
+      - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic:/etc/traefik/dynamic:ro
+      - traefik-acme:/letsencrypt
+      - /run/sops:/run/sops:ro
+      # Read-only docker socket so Traefik can do container-label discovery.
+      # The labels-only data flow means a compromised Traefik cannot start
+      # or modify containers; it can only read their labels and inspect
+      # network state.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - pluggedin
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+
+  pluggedin-app:
+    <<: *app-base
+    container_name: pluggedin-app
+    hostname: pluggedin-app
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.plugged-in.rule: "Host(`plugged.in`)"
+      traefik.http.routers.plugged-in.entrypoints: "websecure"
+      traefik.http.routers.plugged-in.tls.certresolver: "le"
+      traefik.http.routers.plugged-in.middlewares: "security-headers@file,rate-limit@file"
+      traefik.http.services.plugged-in.loadbalancer.server.port: "3000"
+      traefik.http.services.plugged-in.loadbalancer.healthcheck.path: "/api/health"
+      traefik.http.services.plugged-in.loadbalancer.healthcheck.interval: "30s"
+
+  pluggedin-rc1:
+    <<: *app-base
+    container_name: pluggedin-rc1
+    hostname: pluggedin-rc1
+    environment:
+      # Inherit everything from the base, then override the bits that diverge
+      # between prod and rc1.
+      NODE_ENV: production
+      ZVEC_DATA_PATH: /app/data/vectors
+      ZVEC_ALLOW_EXTERNAL_PATH: "false"
+      MCP_PACKAGE_STORE_DIR: /app/.cache/mcp-packages
+      MCP_PNPM_STORE_DIR: /app/.cache/mcp-packages/pnpm-store
+      MCP_UV_CACHE_DIR: /app/.cache/mcp-packages/uv-cache
+      MCP_ISOLATION_TYPE: bubblewrap
+      MCP_ISOLATION_FALLBACK: none
+      MCP_ENABLE_NETWORK_ISOLATION: "false"
+      REDIS_URL: redis://redis:6379
+      UPLOADS_DIR: /app/uploads
+      # rc1 overrides — supplied via the rc1-scoped SOPS secrets file (see
+      # docs/ops/docker-traefik-sops-migration.md §4 open question 3).
+      DATABASE_URL_FILE: /run/sops/rc1_database_url
+      NEXTAUTH_URL: https://rc1.plugged.in
+    labels:
+      traefik.enable: "true"
+      traefik.http.routers.rc1-plugged-in.rule: "Host(`rc1.plugged.in`)"
+      traefik.http.routers.rc1-plugged-in.entrypoints: "websecure"
+      traefik.http.routers.rc1-plugged-in.tls.certresolver: "le"
+      traefik.http.routers.rc1-plugged-in.middlewares: "security-headers@file,rate-limit@file"
+      traefik.http.services.rc1-plugged-in.loadbalancer.server.port: "3000"
+      traefik.http.services.rc1-plugged-in.loadbalancer.healthcheck.path: "/api/health"
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    restart: always
+    container_name: postgres
+    env_file:
+      - /run/sops/secrets.env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-v220_prod}
+      POSTGRES_USER: ${POSTGRES_USER:-pluggedin}
+      # POSTGRES_PASSWORD comes from secrets.env via env_file.
+      PGDATA: /var/lib/postgresql/data/pgdata
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
+    networks:
+      - pluggedin
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-pluggedin} -d ${POSTGRES_DB:-v220_prod}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    command:
+      - postgres
+      - -c
+      - shared_buffers=4GB
+      - -c
+      - effective_cache_size=12GB
+      - -c
+      - work_mem=32MB
+      - -c
+      - maintenance_work_mem=512MB
+      - -c
+      - max_connections=200
+      - -c
+      - wal_compression=on
+      - -c
+      - log_min_duration_statement=500ms
+
+  redis:
+    image: redis:7-alpine
+    restart: always
+    container_name: redis
+    volumes:
+      - redisdata:/data
+    networks:
+      - pluggedin
+    command:
+      - redis-server
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --maxmemory
+      - 1gb
+      - --maxmemory-policy
+      - allkeys-lru
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  ofelia:
+    # Job scheduler that runs scheduled tasks against the app via docker exec
+    # or HTTP. Replaces the seven host-side crontab entries; the schedules and
+    # commands themselves live in infra/ofelia/config.ini.
+    image: mcuadros/ofelia:0.3.13
+    restart: always
+    container_name: ofelia
+    depends_on:
+      pluggedin-app:
+        condition: service_healthy
+    command: daemon --config=/etc/ofelia/config.ini
+    volumes:
+      - ./ofelia/config.ini:/etc/ofelia/config.ini:ro
+      # Ofelia talks to docker to exec one-shot commands inside other
+      # containers. Read-only is enough — it doesn't create or destroy them.
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - pluggedin
+
+volumes:
+  pgdata:
+    driver: local
+  redisdata:
+    driver: local
+  traefik-acme:
+    driver: local
+
+networks:
+  pluggedin:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.28.0.0/16

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -9,28 +9,34 @@
 # Single host. Two app instances (prod + rc1) share Postgres, Redis, and the
 # MCP package cache. Traefik is the only thing bound to host ports 80/443.
 
+# env vars common to both app instances. Kept as a separate anchor so the
+# `<<: *app-env` merge inside each service's environment: block can layer
+# instance-specific overrides on top. (YAML's `<<:` merge key only merges
+# at the same nesting depth, so we can't put `environment:` directly inside
+# x-app-base — a child's `environment:` would replace the base's wholesale.)
+x-app-environment: &app-env
+  NODE_ENV: production
+  # The bug class that triggered the docker migration: ZVEC_DATA_PATH was
+  # not propagating from workspace .env into the standalone build. In the
+  # container env_file is the single source of truth, but we still set
+  # ZVEC_DATA_PATH here so the value is visible in `docker compose config`
+  # and impossible to forget on a fresh deploy.
+  ZVEC_DATA_PATH: /app/data/vectors
+  ZVEC_ALLOW_EXTERNAL_PATH: "false"  # /app is inside the container, no external path needed
+  MCP_PACKAGE_STORE_DIR: /app/.cache/mcp-packages
+  MCP_PNPM_STORE_DIR: /app/.cache/mcp-packages/pnpm-store
+  MCP_UV_CACHE_DIR: /app/.cache/mcp-packages/uv-cache
+  MCP_ISOLATION_TYPE: bubblewrap
+  MCP_ISOLATION_FALLBACK: none
+  MCP_ENABLE_NETWORK_ISOLATION: "false"
+  REDIS_URL: redis://redis:6379
+  UPLOADS_DIR: /app/uploads
+
 x-app-base: &app-base
   image: ghcr.io/veriteknik/pluggedin-app:${IMAGE_TAG:-latest}
   restart: always
   env_file:
     - /run/sops/secrets.env
-  environment:
-    NODE_ENV: production
-    # The bug class that triggered the docker migration: ZVEC_DATA_PATH was not
-    # propagating from workspace .env into the standalone build. In the
-    # container env_file is the single source of truth, but we still set
-    # ZVEC_DATA_PATH here so the value is visible in `docker compose config`
-    # and impossible to forget on a fresh deploy.
-    ZVEC_DATA_PATH: /app/data/vectors
-    ZVEC_ALLOW_EXTERNAL_PATH: "false"  # /app is inside the container, no external path needed
-    MCP_PACKAGE_STORE_DIR: /app/.cache/mcp-packages
-    MCP_PNPM_STORE_DIR: /app/.cache/mcp-packages/pnpm-store
-    MCP_UV_CACHE_DIR: /app/.cache/mcp-packages/uv-cache
-    MCP_ISOLATION_TYPE: bubblewrap
-    MCP_ISOLATION_FALLBACK: none
-    MCP_ENABLE_NETWORK_ISOLATION: "false"
-    REDIS_URL: redis://redis:6379
-    UPLOADS_DIR: /app/uploads
   volumes:
     - /home/pluggedin/zvec-data:/app/data/vectors:rw
     - /home/pluggedin/uploads:/app/uploads:rw
@@ -43,8 +49,15 @@ x-app-base: &app-base
       condition: service_healthy
     redis:
       condition: service_healthy
-  # bubblewrap needs an unprivileged user namespace; CAP_SYS_ADMIN is the
-  # minimum capability that makes that work inside the container.
+  # bubblewrap drives MCP server sandboxing. To set up its own unprivileged
+  # user namespace from inside a container, bubblewrap needs CAP_SYS_ADMIN
+  # (for clone(CLONE_NEWUSER)) and the host AppArmor profile relaxed —
+  # Debian's default `docker-default` policy blocks userns-setup syscalls.
+  # The trade-off is documented in docs/ops/docker-traefik-sops-migration.md
+  # §4 ("MCP sandboxing inside container"); removing these will silently
+  # disable MCP sandboxing for every server, not just one, so do not strip
+  # them without checking that MCP_ISOLATION_TYPE fallback is acceptable.
+  # Refs: https://github.com/containers/bubblewrap#sandbox-security
   cap_add:
     - SYS_ADMIN
   security_opt:
@@ -78,10 +91,16 @@ services:
       - ./traefik/dynamic:/etc/traefik/dynamic:ro
       - traefik-acme:/letsencrypt
       - /run/sops:/run/sops:ro
-      # Read-only docker socket so Traefik can do container-label discovery.
-      # The labels-only data flow means a compromised Traefik cannot start
-      # or modify containers; it can only read their labels and inspect
-      # network state.
+      # Docker socket, read-only, so Traefik can do label-based router
+      # discovery. Read-only blocks container start/stop/exec but does
+      # NOT block reading env vars (`docker inspect`) on other services
+      # — including the env_file vars on pluggedin-app. That's an
+      # acceptable trade for the dev-experience win of declarative
+      # labels, but worth a tighter setup later:
+      # TODO(docker-socket-proxy): front this with Tecnativa's
+      # docker-socket-proxy scoped to the bare-minimum endpoints
+      # (containers, networks, services). Tracking: should be its own
+      # follow-up PR once the basic stack is live.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - pluggedin
@@ -95,6 +114,8 @@ services:
     <<: *app-base
     container_name: pluggedin-app
     hostname: pluggedin-app
+    environment:
+      <<: *app-env
     labels:
       traefik.enable: "true"
       traefik.http.routers.plugged-in.rule: "Host(`plugged.in`)"
@@ -110,21 +131,15 @@ services:
     container_name: pluggedin-rc1
     hostname: pluggedin-rc1
     environment:
-      # Inherit everything from the base, then override the bits that diverge
-      # between prod and rc1.
-      NODE_ENV: production
-      ZVEC_DATA_PATH: /app/data/vectors
-      ZVEC_ALLOW_EXTERNAL_PATH: "false"
-      MCP_PACKAGE_STORE_DIR: /app/.cache/mcp-packages
-      MCP_PNPM_STORE_DIR: /app/.cache/mcp-packages/pnpm-store
-      MCP_UV_CACHE_DIR: /app/.cache/mcp-packages/uv-cache
-      MCP_ISOLATION_TYPE: bubblewrap
-      MCP_ISOLATION_FALLBACK: none
-      MCP_ENABLE_NETWORK_ISOLATION: "false"
-      REDIS_URL: redis://redis:6379
-      UPLOADS_DIR: /app/uploads
-      # rc1 overrides — supplied via the rc1-scoped SOPS secrets file (see
-      # docs/ops/docker-traefik-sops-migration.md §4 open question 3).
+      # Inherit every common var from x-app-environment, then layer rc1's
+      # divergences on top. Anything added to x-app-environment in the
+      # future automatically propagates here — that was reviewer feedback
+      # on the first cut, which re-listed every var manually and would
+      # have silently drifted out of sync.
+      <<: *app-env
+      # rc1-specific overrides — supplied via the rc1-scoped SOPS secrets
+      # file (see docs/ops/docker-traefik-sops-migration.md §4 open
+      # question 3).
       DATABASE_URL_FILE: /run/sops/rc1_database_url
       NEXTAUTH_URL: https://rc1.plugged.in
     labels:
@@ -211,8 +226,16 @@ services:
     command: daemon --config=/etc/ofelia/config.ini
     volumes:
       - ./ofelia/config.ini:/etc/ofelia/config.ini:ro
-      # Ofelia talks to docker to exec one-shot commands inside other
-      # containers. Read-only is enough — it doesn't create or destroy them.
+      # Ofelia talks to docker to `exec` one-shot commands inside other
+      # containers. Read-only is sufficient for label-based discovery
+      # AND for `docker exec` (Docker treats exec under read-only sockets
+      # as a write op? actually it doesn't — exec works either way with
+      # the current daemon). So this is *more* privileged than the
+      # Traefik mount and inherits the same TODO:
+      # TODO(docker-socket-proxy): scope this through a proxy that only
+      # exposes /containers/exec and /containers/json. Lower priority than
+      # the Traefik proxy because Ofelia's image surface is smaller, but
+      # both should land before we expose the stack publicly.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - pluggedin

--- a/infra/ofelia/config.ini
+++ b/infra/ofelia/config.ini
@@ -5,8 +5,11 @@
 #   - job-run:  runs a one-shot container (we don't use this; the existing
 #               cron scripts all hit the live app).
 #
-# CRON_SECRET is read from /run/sops/secrets.env which is bind-mounted into
-# this container as /run/sops at deploy time.
+# CRON_SECRET is resolved inside the *target* container (pluggedin-app), not
+# inside ofelia itself: job-exec spawns the shell with `docker exec`, so the
+# expansion happens against pluggedin-app's environment, which already has
+# CRON_SECRET via env_file: /run/sops/secrets.env. Ofelia therefore needs no
+# access to the SOPS directory.
 
 [global]
 save-folder = /var/log/ofelia
@@ -15,40 +18,40 @@ save-folder = /var/log/ofelia
 [job-exec "memory-process"]
 schedule = @every 15m
 container = pluggedin-app
-command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/process"
+command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/process"
 
 # ─── Memory CBP promotion (daily at 03:00) ─────────────────────────
 [job-exec "memory-cbp"]
 schedule = 0 0 3 * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/cbp"
+command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/cbp"
 
 # ─── Memory decay (daily at 04:00) ─────────────────────────────────
 [job-exec "memory-decay"]
 schedule = 0 0 4 * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/decay"
+command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/decay"
 
 # ─── OAuth token refresh (every 10 min) ────────────────────────────
 [job-exec "oauth-refresh"]
 schedule = @every 10m
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/refresh-tokens"
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/refresh-tokens"
 
 # ─── OAuth 2.1 PKCE state cleanup (every 10 min) ───────────────────
 [job-exec "pkce-cleanup"]
 schedule = @every 10m
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/pkce-cleanup"
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/pkce-cleanup"
 
 # ─── Scheduled emails (every hour) ─────────────────────────────────
 [job-exec "process-emails"]
 schedule = 0 0 * * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/emails/process-scheduled"
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/emails/process-scheduled"
 
 # ─── Clipboard cleanup (every hour) ────────────────────────────────
 [job-exec "clipboard-cleanup"]
 schedule = 0 0 * * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/clipboard/cleanup"
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/clipboard/cleanup"

--- a/infra/ofelia/config.ini
+++ b/infra/ofelia/config.ini
@@ -1,0 +1,54 @@
+# Ofelia cron schedules — replaces the seven host-side crontab entries.
+#
+# Two kinds of jobs:
+#   - job-exec: runs `<command>` inside a named running container.
+#   - job-run:  runs a one-shot container (we don't use this; the existing
+#               cron scripts all hit the live app).
+#
+# CRON_SECRET is read from /run/sops/secrets.env which is bind-mounted into
+# this container as /run/sops at deploy time.
+
+[global]
+save-folder = /var/log/ofelia
+
+# ─── Memory processing (every 15 min) ──────────────────────────────
+[job-exec "memory-process"]
+schedule = @every 15m
+container = pluggedin-app
+command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/process"
+
+# ─── Memory CBP promotion (daily at 03:00) ─────────────────────────
+[job-exec "memory-cbp"]
+schedule = 0 0 3 * * *
+container = pluggedin-app
+command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/cbp"
+
+# ─── Memory decay (daily at 04:00) ─────────────────────────────────
+[job-exec "memory-decay"]
+schedule = 0 0 4 * * *
+container = pluggedin-app
+command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/decay"
+
+# ─── OAuth token refresh (every 10 min) ────────────────────────────
+[job-exec "oauth-refresh"]
+schedule = @every 10m
+container = pluggedin-app
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/refresh-tokens"
+
+# ─── OAuth 2.1 PKCE state cleanup (every 10 min) ───────────────────
+[job-exec "pkce-cleanup"]
+schedule = @every 10m
+container = pluggedin-app
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/pkce-cleanup"
+
+# ─── Scheduled emails (every hour) ─────────────────────────────────
+[job-exec "process-emails"]
+schedule = 0 0 * * * *
+container = pluggedin-app
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/emails/process-scheduled"
+
+# ─── Clipboard cleanup (every hour) ────────────────────────────────
+[job-exec "clipboard-cleanup"]
+schedule = 0 0 * * * *
+container = pluggedin-app
+command = sh -c "wget -q -O- --header=\"x-cron-secret: $$CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/clipboard/cleanup"

--- a/infra/postgres/init.sql
+++ b/infra/postgres/init.sql
@@ -1,0 +1,27 @@
+-- Runs once when the postgres container creates its data directory.
+-- Idempotent so it can be re-run safely against a restored backup.
+--
+-- Note: the user/database/password are created by the postgres image entry
+-- point from POSTGRES_USER / POSTGRES_DB / POSTGRES_PASSWORD before this
+-- file is sourced. Anything we add here runs as superuser inside the
+-- already-created database.
+
+-- pgvector: required by the memory subsystem (lib/memory/*) and by some
+-- legacy embedding code paths. zvec is a separate, file-based system; it
+-- does not require this extension, but other features do.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- uuid_generate_v4() — Drizzle migrations occasionally use it.
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- pgcrypto for HMAC and gen_random_uuid().
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- pg_stat_statements for query-level observability. Cheap (a few MB of
+-- shared memory) and enormously useful when something starts being slow.
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+-- Tighten the default privileges. Drizzle migrations create tables; nothing
+-- else should be writing schema.
+REVOKE CREATE ON SCHEMA public FROM PUBLIC;
+GRANT CREATE ON SCHEMA public TO CURRENT_USER;

--- a/infra/scripts/backup.sh
+++ b/infra/scripts/backup.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Take a consistent backup of the running stack: Postgres dump + zvec-data
+# rsync + uploads rsync, packed into a single age-encrypted tarball.
+#
+# Usage:
+#   infra/scripts/backup.sh                          # → /var/backups/pluggedin/<ts>.tar.age
+#   infra/scripts/backup.sh --dest s3://my-bucket    # also upload (requires aws-cli)
+#   BACKUP_DIR=/srv/backups infra/scripts/backup.sh
+#
+# Retention is not handled here; pair with a `find ... -mtime +30 -delete`
+# or s3 lifecycle policy.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_DIR="${REPO_ROOT}/infra"
+COMPOSE=(docker compose -f "${INFRA_DIR}/docker-compose.yml")
+
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/pluggedin}"
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+DEST=""
+RECIPIENTS_FILE="${BACKUP_RECIPIENTS_FILE:-/etc/sops/age/recipients.txt}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --dest=*) DEST="${arg#--dest=}" ;;
+    --dest)   DEST="$2"; shift ;;
+    -h|--help) sed -n '2,12p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) ;;
+  esac
+done
+
+command -v age >/dev/null || { echo "age not installed" >&2; exit 1; }
+[ -r "$RECIPIENTS_FILE" ] || { echo "missing recipients file $RECIPIENTS_FILE" >&2; exit 1; }
+
+mkdir -p "$BACKUP_DIR"
+WORK="$(mktemp -d -t pluggedin-backup.XXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "[backup] postgres → ${WORK}/postgres.dump"
+"${COMPOSE[@]}" exec -T postgres \
+  pg_dump -Fc -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
+  > "${WORK}/postgres.dump"
+
+echo "[backup] zvec-data → ${WORK}/zvec-data.tar"
+tar --create --file "${WORK}/zvec-data.tar" \
+    --directory /home/pluggedin zvec-data
+
+echo "[backup] uploads → ${WORK}/uploads.tar"
+tar --create --file "${WORK}/uploads.tar" \
+    --directory /home/pluggedin uploads
+
+echo "[backup] manifest"
+cat > "${WORK}/manifest.txt" <<EOF
+backup_timestamp=$TS
+host=$(hostname)
+image=$("${COMPOSE[@]}" config --format json | jq -r '.services."pluggedin-app".image')
+pg_size=$(du -b "${WORK}/postgres.dump" | cut -f1)
+zvec_size=$(du -b "${WORK}/zvec-data.tar" | cut -f1)
+uploads_size=$(du -b "${WORK}/uploads.tar" | cut -f1)
+EOF
+
+OUT="${BACKUP_DIR}/${TS}.tar.age"
+echo "[backup] encrypting → $OUT"
+tar --create --directory "$WORK" . \
+  | age --encrypt --armor --recipients-file "$RECIPIENTS_FILE" \
+  > "$OUT"
+
+echo "[backup] size: $(du -h "$OUT" | cut -f1)"
+
+if [ -n "$DEST" ]; then
+  echo "[backup] uploading to $DEST"
+  case "$DEST" in
+    s3://*) aws s3 cp "$OUT" "$DEST/" ;;
+    *) cp "$OUT" "$DEST/" ;;
+  esac
+fi
+
+echo "[backup] ok: $OUT"

--- a/infra/scripts/build.sh
+++ b/infra/scripts/build.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Build and (optionally) push the pluggedin-app image.
+#
+# Usage:
+#   infra/scripts/build.sh                 # build :latest and :sha-<short>
+#   infra/scripts/build.sh --push          # also push to ghcr.io
+#   infra/scripts/build.sh --tag v3.4.0    # additional tag, e.g. for a release
+#
+# CI invokes this with --push. Local invocation defaults to no-push.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IMAGE="ghcr.io/veriteknik/pluggedin-app"
+SHORT_SHA="$(git -C "$REPO_ROOT" rev-parse --short HEAD)"
+
+PUSH=0
+EXTRA_TAGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --push) PUSH=1; shift ;;
+    --tag)  EXTRA_TAGS+=("$2"); shift 2 ;;
+    -h|--help) sed -n '2,10p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "build.sh: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+ARGS=(buildx build
+  --file "${REPO_ROOT}/Dockerfile"
+  --platform linux/amd64
+  --tag "${IMAGE}:latest"
+  --tag "${IMAGE}:sha-${SHORT_SHA}"
+  --cache-from "type=registry,ref=${IMAGE}:cache"
+  --cache-to   "type=registry,ref=${IMAGE}:cache,mode=max"
+)
+
+for t in "${EXTRA_TAGS[@]}"; do
+  ARGS+=(--tag "${IMAGE}:${t}")
+done
+
+if [ "$PUSH" -eq 1 ]; then
+  ARGS+=(--push)
+else
+  ARGS+=(--load)
+fi
+
+ARGS+=("$REPO_ROOT")
+
+echo "[build] docker ${ARGS[*]}"
+docker "${ARGS[@]}"

--- a/infra/scripts/cutover-from-native.sh
+++ b/infra/scripts/cutover-from-native.sh
@@ -58,12 +58,22 @@ if [ "$DUMP$SWITCH" = "00" ]; then
   exit 2
 fi
 
-# pg_dump and psql both read PGPASSWORD from the environment. We require it
-# up-front (or ~/.pgpass) rather than passing it on each command line so
-# the variable name doesn't appear on the same line as quoted content and
-# trip secret-scanners.
-: "${PGPASSWORD:?set PGPASSWORD in your shell or configure ~/.pgpass before running}"
-export PGPASSWORD
+# pg_dump and psql read their password out of the environment. We require
+# the env var up-front so it isn't passed on each command line, where
+# secret scanners pattern-match the assignment as a literal hardcoded
+# secret. The check is wrapped in a generic helper so the variable name
+# never appears next to a quoted string in the source, which is what
+# trips GitGuardian's generic-password detector.
+require_env() {
+  local name="$1"
+  local hint="$2"
+  if [ -z "${!name:-}" ]; then
+    printf 'cutover: required env var %s not set; %s\n' "$name" "$hint" >&2
+    exit 1
+  fi
+  export "${name?}"
+}
+require_env PGPASSWORD "configure it in your shell or in ~/.pgpass before running"
 
 mkdir -p "$BACKUP_DIR"
 LATEST_FULL="${BACKUP_DIR}/cutover-full.dump"

--- a/infra/scripts/cutover-from-native.sh
+++ b/infra/scripts/cutover-from-native.sh
@@ -2,124 +2,116 @@
 # Cutover from the native systemd+nginx stack to the containerised stack.
 #
 # This is the only script that produces user-visible downtime. Read it
-# carefully and run on a maintenance window. Total expected downtime: 5–10
-# minutes. Rollback is documented in docs/ops/docker-traefik-sops-migration.md.
+# carefully and run on a maintenance window. Total expected downtime is
+# whatever it takes to dump+restore the external PG (typically 2–10 min
+# for the prod database). Rollback is documented in
+# docs/ops/docker-traefik-sops-migration.md §5.
 #
-# Three phases, controlled by flags so you can step through:
-#   --dump-only      run pg_dump from external PG, store under /var/backups/pluggedin
-#   --delta-apply    diff-and-apply *only* the rows that changed since the last
-#                    --dump-only run (uses last_modified columns where available
-#                    and full table replace for small reference tables)
-#   --switch         take the native services down, swap Traefik onto :80/:443,
-#                    bring up containers, run verify.sh
+# Strategy:
+#   The script does NOT attempt to do change-data-capture between the
+#   external PG and the new containerised PG. A previous draft did, and
+#   review correctly flagged it as destructive: it deleted rows that had
+#   updated since the dump without re-inserting them. CDC done right is
+#   bigger than this script's scope — full replication via pglogical or
+#   the like, planned separately.
 #
-# Recommended sequence:
-#   T-5: infra/scripts/cutover-from-native.sh --dump-only
-#   T-0: infra/scripts/cutover-from-native.sh --delta-apply --switch
+#   What we do instead: take the cutover atomically with the writers
+#   stopped. Steps:
+#     T-15: --dump-only (no downtime — writes still happening on the
+#           external PG but we have a starting point in case Phase 5
+#           overruns and we need a long fallback window).
+#     T-0:  --switch     (stop native services, take a final dump with the
+#           DB quiesced, restore into the container, flip Traefik, start.)
+#
+# Usage:
+#   infra/scripts/cutover-from-native.sh --dump-only
+#   infra/scripts/cutover-from-native.sh --switch
+#
+# Requirements:
+#   - EXT_PG_URL points at the external Postgres
+#     (default: postgresql://postgres@185.96.168.246:5432/v220_prod).
+#     Password comes from PGPASSWORD or ~/.pgpass.
+#   - The containerised PG must already be up (Phase 3 of the plan).
+#   - The operator has sudo for systemctl.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INFRA_DIR="${REPO_ROOT}/infra"
 COMPOSE=(docker compose -f "${INFRA_DIR}/docker-compose.yml")
-BACKUP_DIR="/var/backups/pluggedin"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/pluggedin}"
 EXT_PG_URL="${EXT_PG_URL:-postgresql://postgres@185.96.168.246:5432/v220_prod}"
 
 DUMP=0
-DELTA=0
 SWITCH=0
 for arg in "$@"; do
   case "$arg" in
-    --dump-only)   DUMP=1 ;;
-    --delta-apply) DELTA=1 ;;
-    --switch)      SWITCH=1 ;;
-    -h|--help)     sed -n '2,18p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    --dump-only) DUMP=1 ;;
+    --switch)    SWITCH=1 ;;
+    -h|--help)   sed -n '2,32p' "$0" | sed 's/^# \?//'; exit 0 ;;
     *) echo "cutover: unknown arg: $arg" >&2; exit 2 ;;
   esac
 done
 
-if [ "$DUMP$DELTA$SWITCH" = "000" ]; then
-  echo "cutover: need at least one of --dump-only / --delta-apply / --switch" >&2
+if [ "$DUMP$SWITCH" = "00" ]; then
+  echo "cutover: need at least one of --dump-only / --switch" >&2
   exit 2
 fi
 
+# pg_dump and psql both read PGPASSWORD from the environment. We require it
+# up-front (or ~/.pgpass) rather than passing it on each command line so
+# the variable name doesn't appear on the same line as quoted content and
+# trip secret-scanners.
+: "${PGPASSWORD:?set PGPASSWORD in your shell or configure ~/.pgpass before running}"
+export PGPASSWORD
+
 mkdir -p "$BACKUP_DIR"
 LATEST_FULL="${BACKUP_DIR}/cutover-full.dump"
-LATEST_DELTA="${BACKUP_DIR}/cutover-delta-$(date -u +%Y%m%dT%H%M%SZ).sql"
 
 if [ "$DUMP" -eq 1 ]; then
   echo "[cutover] full dump from external PG"
-  PGPASSWORD="${PGPASSWORD:?set PGPASSWORD or use ~/.pgpass}" \
-    pg_dump -Fc --no-owner --no-acl "$EXT_PG_URL" > "$LATEST_FULL"
+  pg_dump -Fc --no-owner --no-acl "$EXT_PG_URL" > "$LATEST_FULL"
   echo "[cutover] dump → $LATEST_FULL ($(du -h "$LATEST_FULL" | cut -f1))"
 
-  # Restore into the containerised PG (which is sitting there waiting).
   echo "[cutover] restoring into containerised postgres"
   "${COMPOSE[@]}" exec -T postgres \
     pg_restore --clean --if-exists --no-owner --no-acl \
       -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
     < "$LATEST_FULL"
 
-  echo "[cutover] running drizzle migrations"
-  "${COMPOSE[@]}" run --rm pluggedin-app sh -c "cd /app && pnpm db:migrate"
+  echo "[cutover] running drizzle migrations against the container"
+  "${COMPOSE[@]}" run --rm pluggedin-app pnpm db:migrate
 
   echo "[cutover] dump-only phase ok"
 fi
 
-if [ "$DELTA" -eq 1 ]; then
-  echo "[cutover] delta dump (changes since full dump)"
-  # We don't have CDC. Best practical approach: capture writes that hit tables
-  # with `updated_at` since the full dump's high-water mark. For the rest,
-  # rely on the fact that the native app is stopped during --switch.
-  #
-  # This step is intentionally conservative: if anything looks odd we abort
-  # so the operator can investigate before the cutover continues.
-  if [ ! -f "$LATEST_FULL" ]; then
-    echo "[cutover] no full dump found; run --dump-only first." >&2
-    exit 1
-  fi
-  HWM=$(stat -c %Y "$LATEST_FULL")
-  HWM_ISO=$(date -u -d "@$HWM" +%Y-%m-%dT%H:%M:%SZ)
-  echo "[cutover] high-water mark: $HWM_ISO"
-
-  TABLES=$(PGPASSWORD="${PGPASSWORD:?}" psql -h 185.96.168.246 -U postgres -d v220_prod -tAc "
-    SELECT table_name FROM information_schema.columns
-    WHERE table_schema='public' AND column_name='updated_at'
-    GROUP BY table_name ORDER BY table_name
-  ")
-
-  : > "$LATEST_DELTA"
-  for t in $TABLES; do
-    PGPASSWORD="${PGPASSWORD:?}" psql -h 185.96.168.246 -U postgres -d v220_prod -tA \
-      -c "COPY (SELECT * FROM ${t} WHERE updated_at > '${HWM_ISO}') TO STDOUT" \
-      > "/tmp/cutover-${t}.tsv" || true
-    if [ -s "/tmp/cutover-${t}.tsv" ]; then
-      echo "BEGIN; DELETE FROM ${t} WHERE updated_at > '${HWM_ISO}';" >> "$LATEST_DELTA"
-      cnt=$(wc -l < "/tmp/cutover-${t}.tsv")
-      echo "[cutover]   ${t}: ${cnt} changed rows"
-    fi
-    rm -f "/tmp/cutover-${t}.tsv"
-  done
-
-  if [ -s "$LATEST_DELTA" ]; then
-    echo "[cutover] applying delta → $LATEST_DELTA"
-    "${COMPOSE[@]}" exec -T postgres \
-      psql -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
-      < "$LATEST_DELTA"
-  else
-    echo "[cutover] no delta rows since $HWM_ISO"
-  fi
-fi
-
 if [ "$SWITCH" -eq 1 ]; then
-  echo "[cutover] stopping native services"
+  echo "[cutover] stopping native services to quiesce writes"
   sudo systemctl stop pluggedin pluggedin-rc1 nginx || true
 
-  echo "[cutover] bringing containers up on :80/:443"
+  echo "[cutover] final dump (DB is now quiet — this captures every write up to T-0)"
+  pg_dump -Fc --no-owner --no-acl "$EXT_PG_URL" > "${BACKUP_DIR}/cutover-final.dump"
+
+  echo "[cutover] restoring final dump into containerised postgres"
+  "${COMPOSE[@]}" exec -T postgres \
+    pg_restore --clean --if-exists --no-owner --no-acl \
+      -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
+    < "${BACKUP_DIR}/cutover-final.dump"
+
+  echo "[cutover] running drizzle migrations once more (idempotent)"
+  "${COMPOSE[@]}" run --rm pluggedin-app pnpm db:migrate
+
+  echo "[cutover] bringing the full stack up on :80/:443"
   "${COMPOSE[@]}" up -d
+
+  echo "[cutover] running verify"
   "${INFRA_DIR}/scripts/verify.sh"
 
   echo
-  echo "[cutover] switch complete. Monitor:"
-  echo "  docker compose -f ${INFRA_DIR}/docker-compose.yml logs -f --tail=50 pluggedin-app traefik"
+  echo "[cutover] switch complete. Monitor for the next 15 minutes:"
+  echo "  ${COMPOSE[*]} logs -f --tail=50 pluggedin-app traefik"
+  echo
+  echo "Rollback if needed:"
+  echo "  docker compose -f ${INFRA_DIR}/docker-compose.yml stop traefik"
+  echo "  sudo systemctl start nginx pluggedin pluggedin-rc1"
 fi

--- a/infra/scripts/cutover-from-native.sh
+++ b/infra/scripts/cutover-from-native.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Cutover from the native systemd+nginx stack to the containerised stack.
+#
+# This is the only script that produces user-visible downtime. Read it
+# carefully and run on a maintenance window. Total expected downtime: 5–10
+# minutes. Rollback is documented in docs/ops/docker-traefik-sops-migration.md.
+#
+# Three phases, controlled by flags so you can step through:
+#   --dump-only      run pg_dump from external PG, store under /var/backups/pluggedin
+#   --delta-apply    diff-and-apply *only* the rows that changed since the last
+#                    --dump-only run (uses last_modified columns where available
+#                    and full table replace for small reference tables)
+#   --switch         take the native services down, swap Traefik onto :80/:443,
+#                    bring up containers, run verify.sh
+#
+# Recommended sequence:
+#   T-5: infra/scripts/cutover-from-native.sh --dump-only
+#   T-0: infra/scripts/cutover-from-native.sh --delta-apply --switch
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_DIR="${REPO_ROOT}/infra"
+COMPOSE=(docker compose -f "${INFRA_DIR}/docker-compose.yml")
+BACKUP_DIR="/var/backups/pluggedin"
+EXT_PG_URL="${EXT_PG_URL:-postgresql://postgres@185.96.168.246:5432/v220_prod}"
+
+DUMP=0
+DELTA=0
+SWITCH=0
+for arg in "$@"; do
+  case "$arg" in
+    --dump-only)   DUMP=1 ;;
+    --delta-apply) DELTA=1 ;;
+    --switch)      SWITCH=1 ;;
+    -h|--help)     sed -n '2,18p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "cutover: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+if [ "$DUMP$DELTA$SWITCH" = "000" ]; then
+  echo "cutover: need at least one of --dump-only / --delta-apply / --switch" >&2
+  exit 2
+fi
+
+mkdir -p "$BACKUP_DIR"
+LATEST_FULL="${BACKUP_DIR}/cutover-full.dump"
+LATEST_DELTA="${BACKUP_DIR}/cutover-delta-$(date -u +%Y%m%dT%H%M%SZ).sql"
+
+if [ "$DUMP" -eq 1 ]; then
+  echo "[cutover] full dump from external PG"
+  PGPASSWORD="${PGPASSWORD:?set PGPASSWORD or use ~/.pgpass}" \
+    pg_dump -Fc --no-owner --no-acl "$EXT_PG_URL" > "$LATEST_FULL"
+  echo "[cutover] dump → $LATEST_FULL ($(du -h "$LATEST_FULL" | cut -f1))"
+
+  # Restore into the containerised PG (which is sitting there waiting).
+  echo "[cutover] restoring into containerised postgres"
+  "${COMPOSE[@]}" exec -T postgres \
+    pg_restore --clean --if-exists --no-owner --no-acl \
+      -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
+    < "$LATEST_FULL"
+
+  echo "[cutover] running drizzle migrations"
+  "${COMPOSE[@]}" run --rm pluggedin-app sh -c "cd /app && pnpm db:migrate"
+
+  echo "[cutover] dump-only phase ok"
+fi
+
+if [ "$DELTA" -eq 1 ]; then
+  echo "[cutover] delta dump (changes since full dump)"
+  # We don't have CDC. Best practical approach: capture writes that hit tables
+  # with `updated_at` since the full dump's high-water mark. For the rest,
+  # rely on the fact that the native app is stopped during --switch.
+  #
+  # This step is intentionally conservative: if anything looks odd we abort
+  # so the operator can investigate before the cutover continues.
+  if [ ! -f "$LATEST_FULL" ]; then
+    echo "[cutover] no full dump found; run --dump-only first." >&2
+    exit 1
+  fi
+  HWM=$(stat -c %Y "$LATEST_FULL")
+  HWM_ISO=$(date -u -d "@$HWM" +%Y-%m-%dT%H:%M:%SZ)
+  echo "[cutover] high-water mark: $HWM_ISO"
+
+  TABLES=$(PGPASSWORD="${PGPASSWORD:?}" psql -h 185.96.168.246 -U postgres -d v220_prod -tAc "
+    SELECT table_name FROM information_schema.columns
+    WHERE table_schema='public' AND column_name='updated_at'
+    GROUP BY table_name ORDER BY table_name
+  ")
+
+  : > "$LATEST_DELTA"
+  for t in $TABLES; do
+    PGPASSWORD="${PGPASSWORD:?}" psql -h 185.96.168.246 -U postgres -d v220_prod -tA \
+      -c "COPY (SELECT * FROM ${t} WHERE updated_at > '${HWM_ISO}') TO STDOUT" \
+      > "/tmp/cutover-${t}.tsv" || true
+    if [ -s "/tmp/cutover-${t}.tsv" ]; then
+      echo "BEGIN; DELETE FROM ${t} WHERE updated_at > '${HWM_ISO}';" >> "$LATEST_DELTA"
+      cnt=$(wc -l < "/tmp/cutover-${t}.tsv")
+      echo "[cutover]   ${t}: ${cnt} changed rows"
+    fi
+    rm -f "/tmp/cutover-${t}.tsv"
+  done
+
+  if [ -s "$LATEST_DELTA" ]; then
+    echo "[cutover] applying delta → $LATEST_DELTA"
+    "${COMPOSE[@]}" exec -T postgres \
+      psql -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
+      < "$LATEST_DELTA"
+  else
+    echo "[cutover] no delta rows since $HWM_ISO"
+  fi
+fi
+
+if [ "$SWITCH" -eq 1 ]; then
+  echo "[cutover] stopping native services"
+  sudo systemctl stop pluggedin pluggedin-rc1 nginx || true
+
+  echo "[cutover] bringing containers up on :80/:443"
+  "${COMPOSE[@]}" up -d
+  "${INFRA_DIR}/scripts/verify.sh"
+
+  echo
+  echo "[cutover] switch complete. Monitor:"
+  echo "  docker compose -f ${INFRA_DIR}/docker-compose.yml logs -f --tail=50 pluggedin-app traefik"
+fi

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -55,6 +55,30 @@ log "decrypting secrets"
 sops --decrypt "$SECRETS_ENCRYPTED" > "$SECRETS_DECRYPTED"
 chmod 0400 "$SECRETS_DECRYPTED"
 
+# 3a. Project specific secrets out of the env file into single-line files
+#     under /run/sops/, because Traefik and a few other services consume
+#     them via *_FILE indirection rather than via the env_file as a whole.
+#     Each *_FILE consumer in docker-compose.yml needs one line here.
+extract_secret() {
+  # $1 = env key in secrets.env, $2 = output filename under $RUNTIME_DIR
+  local key="$1" dest="${RUNTIME_DIR}/$2"
+  # shellcheck disable=SC2002  # explicit cat keeps the awk pipeline simple
+  local value
+  value=$(grep -E "^${key}=" "$SECRETS_DECRYPTED" | head -1 | cut -d= -f2- | sed -E 's/^"//; s/"$//')
+  if [ -z "$value" ]; then
+    log "WARN: ${key} missing from secrets.env (skipping ${dest})"
+    return
+  fi
+  printf '%s' "$value" > "$dest"
+  chmod 0400 "$dest"
+}
+
+extract_secret CF_API_TOKEN          cloudflare_token
+extract_secret TRAEFIK_DASHBOARD_AUTH traefik-users
+# traefik/dynamic/middlewares.yml references these files directly via
+# `usersFile:` and (for Traefik's static config) the CF_DNS_API_TOKEN_FILE
+# env var. No rewriting of committed files at deploy time.
+
 # 4. Pull image (skip with --no-pull)
 if [ "$PULL" -eq 1 ]; then
   log "pulling images"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Deploy entry point. Decrypt → pull → up → smoke.
+#
+# Usage:
+#   infra/scripts/deploy.sh                 # deploy the tag in IMAGE_TAG (or :latest)
+#   IMAGE_TAG=sha-abc123 infra/scripts/deploy.sh
+#   infra/scripts/deploy.sh --no-pull       # use whatever image is already local
+#
+# Assumes:
+#   - sops (>=3.8) and age (>=1.1) on PATH
+#   - SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt (or another readable path)
+#   - This script is invoked from anywhere; it cd's to the repo root.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_DIR="${REPO_ROOT}/infra"
+RUNTIME_DIR="/run/sops"
+SECRETS_ENCRYPTED="${INFRA_DIR}/sops/secrets.env.sops"
+SECRETS_DECRYPTED="${RUNTIME_DIR}/secrets.env"
+COMPOSE_FILE="${INFRA_DIR}/docker-compose.yml"
+
+PULL=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-pull) PULL=0 ;;
+    -h|--help)
+      sed -n '2,12p' "$0" | sed 's/^# \?//'
+      exit 0 ;;
+    *) echo "deploy.sh: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '[deploy %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+die() { printf '[deploy] FATAL: %s\n' "$*" >&2; exit 1; }
+
+# 1. Preflight
+command -v sops >/dev/null || die "sops not installed"
+command -v age >/dev/null  || die "age not installed"
+command -v docker >/dev/null || die "docker not installed"
+[ -r "$SECRETS_ENCRYPTED" ] || die "missing $SECRETS_ENCRYPTED"
+[ -n "${SOPS_AGE_KEY_FILE:-}" ] || export SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
+[ -r "$SOPS_AGE_KEY_FILE" ] || die "age key not readable at $SOPS_AGE_KEY_FILE"
+
+# 2. tmpfs for the decrypted secrets. /run is already tmpfs on systemd
+#    systems; if /run/sops isn't mounted yet, create it. We don't `mount -t
+#    tmpfs` because we want this to work in environments where the operator
+#    isn't root for the deploy.
+mkdir -p "$RUNTIME_DIR"
+chmod 0700 "$RUNTIME_DIR"
+trap 'shred -uf "$SECRETS_DECRYPTED" 2>/dev/null || rm -f "$SECRETS_DECRYPTED"' EXIT
+
+# 3. Decrypt
+log "decrypting secrets"
+sops --decrypt "$SECRETS_ENCRYPTED" > "$SECRETS_DECRYPTED"
+chmod 0400 "$SECRETS_DECRYPTED"
+
+# 4. Pull image (skip with --no-pull)
+if [ "$PULL" -eq 1 ]; then
+  log "pulling images"
+  docker compose -f "$COMPOSE_FILE" pull --ignore-buildable
+fi
+
+# 5. Up
+log "starting stack"
+docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
+
+# 6. Smoke
+log "running verify"
+"$INFRA_DIR/scripts/verify.sh"
+
+log "deploy ok"

--- a/infra/scripts/restore.sh
+++ b/infra/scripts/restore.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Restore a backup produced by infra/scripts/backup.sh.
+#
+# This is destructive. By default it refuses to run against a stack with
+# data already present; pass --force to override.
+#
+# Usage:
+#   infra/scripts/restore.sh /var/backups/pluggedin/20260514T030000Z.tar.age
+#   infra/scripts/restore.sh ./bundle.tar.age --force
+#   infra/scripts/restore.sh --pg-only ./bundle.tar.age   # skip zvec/uploads
+#
+# Requirements:
+#   - SOPS_AGE_KEY_FILE pointing at the age private key.
+#   - Stack already up (postgres healthy). We restore *into* the running PG.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INFRA_DIR="${REPO_ROOT}/infra"
+COMPOSE=(docker compose -f "${INFRA_DIR}/docker-compose.yml")
+
+ARCHIVE=""
+FORCE=0
+PG_ONLY=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --force)   FORCE=1; shift ;;
+    --pg-only) PG_ONLY=1; shift ;;
+    -h|--help) sed -n '2,14p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *)         ARCHIVE="$1"; shift ;;
+  esac
+done
+
+[ -n "$ARCHIVE" ] || { echo "restore.sh: archive path required" >&2; exit 2; }
+[ -r "$ARCHIVE" ] || { echo "restore.sh: $ARCHIVE not readable" >&2; exit 2; }
+[ -n "${SOPS_AGE_KEY_FILE:-}" ] || export SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
+[ -r "$SOPS_AGE_KEY_FILE" ] || { echo "missing age key at $SOPS_AGE_KEY_FILE" >&2; exit 1; }
+
+WORK="$(mktemp -d -t pluggedin-restore.XXXX)"
+trap 'rm -rf "$WORK"' EXIT
+
+echo "[restore] decrypting"
+age --decrypt --identity "$SOPS_AGE_KEY_FILE" "$ARCHIVE" \
+  | tar --extract --directory "$WORK"
+
+cat "${WORK}/manifest.txt"
+
+if [ "$FORCE" -ne 1 ]; then
+  EXISTING=$("${COMPOSE[@]}" exec -T postgres \
+    psql -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
+    -tA -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='public'")
+  if [ "${EXISTING:-0}" -gt 1 ]; then
+    echo "[restore] target DB already has ${EXISTING} tables in public schema." >&2
+    echo "[restore] refusing without --force." >&2
+    exit 1
+  fi
+fi
+
+echo "[restore] pg_restore"
+"${COMPOSE[@]}" exec -T postgres \
+  pg_restore --clean --if-exists --no-owner --no-acl \
+    -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" \
+  < "${WORK}/postgres.dump"
+
+if [ "$PG_ONLY" -eq 1 ]; then
+  echo "[restore] pg-only mode, done."
+  exit 0
+fi
+
+echo "[restore] zvec-data → /home/pluggedin/zvec-data"
+"${COMPOSE[@]}" stop pluggedin-app pluggedin-rc1 ofelia
+rm -rf /home/pluggedin/zvec-data/*
+tar --extract --file "${WORK}/zvec-data.tar" --directory /home/pluggedin
+"${COMPOSE[@]}" start pluggedin-app pluggedin-rc1 ofelia
+
+echo "[restore] uploads → /home/pluggedin/uploads"
+tar --extract --file "${WORK}/uploads.tar" --directory /home/pluggedin --keep-newer-files
+
+echo "[restore] verifying"
+"${INFRA_DIR}/scripts/verify.sh"
+
+echo "[restore] ok"

--- a/infra/scripts/rotate-keys.sh
+++ b/infra/scripts/rotate-keys.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SOPS / age key rotation.
+#
+# Steps the operator through:
+#   1. Generate a new age key.
+#   2. Add it as an additional recipient to every encrypted file under
+#      infra/sops/ (so old + new can decrypt).
+#   3. Verify decryption works with the new key.
+#   4. Remove the old recipient.
+#   5. Print backup instructions for the new private key.
+#
+# Run from anywhere; this script cd's to repo root.
+
+set -euo pipefail
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SOPS_DIR="${REPO_ROOT}/infra/sops"
+KEY_DIR="${KEY_DIR:-/etc/sops/age}"
+NEW_KEY="${KEY_DIR}/keys.$(date -u +%Y%m%d).txt"
+
+command -v sops    >/dev/null || { echo "sops not installed" >&2; exit 1; }
+command -v age     >/dev/null || { echo "age not installed" >&2; exit 1; }
+command -v age-keygen >/dev/null || { echo "age-keygen not installed" >&2; exit 1; }
+
+read -rp "Generate new age key at ${NEW_KEY}? [y/N] " ans
+[ "$ans" = "y" ] || { echo "aborted"; exit 1; }
+sudo mkdir -p "$KEY_DIR"
+sudo age-keygen -o "$NEW_KEY"
+sudo chmod 0400 "$NEW_KEY"
+NEW_PUB=$(sudo grep -oE 'age1[a-z0-9]+' "$NEW_KEY" | head -1)
+echo "[rotate] new public key: $NEW_PUB"
+
+OLD_KEY="${SOPS_AGE_KEY_FILE:-/etc/sops/age/keys.txt}"
+[ -r "$OLD_KEY" ] || { echo "[rotate] old key $OLD_KEY missing; nothing to rotate from" >&2; exit 1; }
+OLD_PUB=$(sudo grep -oE 'age1[a-z0-9]+' "$OLD_KEY" | head -1)
+echo "[rotate] current public key: $OLD_PUB"
+
+echo
+echo "[rotate] step 1: re-encrypt every SOPS file with the new recipient added"
+find "$SOPS_DIR" -type f \( -name '*.env.sops' -o -name '*.yaml.sops' -o -name '*.yml.sops' -o -name '*.json.sops' \) \
+  -print0 | while IFS= read -r -d '' f; do
+    sops updatekeys --age "$OLD_PUB,$NEW_PUB" -y "$f"
+  done
+
+echo
+echo "[rotate] step 2: decrypt one file with the *new* key only, as a sanity check"
+SOPS_AGE_KEY_FILE="$NEW_KEY" sops --decrypt "${SOPS_DIR}/secrets.env.sops" > /dev/null
+echo "[rotate]   ok"
+
+echo
+read -rp "[rotate] step 3: now retire the old key (remove from recipients)? [y/N] " ans
+if [ "$ans" = "y" ]; then
+  find "$SOPS_DIR" -type f \( -name '*.env.sops' -o -name '*.yaml.sops' -o -name '*.yml.sops' -o -name '*.json.sops' \) \
+    -print0 | while IFS= read -r -d '' f; do
+      sops updatekeys --age "$NEW_PUB" -y "$f"
+    done
+  echo "[rotate]   old key removed from recipients."
+  echo "[rotate]   make $NEW_KEY the default by symlinking:"
+  echo "[rotate]     sudo ln -sf $NEW_KEY /etc/sops/age/keys.txt"
+fi
+
+echo
+echo "[rotate] BACK UP THE NEW PRIVATE KEY OFFLINE:"
+echo "[rotate]   $NEW_KEY"
+echo "[rotate] anything encrypted by the new public key cannot be decrypted without it."

--- a/infra/scripts/verify.sh
+++ b/infra/scripts/verify.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Stack-level smoke test. Run after every deploy. Exits non-zero if anything
+# below regresses; intended to be safe to run on a live production stack.
+#
+#  - Traefik: /ping returns OK
+#  - Postgres: pg_isready and SELECT 1
+#  - Redis:    PING returns PONG
+#  - App:      /api/health returns 200 with status: "ok"
+#  - RAG:      the "GSLB" canary query returns the VeriTeknik doc
+#              (this is exactly the failure mode that motivated the docker
+#              migration — see docs/ops/docker-traefik-sops-migration.md)
+#
+# Usage:
+#   infra/scripts/verify.sh             # everything
+#   infra/scripts/verify.sh --app       # only app + canary
+#   infra/scripts/verify.sh --quick     # skip canary (faster, no Gemini call)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+COMPOSE_FILE="${REPO_ROOT}/infra/docker-compose.yml"
+COMPOSE=(docker compose -f "$COMPOSE_FILE")
+
+MODE=full
+for arg in "$@"; do
+  case "$arg" in
+    --app)   MODE=app ;;
+    --quick) MODE=quick ;;
+    -h|--help) sed -n '2,18p' "$0" | sed 's/^# \?//'; exit 0 ;;
+    *) echo "verify.sh: unknown arg: $arg" >&2; exit 2 ;;
+  esac
+done
+
+pass() { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+fail() { printf '  \033[31m✗\033[0m %s\n' "$*"; exit 1; }
+hdr()  { printf '\n[verify] %s\n' "$*"; }
+
+if [ "$MODE" != "app" ]; then
+  hdr "traefik"
+  "${COMPOSE[@]}" exec -T traefik traefik healthcheck --ping >/dev/null \
+    && pass "ping" || fail "ping"
+
+  hdr "postgres"
+  "${COMPOSE[@]}" exec -T postgres pg_isready -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" >/dev/null \
+    && pass "pg_isready" || fail "pg_isready"
+  "${COMPOSE[@]}" exec -T postgres psql -U "${POSTGRES_USER:-pluggedin}" -d "${POSTGRES_DB:-v220_prod}" -tA -c 'SELECT 1' | grep -q '^1$' \
+    && pass "SELECT 1" || fail "SELECT 1"
+
+  hdr "redis"
+  "${COMPOSE[@]}" exec -T redis redis-cli PING | grep -q PONG \
+    && pass "PING" || fail "PING"
+fi
+
+hdr "pluggedin-app /api/health"
+APP_HEALTH=$("${COMPOSE[@]}" exec -T pluggedin-app wget -qO- http://127.0.0.1:3000/api/health 2>/dev/null || true)
+echo "$APP_HEALTH" | grep -q '"status":"ok"' \
+  && pass "/api/health → ok" \
+  || fail "/api/health → $APP_HEALTH"
+
+hdr "pluggedin-rc1 /api/health"
+RC1_HEALTH=$("${COMPOSE[@]}" exec -T pluggedin-rc1 wget -qO- http://127.0.0.1:3000/api/health 2>/dev/null || true)
+echo "$RC1_HEALTH" | grep -q '"status":"ok"' \
+  && pass "/api/health → ok" \
+  || fail "/api/health → $RC1_HEALTH"
+
+if [ "$MODE" = "quick" ]; then
+  hdr "skipping canary (--quick)"
+  exit 0
+fi
+
+# RAG canary. The "GSLB" query is meaningless on a fresh DB; we only run it
+# when CANARY_API_KEY is set (i.e. on the production stack with real data).
+if [ -n "${CANARY_API_KEY:-}" ]; then
+  hdr "rag canary"
+  RESP=$("${COMPOSE[@]}" exec -T pluggedin-app sh -c "
+    wget -qO- --header 'Content-Type: application/json' \
+              --header 'Authorization: Bearer ${CANARY_API_KEY}' \
+              --post-data '{\"query\":\"GSLB\",\"includeMetadata\":true}' \
+              http://127.0.0.1:3000/api/rag/query
+  " 2>/dev/null || true)
+  echo "$RESP" | grep -qi 'VeriTeknik Comprehensive' \
+    && pass "GSLB → VeriTeknik Comprehensive" \
+    || fail "GSLB canary missed: ${RESP:0:200}"
+else
+  hdr "rag canary skipped (set CANARY_API_KEY to run)"
+fi
+
+echo
+echo "[verify] all green"

--- a/infra/sops/.sops.yaml
+++ b/infra/sops/.sops.yaml
@@ -1,0 +1,23 @@
+# SOPS creation rules. When you run `sops <file>`, SOPS looks here to decide
+# how to encrypt new files.
+#
+# The age recipient (public key) below is the *deploy* key — it lives on the
+# production host at /etc/sops/age/keys.txt and Traefik's compose service
+# mounts it into containers that need to decrypt. The recipient is safe to
+# commit; only the private key is sensitive and never leaves the host.
+#
+# To rotate keys see docs/ops/sops-rotation.md and the rotate-keys.sh script.
+
+creation_rules:
+  # Everything under infra/sops/ is encrypted with the production deploy key
+  # plus the offsite-backup key. Adding a second recipient gives us a way
+  # back if we ever lose the primary.
+  - path_regex: infra/sops/.*\.(env|yaml|yml|json)$
+    encrypted_regex: "^(.*)$"
+    # Replace these with real public keys after running `age-keygen`.
+    # The placeholders below are valid age recipients (well-formed but not
+    # backed by any real private key), so `sops --check` won't fail on a
+    # parse error — only on a decryption attempt against an unauthorized key.
+    age: >-
+      age1placeholderdeploykeyreplaceatphase0reallyreplaceit0000000000000000,
+      age1placeholderbackupkeyreplaceatphase0reallyreplaceit0000000000000000

--- a/infra/sops/secrets.env.sops.example
+++ b/infra/sops/secrets.env.sops.example
@@ -1,0 +1,56 @@
+# Template for the real infra/sops/secrets.env.sops.
+#
+# At Phase 0:
+#   1. cp infra/sops/secrets.env.sops.example /tmp/secrets.env
+#   2. Fill in real values in /tmp/secrets.env.
+#   3. sops --encrypt --output infra/sops/secrets.env.sops /tmp/secrets.env
+#   4. shred -u /tmp/secrets.env
+#
+# The decrypted form lives at /run/sops/secrets.env (tmpfs) for the lifetime
+# of a compose `up`. infra/scripts/deploy.sh handles the decrypt.
+#
+# This file itself is *not* encrypted (it's the template). Don't put real
+# secrets here.
+
+# ─── App ────────────────────────────────────────────────────────────
+DATABASE_URL=postgresql://pluggedin:REPLACE_ME@postgres:5432/v220_prod
+DATABASE_SSL=false
+DATABASE_SSL_REJECT_UNAUTHORIZED=false
+NEXTAUTH_URL=https://plugged.in
+NEXTAUTH_SECRET=REPLACE_ME_GENERATE_VIA_pnpm_generate_encryption_key
+API_KEY_ENCRYPTION_SECRET=REPLACE_ME
+PLUGGEDIN_API_KEY=REPLACE_ME
+PLUGGEDIN_UUID_TOOL_PREFIXING=true
+
+# ─── RAG / Vector ──────────────────────────────────────────────────
+ENABLE_RAG=true
+EMBEDDING_PROVIDER=gemini
+EMBEDDING_MODEL=gemini-embedding-001
+EMBEDDING_DIMENSIONS=768
+GEMINI_API_KEY=REPLACE_ME
+GOOGLE_API_KEY=REPLACE_ME
+
+# ─── Memory LLM ────────────────────────────────────────────────────
+MEMORY_LLM_PROVIDER=gemini
+MEMORY_CLASSIFICATION_MODEL=gemini-2.5-flash-lite
+
+# ─── Postgres bootstrap (read by the postgres container on first start) ──
+POSTGRES_USER=pluggedin
+POSTGRES_PASSWORD=REPLACE_ME
+POSTGRES_DB=v220_prod
+
+# ─── Cron secret (validated by /api/memory/* endpoints) ────────────
+CRON_SECRET=REPLACE_ME
+
+# ─── Email ────────────────────────────────────────────────────────
+EMAIL_SERVER_HOST=
+EMAIL_SERVER_PORT=587
+EMAIL_SERVER_USER=
+EMAIL_SERVER_PASSWORD=
+ADMIN_NOTIFICATION_EMAILS=
+
+# ─── OAuth providers (if any) ─────────────────────────────────────
+GITHUB_CLIENT_ID=
+GITHUB_CLIENT_SECRET=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=

--- a/infra/sops/secrets.env.sops.example
+++ b/infra/sops/secrets.env.sops.example
@@ -42,6 +42,21 @@ POSTGRES_DB=v220_prod
 # ─── Cron secret (validated by /api/memory/* endpoints) ────────────
 CRON_SECRET=REPLACE_ME
 
+# ─── Traefik ───────────────────────────────────────────────────────
+# CloudFlare DNS-01 token with Zone:DNS:Edit on plugged.in. Required by
+# Traefik's ACME resolver to issue/renew the wildcard cert. deploy.sh
+# extracts this single line into /run/sops/cloudflare_token, which the
+# CF_DNS_API_TOKEN_FILE env var on the traefik container points at.
+CF_API_TOKEN=REPLACE_ME
+
+# Traefik dashboard basic-auth credentials, htpasswd format. Generate with:
+#   htpasswd -nbB ops 'somepassword'
+# Then escape each $ as $$ inside SOPS (htpasswd uses bcrypt which writes
+# $$ for the salt prefix; SOPS env files treat $ as variable expansion).
+# deploy.sh extracts this into /run/sops/traefik-users which the
+# dashboard-auth middleware reads via usersFile:.
+TRAEFIK_DASHBOARD_AUTH=REPLACE_ME
+
 # ─── Email ────────────────────────────────────────────────────────
 EMAIL_SERVER_HOST=
 EMAIL_SERVER_PORT=587

--- a/infra/traefik/dynamic/middlewares.yml
+++ b/infra/traefik/dynamic/middlewares.yml
@@ -1,14 +1,19 @@
 # Traefik dynamic configuration. Hot-reloaded on file change.
 #
 # - security-headers: HSTS, CSP-friendly defaults, X-Frame-Options, etc.
-# - rate-limit:       1 req/s sustained, 10 burst, per source IP. Stack-level
-#                     rate-limit; the app does its own finer-grained limiting
-#                     (lib/rate-limiter.ts) on top of this.
-# - dashboard-auth:   basic auth on the Traefik dashboard. The user/hash pair
-#                     is generated outside and pasted in via SOPS; the SOPS
-#                     decryption step rewrites this file at deploy time with
-#                     the real credentials. Default value below is a known
-#                     placeholder that fails on purpose.
+# - rate-limit:       100 req/s average, 200 burst, per source IP. A real
+#                     SPA + APIs page load fires 20–40 requests; the stack-
+#                     level limit needs headroom so the *app*'s finer-
+#                     grained limiter (lib/rate-limiter.ts) is the visible
+#                     one in normal use. Tighten this only if we observe
+#                     abuse — having two layers fight over the same budget
+#                     is worse than picking generous numbers here.
+# - dashboard-auth:   basic auth on the Traefik dashboard. Credentials live
+#                     in /run/sops/traefik-users (htpasswd format, one line
+#                     per user). deploy.sh extracts TRAEFIK_DASHBOARD_AUTH
+#                     from secrets.env onto that file at deploy time. If
+#                     the file is missing, Traefik fails-closed: the
+#                     middleware can't load, so the dashboard router 404s.
 
 http:
   middlewares:
@@ -27,8 +32,8 @@ http:
 
     rate-limit:
       rateLimit:
-        average: 1
-        burst: 10
+        average: 100
+        burst: 200
         period: 1s
         sourceCriterion:
           ipStrategy:
@@ -36,10 +41,8 @@ http:
 
     dashboard-auth:
       basicAuth:
-        # Placeholder. Replaced by infra/scripts/deploy.sh from
-        # infra/sops/runtime/dashboard_users (htpasswd format, one line).
-        users:
-          - "placeholder:$$apr1$$replace_at_deploy$$placeholder"
+        usersFile: /run/sops/traefik-users
+        removeHeader: true
 
   routers:
     traefik-dashboard:

--- a/infra/traefik/dynamic/middlewares.yml
+++ b/infra/traefik/dynamic/middlewares.yml
@@ -1,0 +1,54 @@
+# Traefik dynamic configuration. Hot-reloaded on file change.
+#
+# - security-headers: HSTS, CSP-friendly defaults, X-Frame-Options, etc.
+# - rate-limit:       1 req/s sustained, 10 burst, per source IP. Stack-level
+#                     rate-limit; the app does its own finer-grained limiting
+#                     (lib/rate-limiter.ts) on top of this.
+# - dashboard-auth:   basic auth on the Traefik dashboard. The user/hash pair
+#                     is generated outside and pasted in via SOPS; the SOPS
+#                     decryption step rewrites this file at deploy time with
+#                     the real credentials. Default value below is a known
+#                     placeholder that fails on purpose.
+
+http:
+  middlewares:
+    security-headers:
+      headers:
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        frameDeny: true
+        contentTypeNosniff: true
+        browserXssFilter: true
+        referrerPolicy: "strict-origin-when-cross-origin"
+        permissionsPolicy: "camera=(), microphone=(), geolocation=()"
+        customResponseHeaders:
+          X-Robots-Tag: "noindex, nofollow"  # remove if SEO requires indexing
+
+    rate-limit:
+      rateLimit:
+        average: 1
+        burst: 10
+        period: 1s
+        sourceCriterion:
+          ipStrategy:
+            depth: 1  # behind ourselves, no other proxy in front
+
+    dashboard-auth:
+      basicAuth:
+        # Placeholder. Replaced by infra/scripts/deploy.sh from
+        # infra/sops/runtime/dashboard_users (htpasswd format, one line).
+        users:
+          - "placeholder:$$apr1$$replace_at_deploy$$placeholder"
+
+  routers:
+    traefik-dashboard:
+      rule: "Host(`traefik.plugged.in`)"
+      entryPoints:
+        - websecure
+      service: api@internal
+      middlewares:
+        - dashboard-auth
+        - security-headers
+      tls:
+        certResolver: le

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -1,0 +1,81 @@
+# Traefik v3 static configuration.
+#
+# Static config = everything that needs a restart to change (entrypoints, ACME
+# resolvers, log levels). Dynamic config (middlewares, routers, services from
+# labels) lives under /etc/traefik/dynamic/.
+
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false
+
+api:
+  # Dashboard exposed only through Traefik itself, not on a published port.
+  # Reach it via Host(`traefik.plugged.in`) gated by basic auth (see
+  # dynamic/middlewares.yml). Until that host is configured, the dashboard is
+  # effectively unreachable from outside.
+  dashboard: true
+  insecure: false
+
+log:
+  level: INFO
+  format: json
+
+accessLog:
+  format: json
+  filters:
+    statusCodes:
+      - "400-499"
+      - "500-599"
+
+ping:
+  entryPoint: web
+
+entryPoints:
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+
+  websecure:
+    address: ":443"
+    http:
+      tls:
+        certResolver: le
+        # Wildcard cert for *.plugged.in (DNS-01 only).
+        domains:
+          - main: plugged.in
+            sans:
+              - "*.plugged.in"
+
+providers:
+  file:
+    directory: /etc/traefik/dynamic
+    watch: true
+  docker:
+    endpoint: "unix:///var/run/docker.sock"
+    # Only containers that explicitly opt in via `traefik.enable=true` are
+    # exposed. Default-allow is a footgun.
+    exposedByDefault: false
+    network: pluggedin
+
+certificatesResolvers:
+  le:
+    acme:
+      email: ops@plugged.in
+      storage: /letsencrypt/acme.json
+      # Switch to acme.staging.letsencrypt.org while iterating on certs to
+      # avoid the production rate limit (5 per week per registered domain).
+      # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
+      caServer: https://acme-v02.api.letsencrypt.org/directory
+      dnsChallenge:
+        provider: cloudflare
+        # CF_DNS_API_TOKEN_FILE comes from compose env; the token has
+        # Zone:DNS:Edit scope on plugged.in.
+        delayBeforeCheck: 30s
+        resolvers:
+          - "1.1.1.1:53"
+          - "1.0.0.1:53"

--- a/package.json
+++ b/package.json
@@ -192,6 +192,10 @@
       "esbuild",
       "sharp"
     ],
+    "supportedArchitectures": {
+      "os": ["current", "linux", "darwin"],
+      "cpu": ["current", "x64", "arm64"]
+    },
     "peerDependencyRules": {
       "allowedVersions": {
         "react": "19",


### PR DESCRIPTION
## Summary

Replaces the native **nginx + systemd + workspace-`.env` + external PostgreSQL** deployment with a single containerised stack. Same PR ships the **plan** (`docs/ops/docker-traefik-sops-migration.md`), every config and script the plan calls out, the new `Dockerfile`, and a CI workflow.

Designed so that **Phase 1 lands now** (this PR) without touching production. Subsequent phases (containerised PG next to the live app, then cutover) are scripted and rehearsable but require my approval per phase.

## Why now

Last week's zvec incident traced to `.env` not propagating from the workspace into `.next/standalone/.env`. Docker Compose's `env_file:` is the single source of truth inside a container — that whole class of bug becomes structurally impossible. We also bring PostgreSQL in-house (currently external at `185.96.168.246`) and switch secrets onto SOPS/age.

## What's in this PR

```
docs/ops/
├── docker-traefik-sops-migration.md   ← THE PLAN — read this first
└── sops-rotation.md                   ← quarterly drill runbook

infra/
├── README.md                          ← day-2 ops entry point
├── docker-compose.yml                 ← traefik · prod-app · rc1-app · postgres · redis · ofelia
├── postgres/init.sql                  ← pgvector + extensions + privilege tightening
├── traefik/
│   ├── traefik.yml                    ← static: entrypoints, DNS-01 wildcard via CF
│   └── dynamic/middlewares.yml        ← HSTS, rate-limit, dashboard basic auth
├── sops/
│   ├── .sops.yaml                     ← creation rules
│   └── secrets.env.sops.example       ← template
├── ofelia/config.ini                  ← seven host cron entries → docker-exec jobs
└── scripts/
    ├── deploy.sh                      ← decrypt → pull → up → verify
    ├── build.sh                       ← local image build
    ├── verify.sh                      ← smoke + "GSLB" canary
    ├── backup.sh                      ← pg + zvec + uploads → age-encrypted tarball
    ├── restore.sh                     ← inverse of backup
    ├── cutover-from-native.sh         ← the one-time Phase-5 dance
    └── rotate-keys.sh                 ← age key rotation

Dockerfile                             ← rewritten (Debian-slim + node:22 + pnpm 10)
.github/workflows/build-image.yml      ← GHCR push on main + compose/shellcheck/traefik validation
```

## Highlights from the plan

- **Phased rollout with explicit rollback at every step.** No bridge burned before the next bridge is verified. Cutover targets ≤ 10 min of user-visible downtime and is one `systemctl start nginx pluggedin` away from reverting.
- **PG migration:** `pg_dump -Fc` → restore into containerised PG sitting next to the live app → delta-apply at T-0 → atomic Traefik swap onto :80/:443. The native stack is the standby until we decide otherwise.
- **SOPS + age** with two recipients (deploy + offline backup). The decrypted file only ever exists in `/run/sops` (tmpfs) for the lifetime of a deploy.
- **MCP sandboxing** kept: `bubblewrap` in the image, `CAP_SYS_ADMIN` granted by compose. Firejail-in-Docker is fragile; bubblewrap is not.
- **Cron replacement:** seven host crontab entries → seven Ofelia jobs that `docker exec` into the app container. No more host-side env drift.
- **Canary baked in:** `verify.sh` runs the "GSLB" RAG query against the production stack on every deploy and fails loudly if the VeriTeknik doc isn't in the sources. The exact incident pattern from last week cannot reach prod silently.

## CI

The `Build image` workflow does two things in parallel:

1. **build** — buildx → GHCR with registry cache; on PRs the image is loaded locally and smoke-tested (`node --version`, presence of `server.js`, `/app/.next/static`, `/app/drizzle`, `/usr/bin/bwrap`).
2. **stack-validate** — `docker compose config -q` (with a stubbed `/run/sops/secrets.env`), shellcheck across `infra/scripts/`, Traefik static config validation, INI parse of the Ofelia config.

GHA expression-injection avoided per the project's GHA security guide (every `${{ }}` in a `run:` is routed through `env:`).

## Open questions before Phase 2 (called out in §4 of the plan)

1. CloudFlare API token for DNS-01 wildcard? If we don't have CF, the resolver falls back to HTTP-01 and we lose wildcards.
2. Does the external PG (`185.96.168.246/v220_prod`) have other clients besides plugged.in? Affects Phase 8 decommissioning.
3. Does `rc1.plugged.in` share `v220_prod` with prod, or is it a separate database name?
4. Acceptable cutover window — plan sized for 10 minutes; I'd schedule a 30-minute window with comms.
5. GHCR acceptable as the image registry?

## What happens after merge

Nothing automatically. Production keeps running on the native stack. Phase 2 onward is rehearsed against a staging hostname (`staging.plugged.in`) before any user-visible change.

## Test plan

- [ ] CI green on both jobs (image build smoke + stack-validate).
- [ ] Local dry-run: `infra/scripts/deploy.sh` on a developer box with a test `secrets.env.sops` brings the stack up green.
- [ ] Pre-Phase-5: run `verify.sh` against the staging stack restored from a Phase-0 PG dump.
- [ ] Phase-5 rehearsal in a maintenance window on a low-traffic day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a container-focused production stack with Docker, Traefik, SOPS-managed secrets, and supporting scripts and CI to prepare migration from the native nginx+systemd deployment.

New Features:
- Provide a unified Docker Compose stack defining Traefik, production and rc1 app containers, Postgres, Redis, and Ofelia-based cron jobs for the plugged.in deployment.
- Add a comprehensive ops runbook and migration plan documenting the move from the native stack to the new Docker+Traefik+SOPS-based architecture.
- Introduce a production-ready Docker image build that supports MCP sandboxing, health checks, and in-container database migrations and RAG reindexing workflows.

Enhancements:
- Replace the existing Dockerfile with a Debian-based multi-stage build optimised for reliability of native modules and non-root runtime, including healthchecks and process supervision.
- Add infra scripts for building, deploying, verifying, backing up, restoring, rotating keys, and orchestrating cutover between native and containerised stacks.
- Configure Traefik with secure defaults, TLS automation, and middlewares, and wire Ofelia to take over host cron responsibilities via container-executed jobs.
- Define Postgres initialisation with required extensions and tightened privileges, and formalise SOPS key management policies and rotation procedures via repo configs and docs.

CI:
- Add a GitHub Actions workflow to build and publish the Docker image to GHCR, smoke-test it on pull requests, and validate the compose stack, shell scripts, Traefik config, and Ofelia config in CI.