### PR TITLE
fix(deps): resolve 4 new Dependabot alerts (round 2)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,11 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  brace-expansion@<5.0.8: '>=5.0.8 <6.0.0'
   esbuild@<=0.24.2: '>=0.28.1'
   esbuild@>=0.27.3 <0.28.1: '>=0.28.1'
-  brace-expansion@>=1.0.0 <=1.1.11: '>=1.1.12'
-  brace-expansion@>=2.0.0 <2.0.3: '>=2.0.3 <3.0.0'
-  brace-expansion@>=4.0.0 <5.0.7: '>=5.0.7 <6.0.0'
   prismjs@<1.30.0: '>=1.30.0'
   axios@=1.10.0: '>=1.11.0'
   js-yaml@>=4.0.0 <4.3.0: '>=4.3.0 <5.0.0'
@@ -48,8 +46,9 @@ overrides:
   lodash@<4.18.0: '>=4.18.0 <5.0.0'
   dompurify@<3.4.12: '>=3.4.12 <4.0.0'
   '@opentelemetry/core@<2.8.0': '>=2.8.0 <3.0.0'
-  postcss@<8.5.10: '>=8.5.10'
+  postcss@<8.5.18: '>=8.5.18'
   ws@>=8.0.0 <8.20.1: '>=8.20.1 <9.0.0'
+  ws@>=7.0.0 <7.5.11: '>=7.5.11 <8.0.0'
   smol-toml@<1.6.1: '>=1.6.1'
   '@auth/core@<0.41.3': '>=0.41.3 <0.42.0'
   sharp@<0.35.0: '>=0.35.0 <0.36.0'
@@ -428,11 +427,11 @@ importers:
         specifier: ^13.1.3
         version: 13.1.3
       postcss:
-        specifier: ^8.5.13
-        version: 8.5.13
+        specifier: '>=8.5.18'
+        version: 8.5.24
       postcss-load-config:
         specifier: ^6.0.1
-        version: 6.0.1(jiti@1.21.7)(postcss@8.5.13)(tsx@4.21.0)(yaml@2.8.3)
+        version: 6.0.1(jiti@1.21.7)(postcss@8.5.24)(tsx@4.21.0)(yaml@2.8.3)
       react-hook-form:
         specifier: ^7.71.2
         version: 7.71.2(react@19.2.4)
@@ -3736,9 +3735,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -3776,9 +3772,6 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
-
-  brace-expansion@2.1.0:
-    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
@@ -5731,13 +5724,8 @@ packages:
   nan@2.24.0:
     resolution: {integrity: sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.15:
-    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -6143,20 +6131,20 @@ packages:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
 
   postcss-js@4.1.0:
     resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
 
   postcss-load-config@6.0.1:
     resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
       tsx: ^4.8.1
       yaml: '>=2.7.1'
     peerDependenciesMeta:
@@ -6173,7 +6161,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: '>=8.5.10'
+      postcss: '>=8.5.18'
 
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
@@ -6186,12 +6174,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.13:
-    resolution: {integrity: sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.24:
+    resolution: {integrity: sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -7409,8 +7393,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.13:
+    resolution: {integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -10714,8 +10698,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
@@ -10754,10 +10736,6 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
-
-  brace-expansion@2.1.0:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -12957,11 +12935,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 5.0.8
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.0
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 
@@ -13028,9 +13006,7 @@ snapshots:
   nan@2.24.0:
     optional: true
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.15: {}
+  nanoid@3.3.16: {}
 
   nanoid@5.1.6: {}
 
@@ -13065,7 +13041,7 @@ snapshots:
       '@next/env': 15.5.21
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001761
-      postcss: 8.5.15
+      postcss: 8.5.24
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.4)
@@ -13452,30 +13428,30 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-import@15.1.0(postcss@8.5.13):
+  postcss-import@15.1.0(postcss@8.5.24):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.24
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
 
-  postcss-js@4.1.0(postcss@8.5.13):
+  postcss-js@4.1.0(postcss@8.5.24):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.13
+      postcss: 8.5.24
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.13)(tsx@4.21.0)(yaml@2.8.3):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.24)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.13
+      postcss: 8.5.24
       tsx: 4.21.0
       yaml: 2.8.3
 
-  postcss-nested@6.2.0(postcss@8.5.13):
+  postcss-nested@6.2.0(postcss@8.5.24):
     dependencies:
-      postcss: 8.5.13
+      postcss: 8.5.24
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.0.10:
@@ -13490,15 +13466,9 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.13:
+  postcss@8.5.24:
     dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.15:
-    dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -14025,7 +13995,7 @@ snapshots:
       htmlparser2: 8.0.2
       is-plain-object: 5.0.0
       parse-srcset: 1.0.2
-      postcss: 8.5.13
+      postcss: 8.5.24
 
   sax@1.4.3: {}
 
@@ -14415,11 +14385,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.13
-      postcss-import: 15.1.0(postcss@8.5.13)
-      postcss-js: 4.1.0(postcss@8.5.13)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.13)(tsx@4.21.0)(yaml@2.8.3)
-      postcss-nested: 6.2.0(postcss@8.5.13)
+      postcss: 8.5.24
+      postcss-import: 15.1.0(postcss@8.5.24)
+      postcss-js: 4.1.0(postcss@8.5.24)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.24)(tsx@4.21.0)(yaml@2.8.3)
+      postcss-nested: 6.2.0(postcss@8.5.24)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
       sucrase: 3.35.1
