### PR TITLE
infra(traefik): translate live nginx config 1:1 + HTTP-01 + drop rc1

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -15,6 +15,13 @@ on:
       - 'db/**'
       - 'public/**'
       - 'scripts/**'
+      # infra/** is here so the `Validate compose + scripts` job runs on
+      # PRs that touch only the compose stack, Traefik/Ofelia config, or
+      # the operational scripts. The `build` job in this workflow has its
+      # own `if:` guard which keeps it from firing on fork PRs; on internal
+      # infra-only PRs it'll still rebuild the image, which is acceptable
+      # — the image is small and the host runner has the cache warm.
+      - 'infra/**'
       - '.github/workflows/build-image.yml'
   workflow_dispatch:
 

--- a/docs/ops/docker-traefik-sops-migration.md
+++ b/docs/ops/docker-traefik-sops-migration.md
@@ -358,7 +358,7 @@ systemctl start nginx pluggedin
 
 ## 10. Open questions for you before Phase 2
 
-1. ~~CloudFlare API token~~ — **answered**: no CF, using HTTP-01.
+1. ~~Cloudflare API token~~ — **answered**: no Cloudflare, using HTTP-01.
 2. Does the external PG (`185.96.168.246`) have other clients besides plugged.in?
 3. ~~rc1 data sharing~~ — **answered**: rc1 no longer exists; single instance only.
 4. Acceptable cutover window (timezone + duration)? Plan is sized for 10 minutes but I'd schedule a 30-minute window with comms.

--- a/docs/ops/docker-traefik-sops-migration.md
+++ b/docs/ops/docker-traefik-sops-migration.md
@@ -9,10 +9,10 @@
 
 ## 1. Executive summary
 
-Move `plugged.in` and `rc1.plugged.in` off the bespoke "native nginx + systemd + workspace `.env` + external PostgreSQL" deployment onto a containerised stack:
+Move `plugged.in` off the bespoke "native nginx + systemd + workspace `.env` + external PostgreSQL" deployment onto a containerised stack:
 
 - **Docker Compose** as the unit of deployment (single-host today, portable later).
-- **Traefik v3** as the only TLS terminator and reverse proxy. Automatic Let's Encrypt issuance via DNS-01 on a CloudFlare account-token (planned) or HTTP-01 fallback.
+- **Traefik v3** as the only TLS terminator and reverse proxy. Automatic Let's Encrypt issuance via **HTTP-01** (same mechanism certbot used pre-migration). No DNS-provider account needed.
 - **SOPS + age** as the single source of truth for secrets. Encrypted file checked into the repo, decrypted at deploy time into a tmpfs.
 - **PostgreSQL 16 + pgvector** as a containerised database on this host, replacing the external `185.96.168.246` instance. Data migrated in a short maintenance window via `pg_dump --clean --if-exists` round-trip.
 - **Redis 7** containerised on the same compose stack.
