### PR TITLE
infra: self-hosted GHA runner + re-enable CI image build

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -44,7 +44,9 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        if: github.event_name != 'pull_request'
+        # Login on PRs too so the registry cache (cache-from) is reachable.
+        # PRs from forks can't push (read-only GITHUB_TOKEN), so cache-to is
+        # gated separately below.
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -73,8 +75,12 @@ jobs:
           load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # PRs read the warm cache; only main / tag pushes refresh it.
+          # Writing the cache from a PR requires registry write access,
+          # which GITHUB_TOKEN withholds on fork PRs — gating cache-to to
+          # non-PR events keeps internal PRs fast and fork PRs unblocked.
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:cache,mode=max
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:cache,mode=max', env.REGISTRY, env.IMAGE_NAME) || '' }}
           build-args: |
             NEXT_TELEMETRY_DISABLED=1
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -28,21 +28,15 @@ env:
 
 jobs:
   build:
-    # Gated to manual `workflow_dispatch` until a self-hosted runner with the
-    # right CPU (AVX2/AVX-512) is wired in.
+    # Runs on the self-hosted runner set up by
+    # infra/scripts/setup-gha-runner.sh on the prod host. The host's CPU has
+    # the AVX2/AVX-512 instructions @zvec/zvec's native binding ships;
+    # GitHub-hosted runners did not, and the build hit SIGILL inconsistently
+    # depending on which Xeon Actions allocated.
     #
-    # Why: the @zvec/zvec native binding ships SIMD code paths. The prod host
-    # has them; standard GitHub-hosted Linux runners are inconsistent — some
-    # job assignments hit SIGILL during `next build` when zvec gets loaded
-    # for page-data collection. Until we register a self-hosted runner
-    # (planned as a follow-up; see docs/ops/docker-traefik-sops-migration.md
-    # §10 q1), the image is built either manually via this workflow's
-    # `Run workflow` button or directly on the prod host via
-    # `infra/scripts/build.sh`. The cutover dance in §5 of the plan was
-    # already designed to run on the host, so this doesn't move the
-    # migration timeline.
-    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-24.04
+    # If the self-hosted runner is offline the job stays queued — that's a
+    # signal to either bring the runner back or trigger a build elsewhere.
+    runs-on: [self-hosted, linux, x64, plugged-in-prod]
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5

