### PR TITLE
chore(sentry): reduce ingestion load (traces 100%→10%, replay error-only)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -13,12 +13,12 @@ Sentry.init({
   integrations: process.env.NODE_ENV === 'production' ? [Sentry.replayIntegration()] : [],
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'production' ? 1 : 0,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
 
   // Define how likely Replay events are sampled.
-  // This sets the sample rate to be 10%. You may want this to be 100% while
-  // in development and sample at a lower rate in production
-  replaysSessionSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
+  // Disabled for normal sessions to reduce Sentry replay quota usage;
+  // replays are only captured when an error occurs (see replaysOnErrorSampleRate).
+  replaysSessionSampleRate: 0,
 
   // Define how likely Replay events are sampled when an error occurs.
   replaysOnErrorSampleRate: process.env.NODE_ENV === 'production' ? 1.0 : 0,

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -11,7 +11,7 @@ Sentry.init({
     : '', // Disable Sentry in development
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'production' ? 1 : 0,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -10,7 +10,7 @@ Sentry.init({
     : '', // Disable Sentry in development
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'production' ? 1 : 0,
+  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## Özet

Sentry kotası/yükü ağırlıklı olarak iki ayardan tükeniyordu:

1. **`tracesSampleRate: 1`** — her transaction (her istek) Sentry'ye gönderiliyordu (%100). Performance/transaction kotasının ana tüketicisi.
2. **`replaysSessionSampleRate: 0.1`** — normal oturumların %10'u replay olarak kaydediliyordu.

## Değişiklikler

- **traces: `1` → `0.1`** — client, server ve edge config'lerin hepsinde. Transaction yükünü ~10x azaltır, performans görünürlüğü korunur.
- **`replaysSessionSampleRate`: `0.1` → `0`** — normal gezinme artık kaydedilmiyor.
- **`replaysOnErrorSampleRate`: `1.0` korundu** — replay yalnızca hata oluştuğunda yakalanıyor. `replayIntegration()` bu yüzden duruyor.

Development davranışı değişmedi (zaten `NODE_ENV !== 'production'` için tüm oranlar 0).

## Etki

- Replay quota: normal oturumlar tamamen kesildi, sadece hata anı replay'leri kalıyor.
- Transaction quota: %100 → %10.

## Notlar / sonraki adımlar (bu PR'da yok)

- `tracesSampler` ile route bazlı seçici örnekleme (gürültülü route'ları %0).
- `ignoreErrors` / `denyUrls` ile aksiyon alınamayan client gürültüsünü filtreleme.
- Sentry dashboard tarafında Inbound Filters + spike protection.

Etkili olması için production build + restart gerekir (`pnpm build` + `sudo systemctl restart pluggedin.service`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce Sentry production ingestion load by lowering trace sampling and disabling non-error session replays.

Enhancements:
- Lower Sentry trace sampling rate from 100% to 10% across client, server, and edge configurations for production.
- Disable Sentry session replay sampling for normal sessions so that only error-triggered replays are captured.