### PR TITLE
chore(sentry): add tracesSampler to cut span ingestion volume

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -4,16 +4,21 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { tracesSampler } from '@/lib/sentry-sampling';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
 Sentry.init({
-  dsn: process.env.NODE_ENV === 'production' 
+  dsn: isProduction
     ? 'https://71d8c70c11135db3ec287d3bf15f426b@o4509004867698688.ingest.de.sentry.io/4509541917786192'
     : '', // Disable Sentry in development
 
   // Add optional integrations for additional features
-  integrations: process.env.NODE_ENV === 'production' ? [Sentry.replayIntegration()] : [],
+  integrations: isProduction ? [Sentry.replayIntegration()] : [],
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
+  // Drop high-frequency / low-value transactions entirely and keep the rest at a
+  // low base rate to control span ingestion volume. See lib/sentry-sampling.ts.
+  ...(isProduction ? { tracesSampler } : { tracesSampleRate: 0 }),
 
   // Define how likely Replay events are sampled.
   // Disabled for normal sessions to reduce Sentry replay quota usage;

--- a/lib/sentry-sampling.ts
+++ b/lib/sentry-sampling.ts
@@ -52,9 +52,12 @@ const POLLING_PATTERNS: RegExp[] = [
 // Builds the string we match patterns against from whatever the SDK gives us:
 // the span name plus the most likely URL-bearing attributes/fields, across both
 // browser and node sampling contexts.
-function resolveTarget(ctx: TracesSamplerSamplingContext): string {
+// Span attribute values may be numbers, booleans, or arrays — coercing those
+// into the match string (via join) could inject `[object Object]` or stray
+// tokens and cause accidental regex hits, so keep only non-empty strings.
+function resolveCandidates(ctx: TracesSamplerSamplingContext): string[] {
   const attrs = ctx.attributes ?? {};
-  const candidates = [
+  return [
     ctx.name,
     attrs['http.route'],
     attrs['http.target'],
@@ -63,21 +66,30 @@ function resolveTarget(ctx: TracesSamplerSamplingContext): string {
     attrs['http.url'],
     ctx.normalizedRequest?.url,
     ctx.location?.pathname,
-  ];
-  return candidates.filter(Boolean).join(' ');
+  ].filter((v): v is string => typeof v === 'string' && v.length > 0);
+}
+
+// Each candidate is tested independently so a pattern can't match across the
+// boundary between two concatenated fields.
+function matchesAny(candidates: string[], patterns: RegExp[]): boolean {
+  return candidates.some((c) => patterns.some((re) => re.test(c)));
 }
 
 /**
  * Production `tracesSampler`. Returns the per-transaction sample rate.
  */
 export function tracesSampler(ctx: TracesSamplerSamplingContext): number {
-  const target = resolveTarget(ctx);
+  const candidates = resolveCandidates(ctx);
 
-  if (DROP_PATTERNS.some((re) => re.test(target))) {
+  // Noise is dropped regardless of any incoming trace decision.
+  if (matchesAny(candidates, DROP_PATTERNS)) {
     return 0;
   }
-  if (POLLING_PATTERNS.some((re) => re.test(target))) {
-    return POLLING_SAMPLE_RATE;
+  // For everything else, honor the parent transaction's sampling decision when
+  // there is one (keeps distributed traces intact) and otherwise fall back to
+  // our own rate.
+  if (matchesAny(candidates, POLLING_PATTERNS)) {
+    return ctx.inheritOrSampleWith(POLLING_SAMPLE_RATE);
   }
-  return BASE_SAMPLE_RATE;
+  return ctx.inheritOrSampleWith(BASE_SAMPLE_RATE);
 }

--- a/lib/sentry-sampling.ts
+++ b/lib/sentry-sampling.ts
@@ -1,0 +1,83 @@
+// Shared Sentry trace sampling logic.
+//
+// Span volume (not transaction count) is what Sentry bills against, and a handful
+// of high-frequency, low-value endpoints (health checks, session polling, SWR
+// refetches) dominate that volume. Instead of sampling every transaction at a
+// flat rate, `tracesSampler` lets us drop the noisiest transactions entirely and
+// keep meaningful ones at a modest base rate.
+//
+// Errors and replays are unaffected by this — they are sampled separately.
+
+import type { init } from '@sentry/nextjs';
+
+// `@sentry/nextjs` does not re-export the sampling context type, so derive it
+// from the `tracesSampler` parameter of the init options instead.
+type SentryInitOptions = NonNullable<Parameters<typeof init>[0]>;
+type TracesSamplerSamplingContext = Parameters<
+  NonNullable<SentryInitOptions['tracesSampler']>
+>[0];
+
+// Base sample rate for "normal" transactions in production (page loads, regular
+// API requests, server actions).
+export const BASE_SAMPLE_RATE = 0.05;
+
+// Very low rate for known high-frequency polling endpoints. Keeps a thin signal
+// for outright outages without ingesting a span on every poll.
+const POLLING_SAMPLE_RATE = 0.005;
+
+// Transactions matching these are dropped entirely (rate 0). These are
+// effectively pure noise for tracing purposes.
+const DROP_PATTERNS: RegExp[] = [
+  /\/api\/health(\b|\/|$)/i,        // app / mcp-servers / registry health checks
+  /\/api\/auth\/session/i,          // NextAuth session is polled constantly
+  /\/api\/auth\/_log/i,
+  /\/_next\//i,                     // Next.js internals & static assets
+  /\/favicon/i,
+  /\/manifest\.webmanifest/i,
+  /\.(?:js|css|map|png|jpg|jpeg|svg|gif|webp|ico|woff2?)(?:\?|$)/i,
+];
+
+// Transactions matching these are heavily down-sampled. These back SWR hooks
+// that refetch every few seconds (see e.g. the agent detail page polling 4
+// endpoints every 5-10s, memory stats every 30s).
+const POLLING_PATTERNS: RegExp[] = [
+  /\/api\/agents\//i,
+  /\/api\/memory\//i,
+  /\/api\/metrics/i,
+  /\/api\/platform-metrics/i,
+  /\/api\/analytics/i,
+  /\/api\/notifications/i,
+];
+
+// Builds the string we match patterns against from whatever the SDK gives us:
+// the span name plus the most likely URL-bearing attributes/fields, across both
+// browser and node sampling contexts.
+function resolveTarget(ctx: TracesSamplerSamplingContext): string {
+  const attrs = ctx.attributes ?? {};
+  const candidates = [
+    ctx.name,
+    attrs['http.route'],
+    attrs['http.target'],
+    attrs['url.path'],
+    attrs['url.full'],
+    attrs['http.url'],
+    ctx.normalizedRequest?.url,
+    ctx.location?.pathname,
+  ];
+  return candidates.filter(Boolean).join(' ');
+}
+
+/**
+ * Production `tracesSampler`. Returns the per-transaction sample rate.
+ */
+export function tracesSampler(ctx: TracesSamplerSamplingContext): number {
+  const target = resolveTarget(ctx);
+
+  if (DROP_PATTERNS.some((re) => re.test(target))) {
+    return 0;
+  }
+  if (POLLING_PATTERNS.some((re) => re.test(target))) {
+    return POLLING_SAMPLE_RATE;
+  }
+  return BASE_SAMPLE_RATE;
+}

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,13 +5,18 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { tracesSampler } from '@/lib/sentry-sampling';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
 Sentry.init({
-  dsn: process.env.NODE_ENV === 'production' 
+  dsn: isProduction
     ? 'https://71d8c70c11135db3ec287d3bf15f426b@o4509004867698688.ingest.de.sentry.io/4509541917786192'
     : '', // Disable Sentry in development
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
+  // Drop high-frequency / low-value transactions entirely and keep the rest at a
+  // low base rate to control span ingestion volume. See lib/sentry-sampling.ts.
+  ...(isProduction ? { tracesSampler } : { tracesSampleRate: 0 }),
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,13 +4,18 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+import { tracesSampler } from '@/lib/sentry-sampling';
+
+const isProduction = process.env.NODE_ENV === 'production';
+
 Sentry.init({
-  dsn: process.env.NODE_ENV === 'production' 
+  dsn: isProduction
     ? 'https://71d8c70c11135db3ec287d3bf15f426b@o4509004867698688.ingest.de.sentry.io/4509541917786192'
     : '', // Disable Sentry in development
 
-  // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
-  tracesSampleRate: process.env.NODE_ENV === 'production' ? 0.1 : 0,
+  // Drop high-frequency / low-value transactions entirely and keep the rest at a
+  // low base rate to control span ingestion volume. See lib/sentry-sampling.ts.
+  ...(isProduction ? { tracesSampler } : { tracesSampleRate: 0 }),
 
   // Setting this option to true will print useful information to the console while you're setting up Sentry.
   debug: false,


### PR DESCRIPTION
## Why
Org consumed ~80% of the monthly reserved spans budget (4.0M / 5.0M) mid-cycle, risking pay-as-you-go charges. The previous flat `tracesSampleRate: 0.1` samples noise (health checks, session polling, high-frequency SWR refetches) at the same rate as meaningful traffic.

## What
New shared `tracesSampler` ([lib/sentry-sampling.ts](lib/sentry-sampling.ts)) used by all three init points (server, edge, client):

- **Dropped entirely (rate 0):** `/api/health*`, NextAuth `/api/auth/session`, `/_next/` & static assets, favicon
- **Heavily down-sampled (0.5%):** high-frequency SWR polling — `/api/agents/*` (agent detail page polls 4 endpoints every 5–10s), `/api/memory/*` (30s), metrics, platform-metrics, analytics, notifications
- **Everything else:** 5% base rate

Errors and replay sampling are unaffected (replay already error-only).

## Notes
- The already-accrued 4.0M spans won't disappear — they were ingested earlier in the cycle at 100%. Full effect is visible after the billing cycle resets; meanwhile this sharply slows accrual.
- Type for the sampling context is derived from the init options because `@sentry/nextjs` does not re-export it.

## Verification
- `tsc --noEmit` (project config): 0 errors
- `eslint` on changed files: clean
- `pnpm build`: succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce centralized Sentry trace sampling to reduce span ingestion from low-value, high-frequency traffic while maintaining visibility on meaningful transactions.

Enhancements:
- Replace flat tracesSampleRate configuration with a shared tracesSampler applied to client, server, and edge Sentry init points.
- Exclude known noisy endpoints (e.g., health checks, static assets, session polling) from tracing and heavily down-sample high-frequency polling APIs.
- Standardize production environment checks in Sentry configs via a shared isProduction flag.