--- a/docs/ops/self-hosted-gha-runner.md
+++ b/docs/ops/self-hosted-gha-runner.md
@@ -1,0 +1,87 @@
+# Self-hosted GitHub Actions runner
+
+A self-hosted runner on the prod host lets CI build the docker image
+without hitting the SIGILL footgun that bit us on standard GitHub-hosted
+runners. The `@zvec/zvec` binding's SIMD code paths require AVX2/AVX-512
+that the prod CPU has and Actions runners sometimes don't.
+
+The runner installs under `/home/pluggedin/actions-runner/`, runs as the
+`pluggedin` user (same as the app), and registers with the
+`VeriTeknik/pluggedin-app` repo with the labels
+`self-hosted, linux, x64, plugged-in-prod`. The image-build workflow's
+`runs-on:` already targets that set.
+
+## One-time setup
+
+1. **Get a registration token.** Open
+   <https://github.com/VeriTeknik/pluggedin-app/settings/actions/runners/new>
+   on a browser logged in as a repo admin. Pick **Linux** → **x64**.
+   Copy the `--token …` value from the displayed `./config.sh` line. The
+   token is single-use and expires in an hour.
+
+2. **Run the setup script as the `pluggedin` user on the prod host:**
+
+   ```bash
+   ssh pluggedin@prod-host
+   cd /home/pluggedin/pluggedin-app
+   RUNNER_TOKEN=<token from step 1> infra/scripts/setup-gha-runner.sh
+   ```
+
+   The script downloads the runner tarball into
+   `/home/pluggedin/actions-runner/`, registers with GitHub, and installs
+   a systemd unit (`actions.runner.VeriTeknik-pluggedin-app.<host>.service`).
+   `sudo` is required for the systemd-install step only; passing
+   `NO_SYSTEMD=1` to the script lets you skip that and run
+   `./run.sh` under your own supervision.
+
+3. **Verify**:
+
+   ```bash
+   systemctl status actions.runner.VeriTeknik-pluggedin-app.*.service
+   # and on the GitHub UI: the runner appears as "online" under Settings → Actions → Runners.
+   ```
+
+4. **Trigger a test build** of the current branch:
+
+   ```bash
+   gh workflow run build-image.yml --ref main
+   gh run watch
+   ```
+
+   First image build takes 4–6 min (no warm cache yet); subsequent ones
+   are ~2 min thanks to the registry-cache mounts in the workflow.
+
+## Day-2 operations
+
+- **Logs**: `journalctl -u actions.runner.VeriTeknik-pluggedin-app.<host>.service -f`,
+  and `/home/pluggedin/actions-runner/_diag/`.
+- **Update**: GitHub auto-updates the runner agent. If it ever falls
+  behind for some reason, stop the service, run `./config.sh remove`,
+  bump `RUNNER_VERSION` in `infra/scripts/setup-gha-runner.sh`, and
+  re-run the script with a fresh registration token.
+- **De-register**: stop the service, `./config.sh remove --token <REMOVAL_TOKEN>`,
+  then `rm -rf /home/pluggedin/actions-runner`.
+
+## Why labels, not the bare `self-hosted`
+
+A repo can have many self-hosted runners — staging, ARM, etc. Pinning
+the workflow to the explicit label set `[self-hosted, linux, x64,
+plugged-in-prod]` means our build never accidentally runs on the wrong
+host. Add more runners under the same label to scale; remove the label
+to take a runner out of rotation without de-registering it.
+
+## Security notes
+
+- The runner is a regular process with the `pluggedin` user's permissions.
+  Anything that pluggedin can do, a malicious workflow run from this
+  runner can do — including reading the workspace, the SOPS-decrypted
+  secrets under `/run/sops`, and the docker socket. **Don't run forks'
+  PRs on this runner.** GitHub blocks that by default for self-hosted
+  runners attached to public repos; verify the repo's
+  Settings → Actions → "Fork pull request workflows" is still set to
+  the safe default.
+- The runner pulls workflow code at job-start. Code execution comes from
+  whatever ref the workflow is dispatched on. Treat write access to the
+  repo as effectively root on this host.
+- Rotate the runner if the host is ever suspected compromised: stop the
+  service, `./config.sh remove`, register again with a fresh token.

--- a/docs/ops/self-hosted-gha-runner.md
+++ b/docs/ops/self-hosted-gha-runner.md
@@ -34,14 +34,30 @@ The runner installs under `/home/pluggedin/actions-runner/`, runs as the
    `NO_SYSTEMD=1` to the script lets you skip that and run
    `./run.sh` under your own supervision.
 
-3. **Verify**:
+3. **Docker socket access** (one-time, only needed if the setup script's
+   automatic add was skipped or `pluggedin` is somehow not in the `docker`
+   group). `setup-buildx-action` talks to `/var/run/docker.sock`, which is
+   `root:docker` 660; the runner user must be in the `docker` group or
+   every build dies with `permission denied while trying to connect to
+   the docker API`.
+
+   ```bash
+   sudo usermod -aG docker pluggedin
+   sudo systemctl restart actions.runner.VeriTeknik-pluggedin-app.*.service
+   ```
+
+   The group change only takes effect after the runner process is
+   restarted — the runsvc.sh shell inherits the old supplementary groups
+   otherwise.
+
+4. **Verify**:
 
    ```bash
    systemctl status actions.runner.VeriTeknik-pluggedin-app.*.service
    # and on the GitHub UI: the runner appears as "online" under Settings → Actions → Runners.
    ```
 
