### PR TITLE
Working default self-host Docker setup (build-from-source) + build/runtime fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,11 @@ RUN test -e node_modules/@zvec/bindings-linux-x64/zvec_node_binding.node \
 # (see lib/vectors/vector-service.ts callers).
 
 COPY . .
-RUN pnpm build
+# Raise V8's heap limit for the build. `next build` on this app exceeds V8's
+# default old-space cap and aborts with "JavaScript heap out of memory"
+# (exit 134) on memory-constrained Docker engines (e.g. an 8 GB Docker Desktop).
+# Scoped to this RUN so it doesn't affect the runtime process.
+RUN NODE_OPTIONS=--max-old-space-size=6144 pnpm build
 
 # Note: dev dependencies are *not* pruned. drizzle-kit and tsx are listed as
 # devDependencies but are needed at runtime by `pnpm db:migrate` and
@@ -70,9 +74,14 @@ RUN pnpm build
 # ─── stage 2: runtime ─────────────────────────────────────────────────
 FROM node:22-trixie-slim AS runtime
 
+# HOSTNAME=0.0.0.0: Next.js standalone binds to process.env.HOSTNAME. Docker
+# sets HOSTNAME to the container id, so without this the server binds to the
+# eth0 IP only and the loopback HEALTHCHECK (127.0.0.1:3000) is refused →
+# the container is reported "unhealthy" even though the app serves fine.
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1 \
-    PORT=3000
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
 
 # bubblewrap: MCP sandboxing.
 # tini:       PID-1 signal handling — without it stdio MCP zombies pile up.

--- a/README.md
+++ b/README.md
@@ -69,34 +69,46 @@ Security: AES-256-GCM encryption, Redis rate limiting
 
 ### Docker (Recommended - 2 minutes)
 
-#### **Supported Architectures**
+#### **Self-hosting builds the image locally**
 
-Plugged.in Docker images are multi-architecture (`amd64` and `arm64`) and will automatically select the correct platform for your system.
+The default `docker-compose.yml` **builds the app image from source** (`./Dockerfile`) for your platform. There is intentionally **no prebuilt self-host image**: the embedded **zvec** vector engine needs build-time flags/bindings that a generic registry image can't carry, so the image is compiled locally with the right `supportedArchitectures` configuration.
 
-**Important Notes:**
-- ✅ **Docker Compose automatically pulls the correct architecture** - no manual configuration needed
-- ✅ **Works seamlessly on mixed architectures** - run the same `docker-compose.yml` on any platform
-- ✅ **No performance penalty** - native builds for both AMD64 and ARM64
-
-To verify which platforms are available, run:
-```bash
-docker manifest inspect veriteknik/pluggedin:latest --verbose | jq '.manifests[].platform'
-```
+> The first `docker compose up --build` takes roughly **10–15 minutes** (installing dependencies + `next build`). Subsequent starts are instant — the image is cached. Requirements: Docker with BuildKit (Docker Desktop, or `docker buildx`) and **at least ~8 GB of memory allotted to the Docker engine** — `next build` is memory-hungry and will abort with "JavaScript heap out of memory" on smaller limits (raise it in Docker Desktop → Settings → Resources).
 
 ```bash
 # Clone and setup
 git clone https://github.com/VeriTeknik/pluggedin-app.git
 cd pluggedin-app
 cp .env.example .env
+# Edit .env and set at minimum NEXTAUTH_SECRET (generate one with:
+#   openssl rand -base64 32
+# ). The bundled PostgreSQL/Redis URLs already work out of the box.
 
-# Start with Docker (includes PostgreSQL 18 + pgvector)
+# Build the app image and start the full stack (PostgreSQL 18 + pgvector,
+# Redis, one-shot migration, then the app):
 docker compose up --build -d
+
+# Follow startup (migration runs first, then the app becomes healthy):
+docker compose logs -f pluggedin-app
 
 # Visit http://localhost:12005
 ```
 
+Useful commands:
+```bash
+docker compose ps                       # service status
+docker compose run --rm pluggedin-migrate   # re-run database migrations
+docker compose down                     # stop (keeps data)
+docker compose down -v                  # stop + wipe all volumes
+```
+
+> **Production / hosted deployments use a different file** — this `docker-compose.yml` is the self-host default, not the production stack:
+> - `docker-compose.production.yml` — pulls the prebuilt `veriteknik/pluggedin` image (the hosted/cloud build)
+> - `infra/docker-compose.yml` — the Traefik + SOPS production stack used by plugged.in
+
 **What's included:**
 - ✅ PostgreSQL 18 with pgvector extension for vector search