@@ -14768,7 +14738,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.24
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -14849,7 +14819,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.10
+      ws: 7.5.13
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14982,7 +14952,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@7.5.10: {}
+  ws@7.5.13: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,13 @@
 # allowlist, supported architectures, and peer-dependency rules.
 
 overrides:
+  # GHSA-mh99-v99m-4gvg: DoS via unbounded expansion. The advisory has a SINGLE
+  # range, '<= 5.0.7', with 5.0.8 as the only patched version — there is no 1.x
+  # or 2.x backport, so every earlier line is affected and one selector covers
+  # all of them. 5.0.8 publishes both ESM and CJS (exports.require), and
+  # minimatch only calls expand(), so this is a drop-in for the minimatch 3/9/10
+  # consumers in the tree (glob/rimraf/eslint tooling).
+  'brace-expansion@<5.0.8': '>=5.0.8 <6.0.0'
   # Target must be >=0.28.1, not >=0.25.0: pnpm matches override selectors
   # against the DECLARED range, so this entry catches @esbuild-kit/core-utils'
   # '~0.18.20' and is the only override that ever fires for it. Pointing it at
@@ -11,11 +18,6 @@ overrides:
   # GHSA-g7r4-m6w7-qqqr. Became reachable once vite moved to 7.3.6, which pulls
   # esbuild 0.27.7 into the tree; the pre-bump tree only had 0.25.12/0.27.1.
   'esbuild@>=0.27.3 <0.28.1': '>=0.28.1'
-  'brace-expansion@>=1.0.0 <=1.1.11': '>=1.1.12'
-  'brace-expansion@>=2.0.0 <2.0.3': '>=2.0.3 <3.0.0'
-  # GHSA-3jxr-9vmj-r5cp (high). Range is >=3.0.0 <5.0.7, so the 2.1.0 copy in
-  # the tree is NOT affected and is deliberately left alone.
-  'brace-expansion@>=4.0.0 <5.0.7': '>=5.0.7 <6.0.0'
   'prismjs@<1.30.0': '>=1.30.0'
   'axios@=1.10.0': '>=1.11.0'
   # GHSA-52cp-r559-cp3m (high) + GHSA-h67p-54hq-rp68
@@ -63,8 +65,11 @@ overrides:
   # GHSA-c2j3-45gr-mqc4
   'dompurify@<3.4.12': '>=3.4.12 <4.0.0'
   '@opentelemetry/core@<2.8.0': '>=2.8.0 <3.0.0'
-  'postcss@<8.5.10': '>=8.5.10'
+  # Round 2: <=8.5.17 vulnerable.
+  'postcss@<8.5.18': '>=8.5.18'
   'ws@>=8.0.0 <8.20.1': '>=8.20.1 <9.0.0'
+  # Round 2: the 7.x copy in the tree is covered by >=7.0.0 <7.5.11.
+  'ws@>=7.0.0 <7.5.11': '>=7.5.11 <8.0.0'
   'smol-toml@<1.6.1': '>=1.6.1'
   # GHSA-xmf8-cvqr-rfgj (high), GHSA-7rqj-j65f-68wh (critical), GHSA-x445-f3h2-j279
   # reached via @auth/drizzle-adapter (next-auth itself is bumped directly).