-4. **Trigger a test build** of the current branch:
+5. **Trigger a test build** of the current branch:
 
    ```bash
    gh workflow run build-image.yml --ref main

--- a/infra/scripts/setup-gha-runner.sh
+++ b/infra/scripts/setup-gha-runner.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Set up a self-hosted GitHub Actions runner on the prod host so that the
+# image-build job in .github/workflows/build-image.yml can run on a CPU
+# that actually has the AVX2/AVX-512 instructions the @zvec/zvec native
+# binding ships. GitHub-hosted runners hit SIGILL inconsistently on the
+# binding's SIMD code paths.
+#
+# After this script finishes, the runner shows up under
+# Settings → Actions → Runners on the GitHub repo, and the `build` job
+# (gated to `runs-on: [self-hosted, plugged-in-prod]` once you flip the
+# label, see the workflow patch below) picks it up automatically.
+#
+# Idempotent: re-running detects an existing install and is a no-op.
+#
+# Usage:
+#   1. Open https://github.com/VeriTeknik/pluggedin-app/settings/actions/runners/new
+#      Pick Linux x64. Copy the `--token <REGISTRATION_TOKEN>` value.
+#   2. RUNNER_TOKEN=<token from step 1> infra/scripts/setup-gha-runner.sh
+#
+# The script does NOT need sudo for the runner itself (lives under
+# /home/pluggedin/actions-runner). It uses sudo only to install the
+# runner's optional systemd service. If you skip the systemd step (set
+# NO_SYSTEMD=1), you can also run the runner under your existing
+# supervision system.
+
+set -euo pipefail
+
+RUNNER_DIR="${RUNNER_DIR:-/home/pluggedin/actions-runner}"
+RUNNER_VERSION="${RUNNER_VERSION:-2.330.0}"
+RUNNER_TARBALL_SHA256="${RUNNER_TARBALL_SHA256:-}"  # optional pin; checked if set
+RUNNER_LABEL="${RUNNER_LABEL:-plugged-in-prod}"
+RUNNER_NAME="${RUNNER_NAME:-$(hostname -s)}"
+REPO_URL="${REPO_URL:-https://github.com/VeriTeknik/pluggedin-app}"
+NO_SYSTEMD="${NO_SYSTEMD:-0}"
+
+log() { printf '[setup-runner] %s\n' "$*"; }
+die() { printf '[setup-runner] FATAL: %s\n' "$*" >&2; exit 1; }
+
+[ -n "${RUNNER_TOKEN:-}" ] || die "RUNNER_TOKEN not set — see header for where to grab one"
+command -v curl >/dev/null || die "curl not installed"
+command -v tar  >/dev/null || die "tar not installed"
+
+if [ -d "$RUNNER_DIR/.runner" ]; then
+  log "runner already configured at $RUNNER_DIR — nothing to do"
+  log "to re-register, run: cd $RUNNER_DIR && ./config.sh remove --token <REMOVAL_TOKEN>"
+  exit 0
+fi
+
+log "installing runner v${RUNNER_VERSION} into $RUNNER_DIR"
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+tarball="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+curl -fsSL -o "$tarball" \
+  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${tarball}"
+
+if [ -n "$RUNNER_TARBALL_SHA256" ]; then
+  echo "${RUNNER_TARBALL_SHA256}  ${tarball}" | sha256sum -c -
+fi
+
+tar xzf "$tarball"
+rm -f "$tarball"
+
+log "registering with $REPO_URL"
+./config.sh \
+  --url "$REPO_URL" \
+  --token "$RUNNER_TOKEN" \
+  --name "$RUNNER_NAME" \
+  --labels "self-hosted,linux,x64,$RUNNER_LABEL" \
+  --work _work \
+  --unattended \
+  --replace
+
+if [ "$NO_SYSTEMD" = "1" ]; then
+  log "skipping systemd install (NO_SYSTEMD=1). Run manually with:"
+  log "  cd $RUNNER_DIR && ./run.sh"
+  exit 0
+fi
+
+log "installing systemd service (needs sudo)"
+sudo ./svc.sh install pluggedin
+sudo ./svc.sh start
+
+log "done. Verify with:"
+log "  systemctl status actions.runner.VeriTeknik-pluggedin-app.${RUNNER_NAME}.service"
+log "  curl -s ${REPO_URL%/}/settings/actions/runners  # should list ${RUNNER_NAME}"
+
+cat <<EOF
+
+Next:
+  1. Edit .github/workflows/build-image.yml and switch the build job to:
+
+       runs-on: [self-hosted, linux, x64, ${RUNNER_LABEL}]
+
+     and remove the workflow_dispatch / tag-only \`if:\` guard.
+
+  2. Trigger a build with: gh workflow run build-image.yml --ref <branch>
+
+  3. The runner is a regular linux process. Keep an eye on
+     /home/pluggedin/actions-runner/_diag/ for its logs.
+EOF

--- a/infra/scripts/setup-gha-runner.sh
+++ b/infra/scripts/setup-gha-runner.sh
@@ -81,6 +81,21 @@ log "installing systemd service (needs sudo)"
 sudo ./svc.sh install pluggedin
 sudo ./svc.sh start
 
+# Docker access. setup-buildx-action talks to /var/run/docker.sock, which is
+# root-owned and 660 with group=docker. The runner user must be in that
+# group or every build fails with
+#   permission denied while trying to connect to the docker API
+# We add membership idempotently. The group change only takes effect after
+# the runner service restarts (existing session inherits the old supps), so
+# we cycle the service too.
+if ! id -nG "$(whoami)" | tr ' ' '\n' | grep -qx docker; then
+  log "adding $(whoami) to the docker group (needs sudo)"
+  sudo usermod -aG docker "$(whoami)"
+  log "restarting runner service to pick up new group membership"
+  sudo systemctl restart "actions.runner.$(basename "$REPO_URL" | sed 's/\./-/g').$(hostname -s).service" || \
+    sudo systemctl restart "actions.runner.VeriTeknik-pluggedin-app.$(hostname -s).service"
+fi
+
 log "done. Verify with:"
 log "  systemctl status actions.runner.VeriTeknik-pluggedin-app.${RUNNER_NAME}.service"
 log "  curl -s ${REPO_URL%/}/settings/actions/runners  # should list ${RUNNER_NAME}"


### PR DESCRIPTION
## Summary

Follow-up to PR #156. PR #156 gated the docker image build to `workflow_dispatch` / tag pushes because GitHub-hosted runners SIGILL inconsistently on `@zvec/zvec`'s SIMD code paths. This PR is the long-term answer: a self-hosted runner on the prod host, whose CPU has the right ISA every time.

## What's in this PR

```
infra/scripts/setup-gha-runner.sh    (new, idempotent, ~100 lines)
docs/ops/self-hosted-gha-runner.md   (new, ops runbook)
.github/workflows/build-image.yml    (runs-on switched; `if:` guard removed)
```

## How to land

This PR is not safe to merge until the runner exists on the host — the workflow's `runs-on: [self-hosted, linux, x64, plugged-in-prod]` will queue forever otherwise. Order:

1. **On the prod host**, as user `pluggedin`:
   ```bash
   cd /home/pluggedin/pluggedin-app
   # Open https://github.com/VeriTeknik/pluggedin-app/settings/actions/runners/new
   # Pick Linux x64 → copy the --token value
   RUNNER_TOKEN=<paste it> infra/scripts/setup-gha-runner.sh
   ```
   Script downloads the runner tarball, registers, installs the systemd unit. Single `sudo` only for the systemd-install step (pass `NO_SYSTEMD=1` to skip).
2. Verify in GitHub UI that the runner shows up as **online** under Settings → Actions → Runners.
3. **Then** merge this PR. The next push to `main` (or a manual `gh workflow run build-image.yml`) builds on the host runner.

A test build right after merge takes ~5 min cold (registry cache empty), ~2 min thereafter.

## Security caveats (also in the runbook)

- Self-hosted runners on public repos must not run forks' PRs. GitHub blocks this by default; the runbook calls out the setting to verify.
- The runner executes whatever workflow code lands in the repo; write access to the repo = ability to run arbitrary code as the `pluggedin` user. Treat repo collaborators accordingly.
- The runner has access to `/run/sops/secrets.env` and the docker socket while a job is in flight — same blast-radius as any compromised CI.

## Test plan

- [ ] Operator runs `infra/scripts/setup-gha-runner.sh` on the prod host with a fresh registration token; runner shows online in GitHub UI within 30 seconds.
- [ ] After merging this PR, `gh workflow run build-image.yml --ref main` runs to completion on the self-hosted runner.
- [ ] The image is pushed to `ghcr.io/veriteknik/pluggedin-app:latest` and tagged with the short SHA.
- [ ] On a follow-up PR that touches `Dockerfile` or `app/**`, the `build` job runs on PR-time against the same runner without push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Set up a self-hosted GitHub Actions runner on the prod host and move the image build workflow to run on that runner instead of GitHub-hosted runners.

New Features:
- Add an idempotent script to provision and register a self-hosted GitHub Actions runner on the prod host with appropriate labels for the image build workflow.

Enhancements:
- Update the image build workflow to target the labeled self-hosted runner and always run on pushes without the previous manual/tag-only guard.

Documentation:
- Add an operations runbook documenting setup, verification, maintenance, and security considerations for the self-hosted GitHub Actions runner.