### PR TITLE
security: layered defenses for self-hosted runner on a public repo

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -18,9 +18,12 @@ on:
       - '.github/workflows/build-image.yml'
   workflow_dispatch:
 
+# Default to read-only token. The build job re-grants packages:write
+# explicitly. Other jobs (stack-validate) inherit the read-only default,
+# so a compromised checkout in those jobs can't push branches, comment
+# on PRs, or write to packages.
 permissions:
   contents: read
-  packages: write
 
 env:
   REGISTRY: ghcr.io
@@ -33,6 +36,27 @@ jobs:
     # the AVX2/AVX-512 instructions @zvec/zvec's native binding ships;
     # GitHub-hosted runners did not, and the build hit SIGILL inconsistently
     # depending on which Xeon Actions allocated.
+    #
+    # SECURITY: this is a self-hosted runner on a public repo's prod box —
+    # the host carries the SOPS-decrypted secrets, prod DB credentials,
+    # and the docker socket. A malicious workflow run from a fork PR
+    # could exfiltrate any of that. Three guards layer here:
+    #   1. The `if:` below skips fork PRs entirely. github.event.pull_request
+    #      .head.repo.full_name only matches when the PR's head branch is in
+    #      this repo, not a fork.
+    #   2. GitHub's repo-level "Require approval for all outside
+    #      collaborators" setting (Settings → Actions → General → Fork pull
+    #      request workflows). Must stay enabled — operators verify it as
+    #      part of the runner runbook.
+    #   3. The workflow's default `permissions:` is read-only above; we
+    #      re-grant packages:write here for this job alone.
+    # If any one of those fails, the others still hold.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      packages: write
     #
     # If the self-hosted runner is offline the job stays queued — that's a
     # signal to either bring the runner back or trigger a build elsewhere.