### PR DESCRIPTION
Follow-up to #171. Four advisories published after that PR was prepared.

Verified against the resolved dependency tree before and after; 4/4 now out of range.

| Package | Change | Advisory |
|---|---|---|
| `postcss` | `<8.5.18` → 8.5.24 | `<=8.5.17` vulnerable |
| `ws` (7.x line) | `<7.5.11` → 7.5.13 | `>=7.0.0 <7.5.11` |
| `brace-expansion` | `<5.0.8` → 5.0.8 | GHSA-mh99-v99m-4gvg + `>=2.0.0 <2.1.2` |

## This reverses a judgement from #171 — here is why

#171 deliberately **left the 2.x copy of `brace-expansion` alone**, on the grounds that the advisory in force then started at `>=3.0.0`, so the installed 2.1.0 was genuinely unaffected and forcing it up three majors would be churn with no security benefit. That was correct at the time.

Two new advisories supersede it. **GHSA-mh99-v99m-4gvg has a single range, `<= 5.0.7`, with 5.0.8 as its only patched version.** I checked `security_advisory.vulnerabilities[]` on the alert rather than trusting the collapsed summary field — there is no 1.x or 2.x backport. So every earlier line is affected and no 2.x pin can clear it.

The five previous per-line `brace-expansion` selectors are therefore collapsed into a single `<5.0.8` selector.

That is a three-major jump for the `minimatch@3` path, so it was checked rather than assumed:
- 5.0.8 publishes **both** ESM and CJS (`exports.require` → `dist/commonjs/index.js`), so CJS consumers still resolve.
- `engines` is `node 20 || >=22`.
- `minimatch` only ever calls `expand()`, which is unchanged.

## A bug this surfaced

The pre-existing 1.x selector targeted an **open-ended** `'>=1.1.12'`. That was resolving `minimatch@3`'s declared `^1.1.7` all the way up to **2.1.0** — a version the new advisory covers. In other words the override was actively pushing that dependency path onto a vulnerable version, and would have kept doing so.

This is the same class of trap as the `esbuild` selector in #171: pnpm matches override selectors against the **declared** range, and an unbounded replacement target then floats to whatever resolves. Consolidating removes the whole class here — the tree now carries **one** `brace-expansion` version, down from three.

## Verification

- Production `pnpm build` succeeds.
- `pnpm lint` still globs and reports across 188 files. That is the meaningful check that `minimatch`/`glob` survived the major jump: had it broken, eslint would have crashed rather than produced findings.
- Test suite reports 42 failed files / 204 failed tests — byte-identical to the baseline on `main`, tracked separately in #173.
- `pnpm install --frozen-lockfile` succeeds.

## Meta

This is the second round in a day, and the second time a version an override *targeted* later became vulnerable itself (`@hono/node-server` 2.0.5 in the mcp repo, `brace-expansion` 2.x here). Worth considering whether Dependabot's own PRs should be enabled for the lockfile so this churn is not handled by hand each time.

## Summary by Sourcery

Update dependency overrides to address newly published security advisories and consolidate vulnerable brace-expansion ranges.

Bug Fixes:
- Resolve new security advisories for brace-expansion, postcss, and ws by adjusting pnpm override ranges to patched versions.

Enhancements:
- Consolidate multiple brace-expansion override entries into a single selector that covers all affected major lines, reducing override complexity and version churn.

Build:
- Refresh pnpm lockfile and workspace overrides to align dependency tree with the latest non-vulnerable versions in the 7.x ws and 8.x postcss lines.

<!-- Generated by sourcery-ai[bot]: start fixed-security -->
- Resolves all 2 issues in [brace-expansion](https://app.sourcery.ai/dashboard/security/issues?groupId=32263008&issueIds=89888837,90829937)
- Resolves [GHSA-r28c-9q8g-f849 — PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure](https://app.sourcery.ai/dashboard/security/issues?groupId=42251953&issueIds=90554790)
- Resolves [CVE-2026-48779 — ws: Denial of Service via memory exhaustion from small WebSocket fragments](https://app.sourcery.ai/dashboard/security/issues?groupId=53832152&issueIds=70739439)
<!-- Generated by sourcery-ai[bot]: end fixed-security -->