+- ✅ Redis 7 for rate limiting / caching
 - ✅ Embedded zvec vector engine for RAG (no external Milvus/Qdrant needed)
 - ✅ Next.js 15 web application with optimized production build
 - ✅ Persistent volumes for database, uploads, vectors, and logs
@@ -105,16 +117,19 @@ docker compose up --build -d
 **Docker Architecture:**
 ```yaml
 Services:
-  - pluggedin-app: Main web application (port 12005)
+  - pluggedin-migrate:  One-shot DB migration; reuses the app image, then exits
+  - pluggedin-app:      Main web application (host port 12005 → container 3000),
+                        starts only after migration completes successfully
   - pluggedin-postgres: PostgreSQL 18 + pgvector database (port 5432)
-  - drizzle-migrate: One-time migration runner (auto-stops)
+  - pluggedin-redis:    Redis 7 (port 6379)
 
 Volumes:
   - pluggedin-postgres: Database data (persistent)
-  - zvec-data: Vector collections (persistent)
-  - app-uploads: User uploaded files (persistent)
-  - app-logs: Application logs (persistent)
-  - mcp-cache: MCP package cache (persistent)
+  - pluggedin-redis:    Redis append-only data (persistent)
+  - zvec-data:          Vector collections (persistent)
+  - app-uploads:        User uploaded files (persistent)
+  - app-logs:           Application logs (persistent)
+  - mcp-cache:          MCP package cache (persistent)
 ```
 
 **Upgrading from older versions:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,46 @@
+# Default self-host setup for end users.
+#
+# The app image is BUILT LOCALLY from ./Dockerfile — there is no prebuilt
+# registry image for self-hosting, because the embedded zvec vector engine
+# needs build-time flags/bindings that a generic prebuilt image cannot carry.
+#
+#   cp .env.example .env          # then set NEXTAUTH_SECRET (see README)
+#   docker compose up --build -d  # first run builds the image (~10-15 min)
+#   open http://localhost:12005
+#
+# Production / hosted deployments use a DIFFERENT file — this is NOT the prod
+# stack:
+#   - docker-compose.production.yml  → pulls the prebuilt veriteknik/pluggedin image
+#   - infra/docker-compose.yml       → Traefik + SOPS production stack
+#
+# See README "Quick Start → Docker" for details.
+
 services:
+  # One-shot database migration. Reuses the app image built below (no second
+  # build) and exits when migrations are applied; the app waits for it.
+  pluggedin-migrate:
+    container_name: pluggedin-migrate
+    image: pluggedin-app:local
+    # Run drizzle-kit directly from node_modules — the runtime image ships it
+    # (drizzle-kit is kept in the image) and this avoids depending on a package
+    # manager being present in the production runtime.
+    command: ["node_modules/.bin/drizzle-kit", "migrate"]
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgresql://pluggedin:pluggedin_secure_password@pluggedin-postgres:5432/pluggedin
+      - DATABASE_SSL=false
+    depends_on:
+      pluggedin-postgres:
+        condition: service_healthy
+    restart: "no"
+
   pluggedin-app:
     container_name: pluggedin-app
     build:
       context: .
       dockerfile: Dockerfile
+    image: pluggedin-app:local
     env_file:
       - .env
     restart: always
@@ -33,6 +70,8 @@ services:
         condition: service_healthy
       pluggedin-redis:
         condition: service_healthy
+      pluggedin-migrate:
+        condition: service_completed_successfully
 
   pluggedin-postgres:
     container_name: pluggedin-postgres
@@ -43,6 +82,11 @@ services:
       POSTGRES_DB: pluggedin
       POSTGRES_USER: pluggedin
       POSTGRES_PASSWORD: pluggedin_secure_password
+      # postgres:18 moved the default PGDATA out of /var/lib/postgresql/data;
+      # pin it back to the mounted path so data persists in the volume and the
+      # server actually initialises there (otherwise it boots in a throwaway
+      # location and the healthcheck never passes).
+      PGDATA: /var/lib/postgresql/data
     ports:
       - '5432:5432'
     volumes:
@@ -51,7 +95,8 @@ services:
       test: ["CMD-SHELL", "pg_isready -U pluggedin -d pluggedin"]
       interval: 5s
       timeout: 5s
-      retries: 5
+      retries: 10
+      start_period: 30s
 
   pluggedin-redis:
     container_name: pluggedin-redis