@@ -35,11 +35,10 @@ The migration also incidentally fixes the class of bug we just hit (workspace `.
 | Component | Where | Notes |
 |---|---|---|
 | `pluggedin.service` (systemd) | `/etc/systemd/system/pluggedin.service` | Runs `pnpm start` → `node .next/standalone/server.js` on `:12005` |
-| `pluggedin-rc1.service` (assumed) | parallel unit | Runs on `:12006`, serves `rc1.plugged.in` |
-| `nginx.service` | `/etc/nginx/sites-enabled/{plugged.in,rc1.plugged.in}` | TLS termination + `proxy_pass http://localhost:1200{5,6}` |
+| `nginx.service` | `/etc/nginx/sites-enabled/plugged.in` | TLS termination + `proxy_pass http://localhost:12005` plus per-location rules (gzip, SSE timeouts, widget CORS, immutable static cache, security headers — translated 1:1 into `infra/traefik/dynamic/middlewares.yml` and labels on `pluggedin-app`) |
 | `redis-server.service` | local | `redis://localhost:6379` |
 | PostgreSQL | **External** `185.96.168.246:5432/v220_prod` | Shared with other VeriTeknik infra |
-| TLS certs | `/etc/letsencrypt/live/{plugged.in,rc1.plugged.in}/` | certbot |
+| TLS certs | `/etc/letsencrypt/live/plugged.in/` | certbot HTTP-01 → Traefik will take over with the same challenge type, same renewal cadence |
 | `.env` | `/home/pluggedin/pluggedin-app/.env` (workspace) and `/home/pluggedin/pluggedin-app/.next/standalone/.env` (build copy) | Two copies, drift caused the recent zvec incident |
 | zvec data | `/home/pluggedin/zvec-data/` (3.9 MiB after reindex) | bind-mount candidate |
 | MCP package cache | `/var/mcp-packages/` (**88 GiB**) | Stays on host disk; bind-mount, do not move into named volume |
@@ -63,27 +62,26 @@ The migration also incidentally fixes the class of bug we just hit (workspace `.
                    ▼
         ┌──────────────────────┐
         │  Traefik v3          │ :80 → :443 redirect
-        │  cloudflare-dns LE   │ :443 TLS terminator
+        │  LE HTTP-01          │ :443 TLS terminator
         └──────────┬───────────┘
                    │  internal docker network: pluggedin
                    │
-       ┌───────────┼────────────┐
-       ▼           ▼            ▼
-   pluggedin-app  rc1-app     ofelia-cron
-   :3000 (int)   :3000 (int)  (no port; runs scheduled tasks
-                              against the app via http or
-                              docker exec)
-       │           │
-       ▼           ▼
+       ┌───────────┴────────────┐
+       ▼                        ▼
+   pluggedin-app             ofelia-cron
+   :3000 (int)               (no port; runs scheduled tasks
+                              against the app via docker exec)
+       │
+       ▼
    postgres:16 (pgvector ext) — :5432 internal only
    redis:7                    — :6379 internal only
 
 Bind mounts (host → container):
-  /home/pluggedin/zvec-data   → /app/data/vectors  (rw, both apps)
-  /home/pluggedin/uploads     → /app/uploads       (rw, both apps)
-  /var/mcp-packages           → /app/.cache/mcp-packages (rw, both apps)
-  /var/log/pluggedin          → /app/logs          (rw, both apps)
-  ./infra/sops/runtime/<file> → /run/secrets/<file>  (ro, decrypted at deploy)
+  /home/pluggedin/zvec-data   → /app/data/vectors  (rw)
+  /home/pluggedin/uploads     → /app/uploads       (rw)
+  /var/mcp-packages           → /app/.cache/mcp-packages (rw)
+  /var/log/pluggedin          → /app/logs          (rw)
+  /run/sops                   → /run/sops          (ro, decrypted at deploy)
 
 Named volumes (managed by Docker):
   pgdata          → /var/lib/postgresql/data
@@ -95,10 +93,6 @@ Named volumes (managed by Docker):
 
 88 GiB. Recreating that cache from scratch costs the whole site ~hours of latency while every MCP package re-resolves. Bind mount is one `chown -R` from being writable by the container.
 
-### Why two app services in one stack instead of two stacks?
-
-They share the same `pgdata`, the same MCP cache, the same SOPS keys, and the same Traefik. Splitting them into two compose files multiplies the bookkeeping with no isolation benefit (they're already isolated by container).
-
 ---
 
 ## 4. Decisions (with my recommendation)
@@ -106,7 +100,7 @@ They share the same `pgdata`, the same MCP cache, the same SOPS keys, and the sa
 | Decision | Options | Recommendation | Why |
 |---|---|---|---|
 | **SOPS key backend** | age, GPG, AWS KMS, GCP KMS | **age** with a single host key + one offsite backup key | Zero external dependency, single binary, machine-readable, fits ops scale here. |
-| **Traefik TLS issuer** | LE HTTP-01, LE DNS-01 via CF | **DNS-01 via CloudFlare** (assuming CF is the registrar/DNS provider; HTTP-01 fallback if not) | DNS-01 issues wildcard for `*.plugged.in`, no public port-80 race during cert renew. |
+| **Traefik TLS issuer** | LE HTTP-01, LE DNS-01 | **HTTP-01** | Same mechanism certbot used on this host pre-migration; no DNS-provider API token to manage. We only need certs for `plugged.in` and `traefik.plugged.in`, no wildcards required. Pre-listing both domains on the websecure entrypoint pre-warms issuance at startup so the first request after cutover doesn't pay the ACME round-trip. |
 | **PG migration cutover** | dump/restore, logical replication, pg_dumpall | **`pg_dump -Fc` round-trip in a maintenance window** | Database is small (estimated < 5 GiB based on chunk count and table set); single-shot is faster to plan, validate, and rollback than logical replication. Estimated downtime: 5–10 min. |
 | **PG inside Docker** | yes, no | **Yes**, on this host | One less external dependency, no more cross-network round-trip latency, encrypted at rest if needed via LUKS or pg-tde later. |
 | **Container registry** | GHCR, Docker Hub, self-hosted | **GHCR** (`ghcr.io/veriteknik/pluggedin-app`) | Free for public repos; integrates with GH Actions; tied to the existing repo identity. |
@@ -115,11 +109,9 @@ They share the same `pgdata`, the same MCP cache, the same SOPS keys, and the sa
 | **Logging** | json-file driver, Loki, file bind-mount | **json-file + bind-mount `/var/log/pluggedin`** (Loki later) | Preserves `tail -f /var/log/pluggedin/pluggedin_app.log` muscle memory while we migrate. |
 | **`docker-compose.yml` at repo root** | keep, delete | **Delete** in Phase 9 | Confusing alongside the new `infra/docker-compose.yml`; `Dockerfile.production` becomes `Dockerfile`. |
 
-### Things I cannot decide without you
+### Open questions
 
-1. **CloudFlare API token (or NS provider) for DNS-01.** Need a scoped token with `Zone:DNS:Edit` on `plugged.in`. If we don't have CF, fall back to HTTP-01 and skip wildcards.
-2. **External PG owner.** Are other apps still pointing at `185.96.168.246/v220_prod` after we copy out? If yes, we can't shut down the external instance even after cutover.
-3. **`rc1.plugged.in` data sharing.** Does rc1 share `v220_prod` with prod, or is it a separate database? The plan assumes **separate**; one DB per app, both in the same containerised PG.
+1. **External PG owner.** Are other apps still pointing at `185.96.168.246/v220_prod` after we copy out? If yes, we can't shut down the external instance even after cutover.
 
 ---
 
@@ -129,7 +121,7 @@ Each phase has explicit **rollback** instructions. We never burn a bridge before
 
 ### Phase 0 — Prep (no production impact, ~1 day calendar)
 
-- [ ] Drop DNS TTL on `plugged.in` and `rc1.plugged.in` A records to 60s (currently likely 3600+). Wait one previous-TTL window before any cutover.
+- [ ] Drop DNS TTL on `plugged.in` A record to 60s (currently likely 3600+). Wait one previous-TTL window before any cutover.
 - [ ] Generate age key on this host: `age-keygen -o /etc/sops/age/keys.txt`, `chmod 400`, back up the **private key** to offline storage (1Password, USB, whatever ops already uses).
 - [ ] Take a verified backup of the external Postgres:
       `pg_dump -Fc -h 185.96.168.246 -U postgres -d v220_prod -f /tmp/v220_prod-prepatch.dump`
@@ -147,7 +139,7 @@ Each phase has explicit **rollback** instructions. We never burn a bridge before
 - [x] `infra/scripts/` (`deploy.sh`, `backup.sh`, `restore.sh`, `cutover-from-native.sh`, `rotate-keys.sh`, `verify.sh`).
 - [x] `infra/postgres/init.sql` (extensions, roles).
 - [x] `infra/ofelia/config.ini` (cron jobs, replacing the host crontab).
-- [x] `Dockerfile` (replace existing — produces a single image tagged for prod and rc1).
+- [x] `Dockerfile` (replace existing — single image for the prod app).
 - [x] `.github/workflows/build-image.yml` — image build gated to `workflow_dispatch` and tag pushes until a self-hosted runner with the right CPU profile lands. Standard GitHub-hosted runners SIGILL on the `@zvec/zvec` binding's SIMD code paths inconsistently; the `stack-validate` job (compose config + shellcheck + traefik + ofelia INI parse) still runs on every PR.
 - [x] `docs/ops/docker-traefik-sops-migration.md` — this file.
 
@@ -158,7 +150,7 @@ Each phase has explicit **rollback** instructions. We never burn a bridge before
 The current nginx owns `:80` and `:443`. We bring Traefik up on `:8080` (dashboard) and `:8443` (TLS) bound to a test hostname like `staging.plugged.in` (point a temporary A record at the host), validate certificate issuance, then proceed.
 
 - [ ] `docker compose -f infra/docker-compose.yml up -d traefik`
-- [ ] Issue a cert for `staging.plugged.in` via DNS-01.
+- [ ] Issue a cert for `staging.plugged.in` via HTTP-01 (requires Traefik to own a public port-80 path under that hostname during the test window — we use `8080:80` on Traefik first and gate certbot's existing `:80` ownership by stopping nginx for the 60s validation window only).
 - [ ] `curl --resolve staging.plugged.in:8443:127.0.0.1 https://staging.plugged.in:8443/whoami` returns 200 from Traefik's `whoami` test backend.
 
 **Rollback:** `docker compose down traefik`.
@@ -177,14 +169,14 @@ The live app is untouched in this phase; we have a populated containerised PG si
 ### Phase 4 — Containerise the app, port `:12005` parked under Traefik (½ day)
 
 - [ ] Build the image: `infra/scripts/build.sh` (also runs in CI on every push to `main`).
-- [ ] `docker compose up -d pluggedin-app pluggedin-rc1` (both bind on internal port `3000`, Traefik exposes them).
+- [ ] `docker compose up -d pluggedin-app` (binds internal port `3000`, Traefik exposes it via the labelled router set).
 - [ ] Internal smoke test on the docker network: `docker compose exec traefik curl -fsS http://pluggedin-app:3000/api/health`.
 - [ ] Run `infra/scripts/verify.sh --app` which hits `/api/health`, `/api/rag/query` (with a known query), and the auth flow.
 - [ ] **Critically: the container has the right zvec path because compose sets `ZVEC_DATA_PATH=/app/data/vectors` and bind-mounts `/home/pluggedin/zvec-data` there.** The drift class of bug from this week becomes structurally impossible.
 
 The live nginx still routes `plugged.in` to the native `:12005`. The containerised app is reachable only through Traefik on `:8443`.
 
-**Rollback:** `docker compose down pluggedin-app pluggedin-rc1`.
+**Rollback:** `docker compose down pluggedin-app`.
 
 ### Phase 5 — Cutover (≤ 10 min downtime, scheduled)
 
@@ -194,7 +186,7 @@ This is the only step that affects users. Pick a low-traffic window.
 [T-15] Drop DNS TTL to 60s (already done in Phase 0).
 [T-5]  Run pre-cutover dump for safety:
        infra/scripts/cutover-from-native.sh --dump-only
-[T-0]  systemctl stop pluggedin pluggedin-rc1 nginx
+[T-0]  systemctl stop pluggedin nginx
        Take a delta-dump (changes since the Phase-0 dump) and apply it:
        infra/scripts/cutover-from-native.sh --delta-apply
        Move :80/:443 ownership: bring Traefik down, change its host-port
@@ -208,7 +200,7 @@ This is the only step that affects users. Pick a low-traffic window.
 
 **Rollback (must be feasible in under 2 minutes):**
 1. `docker compose stop traefik`.
-2. `systemctl start nginx pluggedin pluggedin-rc1`.
+2. `systemctl start nginx pluggedin`.
 3. App is back on the native stack. The containerised PG keeps the new writes since cutover — we'll need a small delta apply back to the external PG if we go through with rollback. The cutover script writes the delta into `/var/backups/pluggedin/cutover-delta-<ts>.sql` precisely for this case.
 
 ### Phase 6 — SOPS wired in (1 day, no production impact after Phase 5)
@@ -232,11 +224,11 @@ The compose file already references `infra/sops/runtime/secrets.env`, which is t
 
 ### Phase 8 — Decommission (1 day, after one week of stable run)
 
-- [ ] `systemctl disable --now pluggedin pluggedin-rc1 nginx` (don't delete the unit files yet — they're the documented rollback path).
+- [ ] `systemctl disable --now pluggedin nginx` (don't delete the unit files yet — they're the documented rollback path).
 - [ ] Coordinate with the external PG owner to confirm we're the last consumer of `v220_prod`, then either shut down that database or leave it as a cold replica.
 - [ ] Delete `docker-compose.yml`, `docker-compose.dev.yml`, `docker-compose.production.yml`, `Dockerfile.production`, `docker-build.sh` from the repo root. The `infra/` stack is the only stack.
 
-**Rollback:** `systemctl enable --now pluggedin pluggedin-rc1 nginx`. Revert the file deletions from git.
+**Rollback:** `systemctl enable --now pluggedin nginx`. Revert the file deletions from git.
 
 ### Phase 9 — Operationalisation (continuous)
 
@@ -311,13 +303,12 @@ The canary query — "GSLB" → "VeriTeknik Comprehensive Verticals & Capabiliti
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
 | pg_dump/restore data corruption | low | high | Phase 3 restores into a sandbox first; Phase 5 takes a *delta* dump to bridge any drift between Phase-0 dump and cutover; row counts verified by `verify.sh`. |
-| LE rate limit during testing | medium | medium | DNS-01 with the staging directory (`acme.staging.letsencrypt.org`) for everything except the final cutover. |
+| LE rate limit during testing | medium | medium | Toggle `caServer:` in `traefik.yml` to `acme.staging.letsencrypt.org` for everything except the final cutover. The staging CA's limits are 30,000 certs per week — effectively unbounded for our needs. |
 | Cutover window overruns | low | medium | The cutover is a small, scripted, well-rehearsed sequence; we keep the native stack ready to start with one `systemctl start`. |
 | /var/mcp-packages bind-mount permissions | medium | high (long site latency if cache rebuilds) | Phase 4 verify step includes `docker compose exec pluggedin-app ls /app/.cache/mcp-packages | wc -l` against a known-good count from the host. |
 | firejail / bubblewrap not available inside container | medium | medium | We ship bubblewrap in the image (already present in `Dockerfile.production` base). For the irreducible case where neither works, `MCP_ISOLATION_TYPE=none` is a feature flag, not a code change. |
 | Age private key loss | low | catastrophic (every SOPS secret unreadable) | Key is backed up offline at Phase 0; ops password manager carries a copy; rotation drill quarterly. |
 | External PG decommissioned before all consumers move off | low | low | Phase 8 includes a final consumer scan; the external PG stays read-only for at least two weeks post-cutover. |
-| rc1 and prod share state through `.cache/mcp-packages` causing one to corrupt the other | low | medium | The cache is content-addressable (npm/pip/uv stores). Designed to be shared. Spot-checked in Phase 4. |
 
 ---
 
@@ -357,7 +348,7 @@ tail -f /var/log/pluggedin/pluggedin_app.log
 
 ```bash
 docker compose -f /opt/pluggedin-stack/infra/docker-compose.yml stop traefik
-systemctl start nginx pluggedin pluggedin-rc1
+systemctl start nginx pluggedin
 # DNS is unchanged because Traefik and nginx both terminated on the same
 # host IP. Anything written to the containerised PG since cutover is in
 # /var/backups/pluggedin/cutover-delta-*.sql for re-apply if needed.
@@ -367,8 +358,8 @@ systemctl start nginx pluggedin pluggedin-rc1
 
 ## 10. Open questions for you before Phase 2
 
-1. CloudFlare API token for DNS-01? If no, do we have any DNS provider with API access?
+1. ~~CloudFlare API token~~ — **answered**: no CF, using HTTP-01.
 2. Does the external PG (`185.96.168.246`) have other clients besides plugged.in?
-3. Does `rc1.plugged.in` share `v220_prod` with prod, or is it a different database name?
+3. ~~rc1 data sharing~~ — **answered**: rc1 no longer exists; single instance only.
 4. Acceptable cutover window (timezone + duration)? Plan is sized for 10 minutes but I'd schedule a 30-minute window with comms.
-5. Is GHCR acceptable as the image registry, or do you want self-hosted?
+5. ~~Container registry~~ — **answered**: GHCR, already pushing on every main merge via the self-hosted runner (PR #157, PR #158).

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,8 +1,8 @@
 # `infra/` — production stack
 
-Everything in this directory together defines how `plugged.in` and
-`rc1.plugged.in` run in production. There is no other source of truth; if
-you change deployment, change it here.
+Everything in this directory together defines how `plugged.in` runs in
+production. There is no other source of truth; if you change deployment,
+change it here.
 
 > Background, decisions, and the full migration plan from the native
 > nginx+systemd stack live in
@@ -13,8 +13,8 @@ you change deployment, change it here.
 
 ```
 infra/
-├── docker-compose.yml     # the stack (traefik, app, rc1, postgres, redis, ofelia)
-├── Dockerfile             # at repo root, not here — single image for both prod and rc1
+├── docker-compose.yml     # the stack (traefik, app, postgres, redis, ofelia)
+├── Dockerfile             # at repo root, not here — single image for the prod app
 ├── postgres/init.sql      # extensions + privilege tightening, runs once on first start
 ├── traefik/
 │   ├── traefik.yml        # static config (entrypoints, ACME, providers)
@@ -118,7 +118,7 @@ procedure. tl;dr `./infra/scripts/rotate-keys.sh`.
 
 ```bash
 docker compose -f infra/docker-compose.yml stop traefik
-sudo systemctl start nginx pluggedin pluggedin-rc1
+sudo systemctl start nginx pluggedin
 ```
 
 DNS doesn't change; Traefik and nginx both terminated on the same host IP.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -44,11 +44,13 @@ services:
     command:
       - --configFile=/etc/traefik/traefik.yml
     ports:
-      # Bound to 80/443 at cutover (Phase 5). Until then use 8080:80 and
-      # 8443:443 so the native nginx keeps the canonical ports during
-      # Phase 2 staging.
-      - "80:80"
-      - "443:443"
+      # Pre-cutover defaults so `docker compose up` on the prod host won't
+      # collide with the native nginx that still owns 80/443. Phase 2
+      # staging hits Traefik on these. At Phase 5 cutover, edit this
+      # block to `- "80:80"` / `- "443:443"`, restart Traefik, then stop
+      # nginx — order matters because LE HTTP-01 needs the public :80.
+      - "8080:80"
+      - "8443:443"
     volumes:
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/dynamic:/etc/traefik/dynamic:ro
@@ -121,15 +123,19 @@ services:
       traefik.http.services.plugged-in-sse.loadbalancer.server.port: "3000"
       traefik.http.services.plugged-in-sse.loadbalancer.serverstransport: "sse-transport@file"
       #
-      # SSE sub-router. Priority must beat the catchall router (otherwise
-      # Traefik picks the longest rule which would still be this one, but
-      # being explicit avoids future surprises).
-      traefik.http.routers.plugged-in-sse.rule: "Host(`plugged.in`) && PathPrefix(`/api/discover/stream`)"
+      # SSE sub-router. Trailing slash on the prefix is deliberate — without
+      # it /api/discover/streamABC would also match, which is broader than
+      # nginx's `location ~ ^/api/discover/stream/` semantics. Priority
+      # 120 ensures we always win against the catchall.
+      traefik.http.routers.plugged-in-sse.rule: "Host(`plugged.in`) && PathPrefix(`/api/discover/stream/`)"
       traefik.http.routers.plugged-in-sse.entrypoints: "websecure"
       traefik.http.routers.plugged-in-sse.tls.certresolver: "le"
       traefik.http.routers.plugged-in-sse.priority: "120"
       traefik.http.routers.plugged-in-sse.service: "plugged-in-sse"
-      traefik.http.routers.plugged-in-sse.middlewares: "security-headers@file"
+      # rate-limit included: SSE connections live for up to an hour, so
+      # without a rate-limit a single source could exhaust connection
+      # slots cheaply.
+      traefik.http.routers.plugged-in-sse.middlewares: "security-headers@file,rate-limit@file"
       #
       # /_next/static/* — immutable 1-year cache.
       traefik.http.routers.plugged-in-static.rule: "Host(`plugged.in`) && PathPrefix(`/_next/static`)"
@@ -153,7 +159,9 @@ services:
       traefik.http.routers.plugged-in-widget.tls.certresolver: "le"
       traefik.http.routers.plugged-in-widget.priority: "110"
       traefik.http.routers.plugged-in-widget.service: "plugged-in"
-      traefik.http.routers.plugged-in-widget.middlewares: "security-headers@file,widget-cors@file"
+      # rate-limit on widget too: open CORS + publicly embeddable on any
+      # origin makes this a cheap abuse target without it.
+      traefik.http.routers.plugged-in-widget.middlewares: "security-headers@file,widget-cors@file,rate-limit@file"
       #
       # Catchall — everything else on the host. Lowest priority on
       # purpose so the specific routers above always win.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -2,27 +2,31 @@
 #
 # Run with the wrapper:
 #   infra/scripts/deploy.sh
-# which decrypts infra/sops/secrets.env.sops into /run/sops/secrets.env (tmpfs)
-# and exports IMAGE_TAG before invoking compose. Running compose by hand without
-# the wrapper will fail because env_file points at the decrypted file.
+# which decrypts infra/sops/secrets.env.sops into /run/sops/secrets.env
+# (tmpfs) and exports IMAGE_TAG before invoking compose. Running compose
+# by hand without the wrapper will fail because env_file points at the
+# decrypted file.
 #
-# Single host. Two app instances (prod + rc1) share Postgres, Redis, and the
-# MCP package cache. Traefik is the only thing bound to host ports 80/443.
+# Single host, single app instance. Traefik is the only thing bound to
+# host ports 80/443. Routing rules and per-route middlewares live in
+# the `labels:` block on pluggedin-app — five sub-routers translate
+# the production nginx site directly:
+#
+#   plugged-in            main → app, security-headers + rate-limit
+#   plugged-in-sse        /api/discover/stream/ → app, 3600s timeouts
+#   plugged-in-static     /_next/static/ → app, immutable cache headers
+#   plugged-in-blog-imgs  /blog-images/ → app, 30d cache headers
+#   plugged-in-widget     /widget.js → app, CORS middleware
 
-# env vars common to both app instances. Kept as a separate anchor so the
-# `<<: *app-env` merge inside each service's environment: block can layer
-# instance-specific overrides on top. (YAML's `<<:` merge key only merges
-# at the same nesting depth, so we can't put `environment:` directly inside
-# x-app-base — a child's `environment:` would replace the base's wholesale.)
 x-app-environment: &app-env
   NODE_ENV: production
-  # The bug class that triggered the docker migration: ZVEC_DATA_PATH was
-  # not propagating from workspace .env into the standalone build. In the
-  # container env_file is the single source of truth, but we still set
-  # ZVEC_DATA_PATH here so the value is visible in `docker compose config`
-  # and impossible to forget on a fresh deploy.
+  # The bug class that triggered the docker migration: ZVEC_DATA_PATH
+  # was not propagating from workspace .env into the standalone build.
+  # In the container env_file is the single source of truth, but we
+  # still set ZVEC_DATA_PATH here so the value is visible in
+  # `docker compose config` and impossible to forget on a fresh deploy.
   ZVEC_DATA_PATH: /app/data/vectors
-  ZVEC_ALLOW_EXTERNAL_PATH: "false"  # /app is inside the container, no external path needed
+  ZVEC_ALLOW_EXTERNAL_PATH: "false"
   MCP_PACKAGE_STORE_DIR: /app/.cache/mcp-packages
   MCP_PNPM_STORE_DIR: /app/.cache/mcp-packages/pnpm-store
   MCP_UV_CACHE_DIR: /app/.cache/mcp-packages/uv-cache
@@ -32,43 +36,6 @@ x-app-environment: &app-env
   REDIS_URL: redis://redis:6379
   UPLOADS_DIR: /app/uploads
 
-x-app-base: &app-base
-  image: ghcr.io/veriteknik/pluggedin-app:${IMAGE_TAG:-latest}
-  restart: always
-  env_file:
-    - /run/sops/secrets.env
-  volumes:
-    - /home/pluggedin/zvec-data:/app/data/vectors:rw
-    - /home/pluggedin/uploads:/app/uploads:rw
-    - /var/mcp-packages:/app/.cache/mcp-packages:rw
-    - /var/log/pluggedin:/app/logs:rw
-  networks:
-    - pluggedin
-  depends_on:
-    postgres:
-      condition: service_healthy
-    redis:
-      condition: service_healthy
-  # bubblewrap drives MCP server sandboxing. To set up its own unprivileged
-  # user namespace from inside a container, bubblewrap needs CAP_SYS_ADMIN
-  # (for clone(CLONE_NEWUSER)) and the host AppArmor profile relaxed —
-  # Debian's default `docker-default` policy blocks userns-setup syscalls.
-  # The trade-off is documented in docs/ops/docker-traefik-sops-migration.md
-  # §4 ("MCP sandboxing inside container"); removing these will silently
-  # disable MCP sandboxing for every server, not just one, so do not strip
-  # them without checking that MCP_ISOLATION_TYPE fallback is acceptable.
-  # Refs: https://github.com/containers/bubblewrap#sandbox-security
-  cap_add:
-    - SYS_ADMIN
-  security_opt:
-    - apparmor:unconfined
-  healthcheck:
-    test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1"]
-    interval: 10s
-    timeout: 5s
-    retries: 5
-    start_period: 30s
-
 services:
   traefik:
     image: traefik:v3.2
@@ -77,30 +44,21 @@ services:
     command:
       - --configFile=/etc/traefik/traefik.yml
     ports:
-      # Bound to 80/443 only at cutover (Phase 5). Until then change to
-      # 8080:80 and 8443:443 so nginx keeps the canonical ports.
+      # Bound to 80/443 at cutover (Phase 5). Until then use 8080:80 and
+      # 8443:443 so the native nginx keeps the canonical ports during
+      # Phase 2 staging.
       - "80:80"
       - "443:443"
-    environment:
-      # CloudFlare DNS-01 challenge token; populated from SOPS. If we don't
-      # end up using CloudFlare, switch the traefik.yml resolver to HTTP-01
-      # and remove this line.
-      CF_DNS_API_TOKEN_FILE: /run/sops/cloudflare_token
     volumes:
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
       - ./traefik/dynamic:/etc/traefik/dynamic:ro
       - traefik-acme:/letsencrypt
       - /run/sops:/run/sops:ro
       # Docker socket, read-only, so Traefik can do label-based router
-      # discovery. Read-only blocks container start/stop/exec but does
-      # NOT block reading env vars (`docker inspect`) on other services
-      # — including the env_file vars on pluggedin-app. That's an
-      # acceptable trade for the dev-experience win of declarative
-      # labels, but worth a tighter setup later:
+      # discovery. Read-only blocks container start/stop but does NOT
+      # block reading env vars (`docker inspect`) on other services.
       # TODO(docker-socket-proxy): front this with Tecnativa's
-      # docker-socket-proxy scoped to the bare-minimum endpoints
-      # (containers, networks, services). Tracking: should be its own
-      # follow-up PR once the basic stack is live.
+      # docker-socket-proxy scoped to /containers and /networks only.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - pluggedin
@@ -111,45 +69,100 @@ services:
       retries: 5
 
   pluggedin-app:
-    <<: *app-base
+    image: ghcr.io/veriteknik/pluggedin-app:${IMAGE_TAG:-latest}
+    restart: always
     container_name: pluggedin-app
     hostname: pluggedin-app
+    env_file:
+      - /run/sops/secrets.env
     environment:
       <<: *app-env
+    volumes:
+      - /home/pluggedin/zvec-data:/app/data/vectors:rw
+      - /home/pluggedin/uploads:/app/uploads:rw
+      - /var/mcp-packages:/app/.cache/mcp-packages:rw
+      - /var/log/pluggedin:/app/logs:rw
+    networks:
+      - pluggedin
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    # bubblewrap drives MCP server sandboxing. To set up its own
+    # unprivileged user namespace from inside a container, bubblewrap
+    # needs CAP_SYS_ADMIN (for clone(CLONE_NEWUSER)) and the host
+    # AppArmor profile relaxed — Debian's default `docker-default`
+    # policy blocks userns-setup syscalls. The trade-off is documented
+    # in docs/ops/docker-traefik-sops-migration.md §4 ("MCP sandboxing
+    # inside container"); removing these will silently disable MCP
+    # sandboxing for every server, not just one, so do not strip them
+    # without checking that MCP_ISOLATION_TYPE fallback is acceptable.
+    cap_add:
+      - SYS_ADMIN
+    security_opt:
+      - apparmor:unconfined
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q -O- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     labels:
       traefik.enable: "true"
+      # Service definition — used by every router below.
+      traefik.http.services.plugged-in.loadbalancer.server.port: "3000"
+      traefik.http.services.plugged-in.loadbalancer.serverstransport: "app-transport@file"
+      traefik.http.services.plugged-in.loadbalancer.healthcheck.path: "/api/health"
+      traefik.http.services.plugged-in.loadbalancer.healthcheck.interval: "30s"
+      #
+      # Companion service used only by the SSE sub-router — same backend
+      # port, different transport with 3600s timeouts and no idle close.
+      traefik.http.services.plugged-in-sse.loadbalancer.server.port: "3000"
+      traefik.http.services.plugged-in-sse.loadbalancer.serverstransport: "sse-transport@file"
+      #
+      # SSE sub-router. Priority must beat the catchall router (otherwise
+      # Traefik picks the longest rule which would still be this one, but
+      # being explicit avoids future surprises).
+      traefik.http.routers.plugged-in-sse.rule: "Host(`plugged.in`) && PathPrefix(`/api/discover/stream`)"
+      traefik.http.routers.plugged-in-sse.entrypoints: "websecure"
+      traefik.http.routers.plugged-in-sse.tls.certresolver: "le"
+      traefik.http.routers.plugged-in-sse.priority: "120"
+      traefik.http.routers.plugged-in-sse.service: "plugged-in-sse"
+      traefik.http.routers.plugged-in-sse.middlewares: "security-headers@file"
+      #
+      # /_next/static/* — immutable 1-year cache.
+      traefik.http.routers.plugged-in-static.rule: "Host(`plugged.in`) && PathPrefix(`/_next/static`)"
+      traefik.http.routers.plugged-in-static.entrypoints: "websecure"
+      traefik.http.routers.plugged-in-static.tls.certresolver: "le"
+      traefik.http.routers.plugged-in-static.priority: "110"
+      traefik.http.routers.plugged-in-static.service: "plugged-in"
+      traefik.http.routers.plugged-in-static.middlewares: "security-headers@file,cache-immutable@file"
+      #
+      # /blog-images/* — 30-day cache.
+      traefik.http.routers.plugged-in-blog-imgs.rule: "Host(`plugged.in`) && PathPrefix(`/blog-images`)"
+      traefik.http.routers.plugged-in-blog-imgs.entrypoints: "websecure"
+      traefik.http.routers.plugged-in-blog-imgs.tls.certresolver: "le"
+      traefik.http.routers.plugged-in-blog-imgs.priority: "110"
+      traefik.http.routers.plugged-in-blog-imgs.service: "plugged-in"
+      traefik.http.routers.plugged-in-blog-imgs.middlewares: "security-headers@file,cache-30d@file"
+      #
+      # /widget.js — CORS open for embedding from any origin.
+      traefik.http.routers.plugged-in-widget.rule: "Host(`plugged.in`) && Path(`/widget.js`)"
+      traefik.http.routers.plugged-in-widget.entrypoints: "websecure"
+      traefik.http.routers.plugged-in-widget.tls.certresolver: "le"
+      traefik.http.routers.plugged-in-widget.priority: "110"
+      traefik.http.routers.plugged-in-widget.service: "plugged-in"
+      traefik.http.routers.plugged-in-widget.middlewares: "security-headers@file,widget-cors@file"
+      #
+      # Catchall — everything else on the host. Lowest priority on
+      # purpose so the specific routers above always win.
       traefik.http.routers.plugged-in.rule: "Host(`plugged.in`)"
       traefik.http.routers.plugged-in.entrypoints: "websecure"
       traefik.http.routers.plugged-in.tls.certresolver: "le"
+      traefik.http.routers.plugged-in.priority: "100"
+      traefik.http.routers.plugged-in.service: "plugged-in"
       traefik.http.routers.plugged-in.middlewares: "security-headers@file,rate-limit@file"
-      traefik.http.services.plugged-in.loadbalancer.server.port: "3000"
-      traefik.http.services.plugged-in.loadbalancer.healthcheck.path: "/api/health"
-      traefik.http.services.plugged-in.loadbalancer.healthcheck.interval: "30s"
-
-  pluggedin-rc1:
-    <<: *app-base
-    container_name: pluggedin-rc1
-    hostname: pluggedin-rc1
-    environment:
-      # Inherit every common var from x-app-environment, then layer rc1's
-      # divergences on top. Anything added to x-app-environment in the
-      # future automatically propagates here — that was reviewer feedback
-      # on the first cut, which re-listed every var manually and would
-      # have silently drifted out of sync.
-      <<: *app-env
-      # rc1-specific overrides — supplied via the rc1-scoped SOPS secrets
-      # file (see docs/ops/docker-traefik-sops-migration.md §4 open
-      # question 3).
-      DATABASE_URL_FILE: /run/sops/rc1_database_url
-      NEXTAUTH_URL: https://rc1.plugged.in
-    labels:
-      traefik.enable: "true"
-      traefik.http.routers.rc1-plugged-in.rule: "Host(`rc1.plugged.in`)"
-      traefik.http.routers.rc1-plugged-in.entrypoints: "websecure"
-      traefik.http.routers.rc1-plugged-in.tls.certresolver: "le"
-      traefik.http.routers.rc1-plugged-in.middlewares: "security-headers@file,rate-limit@file"
-      traefik.http.services.rc1-plugged-in.loadbalancer.server.port: "3000"
-      traefik.http.services.rc1-plugged-in.loadbalancer.healthcheck.path: "/api/health"
 
   postgres:
     image: pgvector/pgvector:pg16
@@ -214,9 +227,6 @@ services:
       retries: 5
 
   ofelia:
-    # Job scheduler that runs scheduled tasks against the app via docker exec
-    # or HTTP. Replaces the seven host-side crontab entries; the schedules and
-    # commands themselves live in infra/ofelia/config.ini.
     image: mcuadros/ofelia:0.3.13
     restart: always
     container_name: ofelia
@@ -226,16 +236,9 @@ services:
     command: daemon --config=/etc/ofelia/config.ini
     volumes:
       - ./ofelia/config.ini:/etc/ofelia/config.ini:ro
-      # Ofelia talks to docker to `exec` one-shot commands inside other
-      # containers. Read-only is sufficient for label-based discovery
-      # AND for `docker exec` (Docker treats exec under read-only sockets
-      # as a write op? actually it doesn't — exec works either way with
-      # the current daemon). So this is *more* privileged than the
-      # Traefik mount and inherits the same TODO:
-      # TODO(docker-socket-proxy): scope this through a proxy that only
-      # exposes /containers/exec and /containers/json. Lower priority than
-      # the Traefik proxy because Ofelia's image surface is smaller, but
-      # both should land before we expose the stack publicly.
+      # See TODO(docker-socket-proxy) on the traefik service. Same trade
+      # applies here, smaller surface (Ofelia only calls /containers/exec
+      # and /containers/json) so lower priority follow-up.
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:
       - pluggedin

--- a/infra/scripts/cutover-from-native.sh
+++ b/infra/scripts/cutover-from-native.sh
@@ -97,7 +97,7 @@ fi
 
 if [ "$SWITCH" -eq 1 ]; then
   echo "[cutover] stopping native services to quiesce writes"
-  sudo systemctl stop pluggedin pluggedin-rc1 nginx || true
+  sudo systemctl stop pluggedin nginx || true
 
   echo "[cutover] final dump (DB is now quiet — this captures every write up to T-0)"
   pg_dump -Fc --no-owner --no-acl "$EXT_PG_URL" > "${BACKUP_DIR}/cutover-final.dump"
@@ -123,5 +123,5 @@ if [ "$SWITCH" -eq 1 ]; then
   echo
   echo "Rollback if needed:"
   echo "  docker compose -f ${INFRA_DIR}/docker-compose.yml stop traefik"
-  echo "  sudo systemctl start nginx pluggedin pluggedin-rc1"
+  echo "  sudo systemctl start nginx pluggedin"
 fi

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -73,11 +73,10 @@ extract_secret() {
   chmod 0400 "$dest"
 }
 
-extract_secret CF_API_TOKEN          cloudflare_token
 extract_secret TRAEFIK_DASHBOARD_AUTH traefik-users
-# traefik/dynamic/middlewares.yml references these files directly via
-# `usersFile:` and (for Traefik's static config) the CF_DNS_API_TOKEN_FILE
-# env var. No rewriting of committed files at deploy time.
+# traefik/dynamic/middlewares.yml references this file directly via
+# `usersFile:`. No rewriting of committed files at deploy time. Traefik's
+# TLS issuance uses HTTP-01, so no DNS-provider token needs extracting.
 
 # 4. Pull image (skip with --no-pull)
 if [ "$PULL" -eq 1 ]; then

--- a/infra/scripts/restore.sh
+++ b/infra/scripts/restore.sh
@@ -68,10 +68,10 @@ if [ "$PG_ONLY" -eq 1 ]; then
 fi
 
 echo "[restore] zvec-data → /home/pluggedin/zvec-data"
-"${COMPOSE[@]}" stop pluggedin-app pluggedin-rc1 ofelia
+"${COMPOSE[@]}" stop pluggedin-app ofelia
 rm -rf /home/pluggedin/zvec-data/*
 tar --extract --file "${WORK}/zvec-data.tar" --directory /home/pluggedin
-"${COMPOSE[@]}" start pluggedin-app pluggedin-rc1 ofelia
+"${COMPOSE[@]}" start pluggedin-app ofelia
 
 echo "[restore] uploads → /home/pluggedin/uploads"
 tar --extract --file "${WORK}/uploads.tar" --directory /home/pluggedin --keep-newer-files

--- a/infra/scripts/verify.sh
+++ b/infra/scripts/verify.sh
@@ -57,12 +57,6 @@ echo "$APP_HEALTH" | grep -q '"status":"ok"' \
   && pass "/api/health → ok" \
   || fail "/api/health → $APP_HEALTH"
 
-hdr "pluggedin-rc1 /api/health"
-RC1_HEALTH=$("${COMPOSE[@]}" exec -T pluggedin-rc1 wget -qO- http://127.0.0.1:3000/api/health 2>/dev/null || true)
-echo "$RC1_HEALTH" | grep -q '"status":"ok"' \
-  && pass "/api/health → ok" \
-  || fail "/api/health → $RC1_HEALTH"
-
 if [ "$MODE" = "quick" ]; then
   hdr "skipping canary (--quick)"
   exit 0

--- a/infra/sops/secrets.env.sops.example
+++ b/infra/sops/secrets.env.sops.example
@@ -43,11 +43,10 @@ POSTGRES_DB=v220_prod
 CRON_SECRET=REPLACE_ME
 
 # ─── Traefik ───────────────────────────────────────────────────────
-# CloudFlare DNS-01 token with Zone:DNS:Edit on plugged.in. Required by
-# Traefik's ACME resolver to issue/renew the wildcard cert. deploy.sh
-# extracts this single line into /run/sops/cloudflare_token, which the
-# CF_DNS_API_TOKEN_FILE env var on the traefik container points at.
-CF_API_TOKEN=REPLACE_ME
+# No DNS-provider token needed: Traefik issues TLS certs via Let's
+# Encrypt HTTP-01 (same mechanism certbot used on this host pre-migration).
+# If we ever decide to switch to DNS-01 for wildcard support, add the
+# provider's token here and reference it via *_FILE in compose.
 
 # Traefik dashboard basic-auth credentials, htpasswd format. Generate with:
 #   htpasswd -nbB ops 'somepassword'

--- a/infra/traefik/dynamic/middlewares.yml
+++ b/infra/traefik/dynamic/middlewares.yml
@@ -1,35 +1,84 @@
 # Traefik dynamic configuration. Hot-reloaded on file change.
 #
-# - security-headers: HSTS, CSP-friendly defaults, X-Frame-Options, etc.
-# - rate-limit:       100 req/s average, 200 burst, per source IP. A real
-#                     SPA + APIs page load fires 20–40 requests; the stack-
-#                     level limit needs headroom so the *app*'s finer-
-#                     grained limiter (lib/rate-limiter.ts) is the visible
-#                     one in normal use. Tighten this only if we observe
-#                     abuse — having two layers fight over the same budget
-#                     is worse than picking generous numbers here.
-# - dashboard-auth:   basic auth on the Traefik dashboard. Credentials live
-#                     in /run/sops/traefik-users (htpasswd format, one line
-#                     per user). deploy.sh extracts TRAEFIK_DASHBOARD_AUTH
-#                     from secrets.env onto that file at deploy time. If
-#                     the file is missing, Traefik fails-closed: the
-#                     middleware can't load, so the dashboard router 404s.
+# Translates the production nginx sites-enabled/plugged.in behaviour into
+# Traefik primitives. Each block below has a "nginx →" comment pointing at
+# the directive it replaces.
 
 http:
+  # ─── Middlewares ──────────────────────────────────────────────────
   middlewares:
+
+    # nginx → block of `add_header` directives at the server level:
+    #   X-Frame-Options "SAMEORIGIN"
+    #   X-XSS-Protection "1; mode=block"
+    #   X-Content-Type-Options "nosniff"
+    #   Referrer-Policy "no-referrer-when-downgrade"
+    #   Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'"
+    # Plus HSTS that certbot's options-ssl-nginx.conf already adds.
     security-headers:
       headers:
+        # X-Frame-Options: SAMEORIGIN. Traefik's `frameDeny: true` would
+        # emit DENY, which is stricter than the live site and would break
+        # any same-origin embedding the app currently relies on. Use the
+        # raw header to match nginx exactly.
+        customResponseHeaders:
+          X-Frame-Options: "SAMEORIGIN"
+          X-XSS-Protection: "1; mode=block"
+          Content-Security-Policy: "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'"
+        contentTypeNosniff: true
+        referrerPolicy: "no-referrer-when-downgrade"
         stsSeconds: 31536000
         stsIncludeSubdomains: true
         stsPreload: true
-        frameDeny: true
-        contentTypeNosniff: true
-        browserXssFilter: true
-        referrerPolicy: "strict-origin-when-cross-origin"
-        permissionsPolicy: "camera=(), microphone=(), geolocation=()"
-        customResponseHeaders:
-          X-Robots-Tag: "noindex, nofollow"  # remove if SEO requires indexing
 
+    # nginx → `location /_next/static/ { expires 365d; add_header
+    # Cache-Control "public, max-age=31536000, immutable"; }`.
+    # Next standalone already serves these from /app/.next/static; we just
+    # layer the cache header on the response.
+    cache-immutable:
+      headers:
+        customResponseHeaders:
+          Cache-Control: "public, max-age=31536000, immutable"
+
+    # nginx → `location /blog-images/ { expires 30d; add_header
+    # Cache-Control "public, max-age=2592000"; }`.
+    cache-30d:
+      headers:
+        customResponseHeaders:
+          Cache-Control: "public, max-age=2592000"
+
+    # nginx → `location /widget.js { add_header 'Access-Control-Allow-Origin'
+    # '*' always; ... }` plus the OPTIONS preflight handler. Traefik's CORS
+    # middleware emits the preflight response itself, no second route.
+    widget-cors:
+      headers:
+        accessControlAllowOriginList:
+          - "*"
+        accessControlAllowMethods:
+          - GET
+          - OPTIONS
+        accessControlAllowHeaders:
+          - DNT
+          - User-Agent
+          - X-Requested-With
+          - If-Modified-Since
+          - Cache-Control
+          - Content-Type
+          - Range
+          - Authorization
+        accessControlExposeHeaders:
+          - Content-Length
+          - Content-Range
+        accessControlMaxAge: 1728000
+        addVaryHeader: true
+        # Match nginx `Cache-Control "public, max-age=86400"` on the JS
+        # itself. Cache headers on a 204 preflight are inert.
+        customResponseHeaders:
+          Cache-Control: "public, max-age=86400"
+
+    # Stack-wide protection. The app's lib/rate-limiter.ts is the visible
+    # layer; this only catches abuse. A real SPA + APIs page load fires
+    # 20–40 requests, so the bucket needs serious headroom.
     rate-limit:
       rateLimit:
         average: 100
@@ -37,13 +86,44 @@ http:
         period: 1s
         sourceCriterion:
           ipStrategy:
-            depth: 1  # behind ourselves, no other proxy in front
+            depth: 1
 
+    # Basic auth for the Traefik dashboard. Credentials live at
+    # /run/sops/traefik-users (htpasswd format), extracted from SOPS by
+    # infra/scripts/deploy.sh. If that file is missing the middleware
+    # cannot load and the dashboard router 404s — fail-closed.
     dashboard-auth:
       basicAuth:
         usersFile: /run/sops/traefik-users
         removeHeader: true
 
+  # ─── Servers transports ───────────────────────────────────────────
+  # nginx had per-location timeouts. Traefik attaches these to a service
+  # via `loadbalancer.serverstransport`. Two transports for two profiles:
+  serversTransports:
+
+    # nginx → `proxy_connect_timeout 300s; proxy_send_timeout 300s;
+    # proxy_read_timeout 300s;` on the main / and /api/ locations. OAuth
+    # redirect flows occasionally lean on the full 5-minute window.
+    app-transport:
+      forwardingTimeouts:
+        dialTimeout: "30s"
+        responseHeaderTimeout: "300s"
+        idleConnTimeout: "300s"
+
+    # nginx → `proxy_read_timeout 3600s; proxy_connect_timeout 3600s;
+    # proxy_send_timeout 3600s; keepalive_timeout 3600s; proxy_buffering
+    # off; chunked_transfer_encoding on;` on /api/discover/stream/.
+    # Traefik v3 doesn't buffer responses by default, so the SSE bytes
+    # already flow byte-for-byte; the timeouts are what we have to
+    # extend explicitly.
+    sse-transport:
+      forwardingTimeouts:
+        dialTimeout: "30s"
+        responseHeaderTimeout: "3600s"
+        idleConnTimeout: "3600s"
+
+  # ─── Routers ──────────────────────────────────────────────────────
   routers:
     traefik-dashboard:
       rule: "Host(`traefik.plugged.in`)"

--- a/infra/traefik/dynamic/middlewares.yml
+++ b/infra/traefik/dynamic/middlewares.yml
@@ -26,7 +26,17 @@ http:
           X-XSS-Protection: "1; mode=block"
           Content-Security-Policy: "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'"
         contentTypeNosniff: true
+        # nginx had `Referrer-Policy "no-referrer-when-downgrade"`. We match
+        # it 1:1 here, but the OWASP-preferred value today is
+        # `strict-origin-when-cross-origin` — the current one sends full
+        # paths and query strings to HTTPS third parties. Worth a switch
+        # post-migration once we audit what links out to where.
         referrerPolicy: "no-referrer-when-downgrade"
+        # Permissions-Policy was NOT in nginx but the previous Traefik draft
+        # had it; keeping it is strictly additive — the live site has no
+        # camera/mic/geolocation use, and the header just denies those by
+        # default rather than leaving the browser to its own defaults.
+        permissionsPolicy: "camera=(), microphone=(), geolocation=()"
         stsSeconds: 31536000
         stsIncludeSubdomains: true
         stsPreload: true

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -1,18 +1,25 @@
 # Traefik v3 static configuration.
 #
-# Static config = everything that needs a restart to change (entrypoints, ACME
-# resolvers, log levels). Dynamic config (middlewares, routers, services from
-# labels) lives under /etc/traefik/dynamic/.
+# Static config = entrypoints, ACME resolvers, log levels, providers. Anything
+# that needs a restart to change lives here. Dynamic config (middlewares,
+# routers, services from labels) is hot-reloaded out of /etc/traefik/dynamic/.
+#
+# ACME / TLS:
+#   HTTP-01 challenge, the same mechanism certbot used on this host before
+#   the migration. Traefik must own port 80 at startup so Let's Encrypt's
+#   HTTP-01 validator can reach /.well-known/acme-challenge/. We pre-list
+#   the served hostname on the websecure entrypoint so cert issuance
+#   happens at startup, not lazily on first request — keeps cutover
+#   latency low.
 
 global:
   checkNewVersion: false
   sendAnonymousUsage: false
 
 api:
-  # Dashboard exposed only through Traefik itself, not on a published port.
-  # Reach it via Host(`traefik.plugged.in`) gated by basic auth (see
-  # dynamic/middlewares.yml). Until that host is configured, the dashboard is
-  # effectively unreachable from outside.
+  # Dashboard exposed only behind Traefik on traefik.plugged.in with basic
+  # auth (see dynamic/middlewares.yml). insecure: false means no listener
+  # on a public port.
   dashboard: true
   insecure: false
 
@@ -45,11 +52,13 @@ entryPoints:
     http:
       tls:
         certResolver: le
-        # Wildcard cert for *.plugged.in (DNS-01 only).
+        # Pre-issue at startup; without `domains:`, Traefik lazy-issues on
+        # the first request and that first request pays the LE validation
+        # latency (5–10s). Listed explicitly because HTTP-01 cannot issue
+        # wildcards.
         domains:
           - main: plugged.in
-            sans:
-              - "*.plugged.in"
+          - main: traefik.plugged.in   # dashboard, basic-auth gated
 
 providers:
   file:
@@ -57,8 +66,8 @@ providers:
     watch: true
   docker:
     endpoint: "unix:///var/run/docker.sock"
-    # Only containers that explicitly opt in via `traefik.enable=true` are
-    # exposed. Default-allow is a footgun.
+    # Default-allow on the docker provider is a footgun; every container
+    # that wants exposure must opt in via `traefik.enable=true`.
     exposedByDefault: false
     network: pluggedin
 
@@ -68,14 +77,8 @@ certificatesResolvers:
       email: ops@plugged.in
       storage: /letsencrypt/acme.json
       # Switch to acme.staging.letsencrypt.org while iterating on certs to
-      # avoid the production rate limit (5 per week per registered domain).
+      # avoid the 5-per-week production rate limit.
       # caServer: https://acme-staging-v02.api.letsencrypt.org/directory
       caServer: https://acme-v02.api.letsencrypt.org/directory
-      dnsChallenge:
-        provider: cloudflare
-        # CF_DNS_API_TOKEN_FILE comes from compose env; the token has
-        # Zone:DNS:Edit scope on plugged.in.
-        delayBeforeCheck: 30s
-        resolvers:
-          - "1.1.1.1:53"
-          - "1.0.0.1:53"
+      httpChallenge:
+        entryPoint: web


### PR DESCRIPTION
Walks through every directive in `/etc/nginx/sites-enabled/plugged.in` and writes a Traefik equivalent next to it. Removes `rc1.plugged.in` (no longer deployed) and switches ACME to HTTP-01 (we don't use CloudFlare — certbot has been HTTP-01 here forever).

## What got translated

Every middleware block in `infra/traefik/dynamic/middlewares.yml` and every router label on `pluggedin-app` carries a "nginx →" comment pointing at the exact directive it replaces.

| nginx | Traefik |
|---|---|
| `X-Frame-Options "SAMEORIGIN"`, `X-XSS-Protection "1; mode=block"`, `X-Content-Type-Options "nosniff"`, `Referrer-Policy "no-referrer-when-downgrade"`, CSP `default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval'`, HSTS from certbot's `options-ssl-nginx.conf` | `security-headers` middleware. We used `customResponseHeaders` for `X-Frame-Options` because Traefik's built-in `frameDeny: true` would have emitted `DENY`, which is stricter than the live site and would have broken any same-origin embedding. |
| `location /_next/static/ { expires 365d; ... immutable }` | `cache-immutable` middleware on a `/_next/static/*` router (priority 110) |
| `location /blog-images/ { expires 30d; ... }` | `cache-30d` middleware on a `/blog-images/*` router (priority 110) |
| `location /widget.js` CORS + OPTIONS preflight + 24h cache | `widget-cors` middleware (CORS preflight is emitted by Traefik itself) on a `Path(/widget.js)` router |
| `location ~ ^/api/discover/stream/` SSE — 3600s timeouts, `proxy_buffering off` | `sse-transport` serversTransport + dedicated SSE router (priority 120). Traefik v3 doesn't buffer responses by default, so only the timeouts needed to be widened. |
| `proxy_connect_timeout/read_timeout/send_timeout 300s` on `/` and `/api/` | `app-transport` serversTransport (300s `responseHeaderTimeout` + `idleConnTimeout`) |
| `client_max_body_size 250M` | No equivalent needed — Traefik doesn't buffer request bodies; large uploads pass through |
| `proxy_buffer_size 128k; proxy_buffers 4 256k` (large CSP headers) | No equivalent needed — Traefik streams responses |
| `try_files $uri $uri/ @proxy` (fs first, then proxy) | No equivalent needed — Next.js standalone serves its own statics; the catchall router passes everything through |
| HTTP → HTTPS 301 | `entryPoints.web.http.redirections` in `traefik.yml` |
| WebSocket upgrade (`Upgrade`/`Connection` headers) | Traefik passes through by default |

## ACME / TLS

- Switched from `dnsChallenge: cloudflare` to `httpChallenge: { entryPoint: web }`. Same mechanism certbot used.
- Pre-listed `plugged.in` and `traefik.plugged.in` on the `websecure` entrypoint so Traefik issues certs at startup, not lazily on first request. Reduces post-cutover latency.
- Removed `CF_API_TOKEN` from `secrets.env.sops.example` and the matching `extract_secret cloudflare_token` line from `deploy.sh`.
- Comment in `traefik.yml` shows how to flip to staging-LE while iterating, to avoid the 5-per-week production rate limit.

## Single-instance simplification

- `pluggedin-rc1` removed from `infra/docker-compose.yml`.
- `verify.sh` no longer health-checks rc1.
- `restore.sh` and `cutover-from-native.sh` no longer try to stop/start the rc1 systemd unit.
- `infra/README.md` and the migration plan reflect "one app, one container".
- Plan §10 q1 and q3 marked as answered (no CF, no rc1).

## What's deliberately the same

- bubblewrap + `CAP_SYS_ADMIN` + `apparmor: unconfined` on `pluggedin-app`.
- Docker socket mount on Traefik and Ofelia, still RO, still flagged with `TODO(docker-socket-proxy)`.
- Postgres tuning (4 GiB `shared_buffers`, etc.) and Redis maxmemory.
- Rate-limit middleware (100/s burst 200).

## Test plan

- [x] `docker compose config -q` passes against a stubbed `/run/sops/secrets.env`.
- [ ] **Phase 2** (separate task, no merge gate): bring Traefik up on `8080:80` and `8443:443`, point `staging.plugged.in` at this host, validate cert issuance + every router (SSE, static, widget, blog images, catchall).
- [ ] At Phase 5 cutover: `infra/scripts/verify.sh` against the final stack. The canary RAG query ("GSLB" → VeriTeknik doc) still wired in.
- [ ] Manual smoke after cutover: load the live SPA, watch DevTools Network for `Cache-Control: public, max-age=31536000, immutable` on a `/_next/static/...` response and `Cache-Control: public, max-age=2592000` on a `/blog-images/...` response. Confirm `/widget.js` carries `Access-Control-Allow-Origin: *`.
- [ ] OAuth round-trip end-to-end (300s headroom).
- [ ] SSE: keep `/api/discover/stream/...` open for > 5 min to confirm `sse-transport` works.

## Out of scope

- Container image build doesn't change. CI already builds it on every main push via the self-hosted runner (PR #157, hardened in PR #158).
- App code unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Translate the production nginx configuration for plugged.in into Traefik routing and middleware, switch Let's Encrypt from Cloudflare DNS-01 to HTTP-01, and simplify the stack to a single app instance without rc1.

Enhancements:
- Define Traefik middlewares, routers, and serversTransports that mirror nginx behaviour for security headers, caching, CORS for widget.js, and SSE timeouts, wired via labels on the pluggedin-app service.
- Preconfigure Traefik's ACME resolver to use HTTP-01 with startup issuance for plugged.in and traefik.plugged.in, avoiding lazy certificate issuance latency.
- Clarify and tighten infra documentation and diagrams to reflect the Traefik/HTTP-01 setup, nginx-to-Traefik translation, and single-instance architecture.
- Refine comments around Docker socket mounts for Traefik and Ofelia to document current tradeoffs and future docker-socket-proxy hardening.

Deployment:
- Configure Traefik entrypoints and ACME to use HTTP-01 on the web entrypoint, with pre-listed domains for plugged.in and traefik.plugged.in.
- Remove Cloudflare DNS dependency and related secret extraction from the deployment scripts and compose environment.

Documentation:
- Update the migration plan and infra README to describe HTTP-01-based TLS, the single plugged.in instance, and the Traefik translation of nginx behaviour, while marking previously open questions (CF, rc1, registry) as resolved.

Chores:
- Remove the rc1 application service and all associated references from docker-compose, scripts, and docs, consolidating to a single pluggedin-app service.