--- a/docs/ops/self-hosted-gha-runner.md
+++ b/docs/ops/self-hosted-gha-runner.md
@@ -86,18 +86,101 @@ plugged-in-prod]` means our build never accidentally runs on the wrong
 host. Add more runners under the same label to scale; remove the label
 to take a runner out of rotation without de-registering it.
 
-## Security notes
+## Security — required posture
 
-- The runner is a regular process with the `pluggedin` user's permissions.
-  Anything that pluggedin can do, a malicious workflow run from this
-  runner can do — including reading the workspace, the SOPS-decrypted
-  secrets under `/run/sops`, and the docker socket. **Don't run forks'
-  PRs on this runner.** GitHub blocks that by default for self-hosted
-  runners attached to public repos; verify the repo's
-  Settings → Actions → "Fork pull request workflows" is still set to
-  the safe default.
-- The runner pulls workflow code at job-start. Code execution comes from
-  whatever ref the workflow is dispatched on. Treat write access to the
-  repo as effectively root on this host.
-- Rotate the runner if the host is ever suspected compromised: stop the
-  service, `./config.sh remove`, register again with a fresh token.
+This is a **self-hosted runner on a public repo's production host**. GitHub
+warns explicitly against this setup because a fork PR can run arbitrary
+code on the runner. The threat is real and the consequences here are
+specifically: SOPS-decrypted secrets (when present in `/run/sops`),
+PostgreSQL credentials, the docker socket, and the entire prod state
+become accessible to whatever the workflow runs. We carry that risk
+because the alternative is GitHub-hosted runners that SIGILL on the
+zvec binding's SIMD instructions; the trade is conscious but only
+acceptable with every guard below in place.
+
+### Defense in depth
+
+1. **Workflow-level fork guard** (in `.github/workflows/build-image.yml`):
+
+   ```yaml
+   if: >-
+     github.event_name != 'pull_request' ||
+     github.event.pull_request.head.repo.full_name == github.repository
+   ```
+
+   PRs from forks skip the `build` job entirely. The build never runs
+   on untrusted code unless someone with push access to the repo opens
+   the PR from an internal branch.
+
+2. **Repo-level approval gate** in GitHub UI. Verify in
+   <https://github.com/VeriTeknik/pluggedin-app/settings/actions>:
+
+   - **Fork pull request workflows from outside collaborators**:
+     `Require approval for all outside collaborators` (most strict).
+   - **Workflow permissions**: `Read repository contents and packages
+     permissions` (least privilege). Individual jobs re-grant
+     `packages: write` where needed.
+   - **Allow GitHub Actions to create and approve pull requests**:
+     unchecked.
+
+3. **Token least-privilege** at the workflow level:
+
+   ```yaml
+   permissions:
+     contents: read
+   ```
+
+   The build job re-grants `packages: write` explicitly. Other jobs
+   inherit read-only.
+
+4. **Runner sandboxing** (operational, not yet automated):
+   - Runner registered with **a labelled allow-list**, not bare
+     `self-hosted`. Other workflows in the repo can't accidentally
+     land on this host.
+   - Service runs as the `pluggedin` user; the user is in the `docker`
+     group, but no `sudo` rights for the runner specifically. (The
+     setup script needed sudo only for `svc.sh install`; the running
+     service never invokes sudo.)
+   - Logs at `/home/pluggedin/actions-runner/_diag/` and via
+     `journalctl -u actions.runner.…`. Watch the journal periodically
+     for unexpected jobs.
+
+### Manual checks before every release
+
+- `gh api repos/VeriTeknik/pluggedin-app/actions/permissions` confirms
+  `default_workflow_permissions: read` (write should never appear
+  here unless a job opts in).
+- `gh api repos/VeriTeknik/pluggedin-app/actions/runners` returns
+  exactly the runners you expect — no stale entries, all `online`.
+
+### If the host is ever suspected compromised
+
+1. Stop the runner service: `sudo systemctl stop
+   actions.runner.VeriTeknik-pluggedin-app.*.service`.
+2. De-register: `cd /home/pluggedin/actions-runner && ./config.sh
+   remove --token <REMOVAL_TOKEN_FROM_SETTINGS>`.
+3. Rotate every secret reachable from the host: all entries in
+   `infra/sops/secrets.env.sops`, the PostgreSQL password, NEXTAUTH_SECRET,
+   API_KEY_ENCRYPTION_SECRET, every API token. The SOPS-rotation
+   runbook covers the SOPS-side; non-SOPS secrets need rotation at
+   their respective consoles (CloudFlare, Gemini, etc.).
+4. Re-image the host if confidence in cleanup isn't high. The
+   `infra/scripts/restore.sh` script is the path back from a backup.
+
+### Long-term hardening (out of scope for the initial migration)
+
+The right answer for a public repo with native deps is **not** "runner
+on the prod host". Better topology:
+
+- **A separate build host** with the same CPU profile but no prod
+  credentials. Build images there, push to GHCR, deploy elsewhere.
+  Reduces blast radius from "all of prod" to "throwaway builder VM".
+- **Ephemeral runners** (Actions Runner Controller on K8s, or
+  GitHub's `runs-on` SaaS) that disappear after each job. No
+  long-lived state for a compromise to survive in.
+
+Tracked as a follow-up. The current posture is acceptable for now
+because (a) the fork guard makes the threat surface "internal PRs
+from people with push access", which is the same trust boundary as
+direct pushes to main, and (b) the prod box doesn't run anything
+internet-exposed beyond what nginx already proxies.


### PR DESCRIPTION
GitHub's "Add new self-hosted runner" page warns explicitly that public repos + self-hosted runners are dangerous because fork PRs can run arbitrary code on the runner. Our runner lives on the **prod host**, where SOPS-decrypted secrets, the PostgreSQL password, and the docker socket are all reachable — the warning lands here harder than in most setups, and "GitHub blocks it by default" was underclaiming the work needed.

## Three layers of defense

### 1. Workflow-level fork guard (the strongest layer)
```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```
The `build` job short-circuits on any PR whose head is in a fork — they never reach the self-hosted runner. `stack-validate` continues to run, giving PR authors useful feedback on compose/script changes.

### 2. Token least-privilege at workflow scope
Default `permissions:` is now `contents: read`. The `build` job re-grants `packages: write` inline because it needs to push to GHCR; nothing else does. Future additions inherit the read-only default.

### 3. Repo-UI guards the operator verifies (also documented in the runbook)
In <https://github.com/VeriTeknik/pluggedin-app/settings/actions>:
- **Fork pull request workflows from outside collaborators**: `Require approval for all outside collaborators` (most strict).
- **Workflow permissions**: `Read repository contents and packages permissions` (least privilege). Jobs re-grant write where needed.
- **Allow GitHub Actions to create and approve pull requests**: unchecked.

## What `docs/ops/self-hosted-gha-runner.md` now has

- Threat model and the trade-off rationale up front.
- The three guards, with the exact code/UI knobs.
- Manual-check commands (`gh api repos/.../actions/permissions`, `gh api repos/.../actions/runners`) the operator runs before every release.
- Incident-response checklist for a suspected compromise: stop the service, de-register, **rotate every secret reachable from the host** (SOPS contents + PG password + NEXTAUTH_SECRET + API_KEY_ENCRYPTION_SECRET + every API token).
- Long-term hardening pointer: dedicated build host or ephemeral runners (ARC / runs-on) — tracked as a follow-up, not blocking this PR.

## Test plan

- [ ] After merge, a PR from an internal branch (e.g. `chore/test-internal-pr`) → `build` job runs on the self-hosted runner.
- [ ] A PR from a fork (verifiable via `act` or by a contributor test) → `build` job evaluates the `if:` to false and shows as skipped. `stack-validate` still runs.
- [ ] Repo Settings UI confirms the three radio buttons above.
- [ ] `gh api .../actions/permissions` shows `default_workflow_permissions: read` after this lands (we set the workflow default; the org/repo-level default in the UI also needs to be tightened — that's a manual op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the self-hosted GitHub Actions runner on the public production repo by adding layered defenses against fork PR abuse and documenting the required security posture and operational procedures.

Enhancements:
- Add a workflow-level condition and per-job token permissions to prevent forked pull requests from running sensitive build jobs on the self-hosted prod runner and to enforce least-privilege access.
- Expand and restructure the self-hosted runner operations doc to describe the threat model, required GitHub settings, manual verification steps, incident response actions, and long-term hardening options.

Documentation:
- Document the security posture, safeguards, manual checks, and incident-response process for operating a self-hosted GitHub Actions runner on the production host.