### PR TITLE
fix(mcp-servers): enforce profile ownership in toggleMcpServerStatus (CWE-862)

### DIFF
--- a/app/actions/mcp-servers.ts
+++ b/app/actions/mcp-servers.ts
@@ -248,7 +248,12 @@ export async function toggleMcpServerStatus(
   uuid: string,
   newStatus: McpServerStatus
 ): Promise<void> {
-  return withProfileAuth(profileUuid, async () => {
+  return withProfileAuth(profileUuid, async (session) => {
+    const userId = session.user.id;
+
+    // Apply rate limiting for modification operations
+    await applyRateLimit(userId, 'toggle-server-status', ServerActionRateLimits.serverModification);
+
     await db
       .update(mcpServersTable)
       .set({ status: newStatus })

--- a/app/actions/mcp-servers.ts
+++ b/app/actions/mcp-servers.ts
@@ -248,15 +248,17 @@ export async function toggleMcpServerStatus(
   uuid: string,
   newStatus: McpServerStatus
 ): Promise<void> {
-  await db
-    .update(mcpServersTable)
-    .set({ status: newStatus })
-    .where(
-      and(
-        eq(mcpServersTable.uuid, uuid),
-        eq(mcpServersTable.profile_uuid, profileUuid)
-      )
-    );
+  return withProfileAuth(profileUuid, async () => {
+    await db
+      .update(mcpServersTable)
+      .set({ status: newStatus })
+      .where(
+        and(
+          eq(mcpServersTable.uuid, uuid),
+          eq(mcpServersTable.profile_uuid, profileUuid)
+        )
+      );
+  });
 }
 
 export async function updateMcpServer(


### PR DESCRIPTION
## Summary

`toggleMcpServerStatus` in `app/actions/mcp-servers.ts` is a Next.js server action (RPC-callable by any client that can reach the app) that updates the `status` column of `mcp_servers` rows filtered only by client-supplied `profileUuid` + `uuid`. It performs no session check and no ownership check on the target profile. Any user who can reach the app can enable/disable MCP servers on profiles they don't own, given a target `profileUuid` + server `uuid` pair (guessable or leaked via other endpoints/enumeration).

Every sibling mutation in the same file (`deleteMcpServerByUuid`, `updateMcpServer`, `createMcpServer`, `getMcpServers`, …) already wraps its body in `withProfileAuth(profileUuid, async (session) => { … })`, which enforces an authenticated session and verifies the profile belongs to `session.user.id`. `toggleMcpServerStatus` was the outlier.

- **CWE-862**: Missing Authorization
- **File / function**: `app/actions/mcp-servers.ts` → `toggleMcpServerStatus`
- **Impact**: Cross-tenant write — an attacker can silently disable another tenant's MCP servers (denial of service against their MCP integrations) or re-enable servers the owner has disabled.

## Fix

Wrap the update in the same `withProfileAuth` helper the rest of the file uses, and add the standard `applyRateLimit(userId, 'toggle-server-status', ServerActionRateLimits.serverModification)` call so the endpoint matches its siblings for both authorization and abuse-resistance.

Diff is 16 additions / 9 deletions in a single file — no behaviour change for legitimate callers (the same session cookie that lets them call `updateMcpServer` lets them call this).

## Proof of Concept

Preconditions: attacker has any valid session on the app and knows (or brute-forces) a target `profileUuid` and an MCP server `uuid` belonging to that profile. UUIDs leak through shared/exported configs, screenshots, and error messages; profile UUIDs also appear in shared community links.

Before the fix, from a browser devtools console while signed in as attacker:

```js
// Next.js server action invocation — mirrors what the app's own UI does.
await fetch('/', {
  method: 'POST',
  headers: {
    'Content-Type': 'text/plain;charset=UTF-8',
    'Next-Action': '<action-id-of-toggleMcpServerStatus>', // visible in built _next chunks
  },
  body: JSON.stringify([
    '<VICTIM_PROFILE_UUID>',
    '<VICTIM_SERVER_UUID>',
    'INACTIVE', // McpServerStatus
  ]),
});
```

The row is updated even though `<VICTIM_PROFILE_UUID>` does not belong to the attacker's `user_id`. After the fix, `withProfileAuth` returns an authorization error before the `db.update` runs. The equivalent call for `deleteMcpServerByUuid` / `updateMcpServer` already fails today with the same helper — this PR just brings toggle in line.

You can also reproduce directly by importing the action in a test:

```ts
import { toggleMcpServerStatus } from '@/app/actions/mcp-servers';
// With attacker session mocked, expect this to throw post-fix, succeed pre-fix.
await toggleMcpServerStatus(victimProfileUuid, victimServerUuid, 'INACTIVE');
```

## Verification

- Confirmed `withProfileAuth` is defined in `lib/auth-helpers` and used by every other mutation in `app/actions/mcp-servers.ts` (lines 60, 145, 175, 288, 508).
- Confirmed `applyRateLimit` + `ServerActionRateLimits.serverModification` are the same helpers used by `deleteMcpServerByUuid` and `updateMcpServer`.
- The callback signature `async (session) => { … }` matches the other call sites, so `session.user.id` resolves the same way.
- Return type stays `Promise<void>` — `withProfileAuth` propagates the inner return.

## Adversarial review

Before submitting we tried to disprove this. Candidates considered:
- **Middleware auth gate.** `middleware.ts` handles route protection for pages/APIs, but Next.js server actions are dispatched through the page's own route and rely on the action itself to enforce authorization on its arguments — which is why every sibling in this file does exactly that. Middleware does not check that `profileUuid` belongs to `session.user.id`.
- **DB-layer RLS.** The project uses Drizzle against Postgres without row-level security policies on `mcp_servers`; the `.where(eq(profile_uuid, …))` is the only tenant filter and it trusts the argument.
- **UI-only exposure.** Server actions are reachable by any HTTP client that can craft the `Next-Action` header, not only the app's own UI, so "the UI never sends someone else's UUID" isn't a mitigation.
- **Redundancy with a stronger existing bug.** No other public path lets a non-owner mutate another profile's `mcp_servers.status`; the sibling actions are all gated. So this genuinely adds cross-tenant write access.

Happy to iterate on wording or split the rate-limit hunk if you'd prefer a minimal auth-only patch.

---



## Summary by Sourcery

Enforce authenticated, rate-limited profile-scoped access when toggling MCP server status to prevent unauthorized cross-tenant modifications.

Bug Fixes:
- Fix missing authorization in toggleMcpServerStatus so only owners of a profile can change an MCP server’s status.

Enhancements:
- Align toggleMcpServerStatus with other MCP server actions by applying standard rate limiting for server modification operations.