@@ -67,34 +112,6 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
-
-  drizzle-migrate:
-    container_name: pluggedin-migrate
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: migrator
-    command: >
-      sh -c "
-        echo 'Waiting for database to be ready...';
-        until pg_isready -h pluggedin-postgres -p 5432 -U pluggedin; do
-          echo 'Database is unavailable - sleeping';
-          sleep 2;
-        done;
-        echo 'Database is up - running migrations';
-        pnpm drizzle-kit migrate
-      "
-    env_file:
-      - .env
-    environment:
-      - DATABASE_URL=postgresql://pluggedin:pluggedin_secure_password@pluggedin-postgres:5432/pluggedin
-      - DATABASE_SSL=false
-      - PGUSER=pluggedin
-      - PGHOST=pluggedin-postgres
-      - PGDATABASE=pluggedin
-    depends_on:
-      pluggedin-postgres:
-        condition: service_healthy
 
 volumes:
   pluggedin-postgres:


### PR DESCRIPTION
## Summary

Makes the **default `docker-compose.yml` actually work for end-user self-hosting** with a single `docker compose up --build -d`. Per the decision that there's no prebuilt self-host image (the embedded **zvec** engine needs build-time flags a generic registry image can't carry), this is a **build-from-source** default; the **prod/hosted** stack stays separate (`docker-compose.production.yml`, `infra/docker-compose.yml`).

Verified end-to-end locally: **build → PostgreSQL 18 → migration → app healthy** (`/api/health` → `database: true`).

## What was broken
- `docker-compose.yml`'s migrate service referenced `target: migrator` — **that target doesn't exist** in `./Dockerfile` (only in `Dockerfile.production`), so migration failed.
- `pgvector/pgvector:pg18` changed its default `PGDATA`; with the volume at `/var/lib/postgresql/data` and no `PGDATA` set, **postgres never became healthy**.
- `next build` **OOM-aborted** (exit 134, "JavaScript heap out of memory") on an 8 GB Docker engine.
- Next.js standalone bound to the **container's eth0 IP only** (Docker sets `HOSTNAME` to the container id), so the loopback `HEALTHCHECK` was refused → container **perpetually "unhealthy"** despite serving fine.

## Changes
**`docker-compose.yml`** (self-host default):
- Migrate via the app image using `drizzle-kit migrate` directly (runtime image ships drizzle-kit) — no nonexistent target, no dependency on a package manager in the runtime. App waits via `service_completed_successfully`.
- `PGDATA=/var/lib/postgresql/data` + healthcheck `start_period` so pg18 initialises in the volume and reports healthy.
- Header comments clarify this is the default self-host stack (prod = `.production` / `infra/`).

**`Dockerfile`** (shared with prod CI — both benefit):
- `NODE_OPTIONS=--max-old-space-size=6144` for `next build` (scoped to that RUN).
- `HOSTNAME=0.0.0.0` so the server binds all interfaces and the healthcheck passes.

**`README.md`**: accurate local-build self-host instructions, ~8 GB Docker memory requirement, useful commands, and a clear note that production uses a different file.

## Verification
```
docker compose up --build -d
NAME                 STATUS
pluggedin-app        Up (healthy)
pluggedin-postgres   Up (healthy)
pluggedin-redis      Up (healthy)
# /api/health → {"status":"healthy","checks":{"service":true,"database":true}}
```
Tested under an isolated compose project with fresh volumes (no impact to existing data).

## Summary by Sourcery

Update the default Docker-based self-hosting setup so a single `docker compose up --build -d` reliably builds, migrates, and runs the app with healthy services.

New Features:
- Add a dedicated one-shot `pluggedin-migrate` service that reuses the app image to run database migrations before the app starts.

Bug Fixes:
- Fix PostgreSQL 18 container initialization by explicitly setting PGDATA to the mounted data directory and relaxing the healthcheck timing.
- Prevent `next build` from failing with out-of-memory errors during Docker builds by increasing the Node.js heap limit for the build step.
- Ensure the Next.js runtime binds on all interfaces so container healthchecks succeed instead of reporting the app as unhealthy.

Enhancements:
- Clarify that the default `docker-compose.yml` is a build-from-source self-host stack, distinct from the production/hosted compose files.
- Streamline service dependencies so the app waits for database readiness and successful migration before starting.

Documentation:
- Revise Docker self-hosting documentation with accurate local build instructions, resource requirements, service descriptions, and pointers to the separate production stacks.