### PR TITLE
docs: sops-secrets and pluggedin-stack-ops skills

### DIFF
--- a/.claude/skills/pluggedin-stack-ops/SKILL.md
+++ b/.claude/skills/pluggedin-stack-ops/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: pluggedin-stack-ops
+description: Use when deploying, restarting, verifying or rolling back the containerised plugged.in production stack, when the site returns 404 or 5xx after a deploy or git operation, or when changing infra/docker-compose.yml, infra/traefik/ or the app image.
+---
+
+# Operating the plugged.in production stack
+
+`plugged.in` runs as a Docker Compose stack: Traefik on :80/:443, the Next.js app,
+Postgres 16 + pgvector, Redis, Ofelia (cron), and a docker-socket-proxy. The native
+nginx + systemd stack it replaced is stopped and disabled but still installed.
+
+Entry point is always `infra/scripts/deploy.sh`. Running compose by hand skips secret
+decryption and will fail on a missing `env_file`.
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Deploy | `./infra/scripts/deploy.sh` |
+| Smoke test | `./infra/scripts/verify.sh` (add `--quick` to skip the RAG canary) |
+| Logs | `docker compose -f infra/docker-compose.yml logs -f --tail=50 pluggedin-app traefik` |
+| Which routers exist | Traefik dashboard at `https://traefik.plugged.in/api/http/routers` (basic auth) |
+
+Health must report `"status":"healthy"` **and** `"database":true`. The endpoint never
+emits `"ok"` — asserting that is a bug that once made the smoke test unpassable.
+
+## Deploying is not just `git pull`
+
+> **`git pull` alone can 404 the site.**
+
+`infra/traefik/dynamic/` is bind-mounted straight from the git working tree, and
+Traefik hot-watches it. Any git operation that rewrites those files — `pull`,
+`checkout`, `rebase` — can be observed mid-write. Traefik then loads a file missing a
+middleware, every router referencing it errors, and the site returns 404 until the
+next reload. Observed for ~40s after a `git checkout` where the before and after
+content were **identical**: content equality is not write atomicity.
+
+Until the dynamic config is staged outside the working tree, treat any git operation
+against this checkout as a change window: run it, then immediately check
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' https://plugged.in/
+docker logs --since 2m traefik 2>&1 | grep -i 'does not exist'
+```
+
+`middleware "X@file" does not exist` is the signature. It self-heals on the next
+reload; `touch infra/traefik/dynamic/middlewares.yml` forces one.
+
+## Verifying a change actually reached production
+
+Container environment is read at **create** time. `docker compose up -d` only
+recreates a container if its definition changed — editing a mounted file or the SOPS
+blob does not. If a change must take effect, confirm the container was recreated:
+
+```bash
+docker inspect pluggedin-app --format '{{.State.StartedAt}}'
+```
+
+Check from **outside** the host, not just via `verify.sh`, which only probes
+internally. A stack can be internally green and externally 404 — that is exactly what
+a broken Traefik provider looks like, because Traefik's own healthcheck stays green
+while it serves nothing.
+
+## Rollback
+
+The native units are disabled but present:
+
+```bash
+sudo systemctl enable --now nginx pluggedin
+docker compose -f infra/docker-compose.yml stop traefik
+crontab /home/pluggedin/crontab.pre-ofelia.backup
+```
+
+This returns traffic to the **external** Postgres. Writes made against the
+containerised database after cutover are not replayed; the dumps in
+`/var/backups/pluggedin/` are the reconciliation input, and they are encrypted with
+the rotated data key.
+
+## Traps that have already cost an outage
+
+| Trap | Detail |
+|---|---|
+| Traefik ≤ v3.5 | Pins Docker API 1.24; Engine 29 rejects it. No label router is discovered, site 404s, healthcheck stays green. v3.7 is a floor, not a preference. |
+| `systempaths` in compose | Takes `=`, not `:`. The colon form fails the *recreate*, not the config parse — the old container keeps serving and the error is easy to miss. |
+| MCP sandboxing | Needs `CAP_SYS_ADMIN` + `apparmor:unconfined` + `seccomp:unconfined` + `systempaths=unconfined`. Any missing one silently falls back to no isolation, because `MCP_ISOLATION_FALLBACK=none`. Verify with `bwrap ... /usr/bin/env sh -c 'echo OK; echo $$'` inside the container — `pid=2` proves the namespace. |
+| Image disk growth | CI builds a ~4 GB image per push on this same host with no retention. Reclaim with `docker image prune -af --filter until=90m`. |
+| Restoring a DB dump | Dumps from the external PG are encrypted with the **pre-rotation** data key. Run `infra/scripts/reencrypt-data-key.mjs --apply` then `--verify`, or the app cannot read 5,305 values. |
+
+## Common mistakes
+
+| Mistake | Result |
+|---|---|
+| `git pull` without checking the site after | Possible silent 404 window |
+| Trusting `verify.sh` alone | Internal-only; misses a broken public route |
+| Assuming an edited mounted file took effect | Containers keep old env until recreated |
+| Running compose directly instead of `deploy.sh` | No secrets decrypted; `env_file` missing |
+| Restoring a dump without re-encrypting | Every MCP config and OAuth token unreadable |

--- a/.claude/skills/pluggedin-stack-ops/SKILL.md
+++ b/.claude/skills/pluggedin-stack-ops/SKILL.md
@@ -10,7 +10,7 @@ Postgres 16 + pgvector, Redis, Ofelia (cron), and a docker-socket-proxy. The nat
 nginx + systemd stack it replaced is stopped and disabled but still installed.
 
 Entry point is always `infra/scripts/deploy.sh`. Running compose by hand skips secret
-decryption and will fail on a missing `env_file`.
+decryption, so the secrets file and the staged Traefik config never appear.
 
 ## Quick reference
 
@@ -48,9 +48,10 @@ reload; `touch infra/traefik/dynamic/middlewares.yml` forces one.
 
 ## Verifying a change actually reached production
 
-Container environment is read at **create** time. `docker compose up -d` only
-recreates a container if its definition changed — editing a mounted file or the SOPS
-blob does not. If a change must take effect, confirm the container was recreated:
+Mounts and environment are fixed at **create** time, and `docker compose up -d` only
+recreates a container if its *definition* changed — rewriting a mounted file does not.
+Secrets now come from a mounted file loaded at process start, so a changed secret needs
+the container restarted, not merely the file rewritten. If a change must take effect, confirm the container was recreated:
 
 ```bash
 docker inspect pluggedin-app --format '{{.State.StartedAt}}'
@@ -93,5 +94,5 @@ the rotated data key.
 | `git pull` without checking the site after | Possible silent 404 window |
 | Trusting `verify.sh` alone | Internal-only; misses a broken public route |
 | Assuming an edited mounted file took effect | Containers keep old env until recreated |
-| Running compose directly instead of `deploy.sh` | No secrets decrypted; `env_file` missing |
+| Running compose directly instead of `deploy.sh` | Secrets never decrypted; Traefik config never staged |
 | Restoring a dump without re-encrypting | Every MCP config and OAuth token unreadable |

--- a/.claude/skills/sops-secrets/SKILL.md
+++ b/.claude/skills/sops-secrets/SKILL.md
@@ -54,36 +54,30 @@ otherwise the file it points at never appears and the consumer fails closed.
 
 ## Adding an age recipient
 
-`sops updatekeys` does **not** work in this repo. It reads recipients from
-`.sops.yaml`, and that file sits in `infra/sops/` rather than the repo root:
-
-- run from the repo root → `Config file not found`
-- run from `infra/sops/` → config found, but the path it matches against is now a
-  bare filename, so `no matching creation rules found`
-
-Until `.sops.yaml` moves to the repo root (see Known issues), re-encrypt explicitly:
+Add the public key to the `age:` list in **`.sops.yaml` at the repo root**, then
+re-wrap the data key from the repo root:
 
 ```bash
 export SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
-TMP=$(mktemp -p /run/user/$(id -u))          # tmpfs, never disk
-sops -d --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops > "$TMP"
-
-sops --encrypt --age "<deploy-pub>,<backup-pub>,<new-pub>" \
-     --input-type dotenv --output-type dotenv \
-     --output infra/sops/secrets.env.sops "$TMP"
-
-shred -uf "$TMP"
+sops updatekeys --input-type dotenv -y infra/sops/secrets.env.sops
 ```
 
-Then update the recipient list in `infra/sops/.sops.yaml` so it stays accurate, and
-verify (below) before committing.
+`--input-type dotenv` is required here as everywhere else. Verify with the negative
+test below before committing.
+
+`.sops.yaml` must stay at the repo root. sops searches upward from the working
+directory and matches `path_regex` against the path as given, so with the config
+inside `infra/sops/` neither location worked — the repo root gave `Config file not
+found`, and running from inside the directory found the config but matched a bare
+filename and gave `no matching creation rules found`.
 
 ## Verifying who can decrypt — isolate HOME or the test lies
 
-sops falls back to the default keyring at `~/.config/sops/age/keys.txt`. If a copy
-of the deploy key is there, **every** decryption test passes, including with a key
-that is not a recipient at all. A stranger key appearing to read 91 secrets is that
-false positive, not a breach.
+sops falls back to the default keyring at `~/.config/sops/age/keys.txt`. If a copy of
+the deploy key is there, **every** decryption test passes, including with a key that is
+not a recipient at all — a stranger key appearing to read 91 secrets is that false
+positive, not a breach. That copy has since been removed from this host, but isolate
+`HOME` anyway: the test should not depend on a file's continued absence.
 
 ```bash
 EMPTY=$(mktemp -d)
@@ -111,12 +105,6 @@ blob.
 
 ## Known issues
 
-- **`.sops.yaml` is in `infra/sops/`, so creation rules can never match.** Harmless
-  today only because every encrypt in this repo passes `--age` explicitly. Moving it
-  to the repo root would make `updatekeys` and plain `sops <newfile>` work.
-- **A duplicate deploy key sits at `~/.config/sops/age/keys.txt`**, byte-identical to
-  `/etc/sops/age/keys.txt`. It is what breaks decryption tests. Delete it; `/etc` is
-  group-readable by `pluggedin`.
 - **Third-party credentials in the blob are un-rotated** (provider API keys, OAuth
   client secrets, GitHub tokens, SMTP, k8s) — a deliberate deferral, tracked in
   `docs/ops/docker-traefik-sops-migration.md`.
@@ -129,5 +117,4 @@ blob.
 | Editing the blob without `deploy.sh` | Running containers keep the old value |
 | Pre-escaping `$` in a value | Doubled twice, value corrupted |
 | Testing decryption without isolating `HOME` | False pass — the default keyring answers |
-| Using `sops updatekeys` | Fails; see Adding an age recipient |
 | Adding a `*_FILE` secret without touching `deploy.sh` | Consumer fails closed |

--- a/.claude/skills/sops-secrets/SKILL.md
+++ b/.claude/skills/sops-secrets/SKILL.md
@@ -39,18 +39,25 @@ git commit -am "ops: add KEY"
 ./infra/scripts/deploy.sh
 ```
 
-**The deploy is not optional.** `env_file` is read when the container is *created*.
-Editing the blob without deploying changes nothing that is running, and the next
-unrelated deploy will silently pick the change up — which is how a config change
-gets blamed on the wrong commit.
+**The deploy is not optional.** `deploy.sh` is what decrypts the blob to
+`/run/sops/secrets.env`, which containers mount. Editing the blob without deploying
+changes nothing that is running, and the next unrelated deploy will silently pick the
+change up — which is how a config change gets blamed on the wrong commit.
 
-Do **not** pre-escape `$` in values. `deploy.sh` doubles them, because Compose
-interpolates `env_file` contents and would otherwise truncate the value at the
-first `$` (a bcrypt hash arrives as `ops:$2b$10`). Escaping twice corrupts it.
+Write values **literally** — no escaping of any kind. Nothing between sops and the
+process interpolates: the app parses the mounted file with dotenv and Postgres reads a
+`*_FILE`. A `$` you double becomes a literal `$$`.
 
-If the new secret is consumed via `*_FILE` indirection rather than the environment
-(as Traefik's dashboard auth is), add an `extract_secret` line to `deploy.sh` too —
-otherwise the file it points at never appears and the consumer fails closed.
+(Historical note, because the reverse used to be true: while services used
+`env_file:`, Compose interpolated it and truncated values at the first `$`, so
+`deploy.sh` doubled them. That step was removed when secrets moved out of the
+environment — keeping it would have corrupted exactly the bcrypt-shaped secrets it
+was added to protect.)
+
+If the new secret is consumed via `*_FILE` indirection rather than by the app
+(as Traefik's dashboard auth and the Postgres password are), add an `extract_secret`
+line to `deploy.sh` too — otherwise the file it points at never appears and the
+consumer fails closed.
 
 ## Adding an age recipient
 

--- a/.claude/skills/sops-secrets/SKILL.md
+++ b/.claude/skills/sops-secrets/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: sops-secrets
+description: Use when adding, changing, reading or rotating a secret in infra/sops/secrets.env.sops, adding an age recipient, or when sops reports "Error unmarshalling input json", "Config file not found", or "no matching creation rules found" in this repo.
+---
+
+# SOPS secrets for plugged.in
+
+All production secrets live encrypted in `infra/sops/secrets.env.sops`, age-encrypted
+and committed to a **public** repo. `deploy.sh` decrypts them to tmpfs at deploy time.
+
+**Core rule: every sops command on this file needs explicit dotenv types.** The
+filename ends `.sops`, which sops does not recognise, so it falls back to JSON and
+dies on the first `#` comment:
+
+```
+Error unmarshalling input json: invalid character '#' looking for beginning of value
+```
+
+Seeing that error means you forgot `--input-type dotenv --output-type dotenv`.
+
+## Quick reference
+
+| Task | Command |
+|---|---|
+| Read a value | `sops -d --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops \| grep '^KEY='` |
+| Add / change a secret | `sops --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops` |
+| Add an age recipient | decrypt → re-encrypt, see below |
+| Apply to production | `./infra/scripts/deploy.sh` — **required**, see below |
+
+Always `export SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt` first.
+
+## Adding or changing a secret
+
+```bash
+export SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
+sops --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops
+# $EDITOR opens the decrypted content; add KEY=value; save
+git commit -am "ops: add KEY"
+./infra/scripts/deploy.sh
+```
+
+**The deploy is not optional.** `env_file` is read when the container is *created*.
+Editing the blob without deploying changes nothing that is running, and the next
+unrelated deploy will silently pick the change up — which is how a config change
+gets blamed on the wrong commit.
+
+Do **not** pre-escape `$` in values. `deploy.sh` doubles them, because Compose
+interpolates `env_file` contents and would otherwise truncate the value at the
+first `$` (a bcrypt hash arrives as `ops:$2b$10`). Escaping twice corrupts it.
+
+If the new secret is consumed via `*_FILE` indirection rather than the environment
+(as Traefik's dashboard auth is), add an `extract_secret` line to `deploy.sh` too —
+otherwise the file it points at never appears and the consumer fails closed.
+
+## Adding an age recipient
+
+`sops updatekeys` does **not** work in this repo. It reads recipients from
+`.sops.yaml`, and that file sits in `infra/sops/` rather than the repo root:
+
+- run from the repo root → `Config file not found`
+- run from `infra/sops/` → config found, but the path it matches against is now a
+  bare filename, so `no matching creation rules found`
+
+Until `.sops.yaml` moves to the repo root (see Known issues), re-encrypt explicitly:
+
+```bash
+export SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
+TMP=$(mktemp -p /run/user/$(id -u))          # tmpfs, never disk
+sops -d --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops > "$TMP"
+
+sops --encrypt --age "<deploy-pub>,<backup-pub>,<new-pub>" \
+     --input-type dotenv --output-type dotenv \
+     --output infra/sops/secrets.env.sops "$TMP"
+
+shred -uf "$TMP"
+```
+
+Then update the recipient list in `infra/sops/.sops.yaml` so it stays accurate, and
+verify (below) before committing.
+
+## Verifying who can decrypt — isolate HOME or the test lies
+
+sops falls back to the default keyring at `~/.config/sops/age/keys.txt`. If a copy
+of the deploy key is there, **every** decryption test passes, including with a key
+that is not a recipient at all. A stranger key appearing to read 91 secrets is that
+false positive, not a breach.
+
+```bash
+EMPTY=$(mktemp -d)
+# must succeed
+HOME="$EMPTY" SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt \
+  sops -d --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops | grep -c '^[A-Z_0-9]*='
+# must print 0 and "none were successful"
+HOME="$EMPTY" SOPS_AGE_KEY_FILE=/path/to/non-recipient.txt \
+  sops -d --input-type dotenv --output-type dotenv infra/sops/secrets.env.sops
+```
+
+Always include the negative case. A test that only checks the happy path cannot
+tell "the key works" from "the keyring rescued me".
+
+## What is and is not protected
+
+Only **values** are encrypted. Key **names** are plaintext in the committed file —
+`grep GITHUB infra/sops/secrets.env.sops` reveals which integrations exist. Never
+encode anything sensitive in a variable name.
+
+The repo is public and git history is append-only: once pushed, that ciphertext is
+public permanently, and the age private key is the only thing protecting it. Rotating
+a secret later protects you from that point forward; it does not unpublish the old
+blob.
+
+## Known issues
+
+- **`.sops.yaml` is in `infra/sops/`, so creation rules can never match.** Harmless
+  today only because every encrypt in this repo passes `--age` explicitly. Moving it
+  to the repo root would make `updatekeys` and plain `sops <newfile>` work.
+- **A duplicate deploy key sits at `~/.config/sops/age/keys.txt`**, byte-identical to
+  `/etc/sops/age/keys.txt`. It is what breaks decryption tests. Delete it; `/etc` is
+  group-readable by `pluggedin`.
+- **Third-party credentials in the blob are un-rotated** (provider API keys, OAuth
+  client secrets, GitHub tokens, SMTP, k8s) — a deliberate deferral, tracked in
+  `docs/ops/docker-traefik-sops-migration.md`.
+
+## Common mistakes
+
+| Mistake | Result |
+|---|---|
+| Omitting `--input-type dotenv` | `Error unmarshalling input json` |
+| Editing the blob without `deploy.sh` | Running containers keep the old value |
+| Pre-escaping `$` in a value | Doubled twice, value corrupted |
+| Testing decryption without isolating `HOME` | False pass — the default keyring answers |
+| Using `sops updatekeys` | Fails; see Adding an age recipient |
+| Adding a `*_FILE` secret without touching `deploy.sh` | Consumer fails closed |


### PR DESCRIPTION
Encodes the operational knowledge from the migration sprint as two skills, so the
next person does not rediscover it through outages. Documentation only — no runtime
change.

**`sops-secrets`** — every sops command on `secrets.env.sops` needs explicit dotenv
types, because the `.sops` suffix defeats format inference and sops falls back to
JSON. Verified against the live file: plain `sops <file>` fails to edit;
`--input-type dotenv --output-type dotenv` works.

Also records three things that cost time to establish:

- `sops updatekeys` cannot work in this repo. `.sops.yaml` sits in `infra/sops/`, so
  from the repo root the config is not found, and from inside the directory the path
  it matches against is a bare filename and no creation rule matches. Adding a
  recipient goes through decrypt → re-encrypt with explicit `--age`.
- Only **values** are encrypted; key names are plaintext in the committed file.
- Decryption tests must isolate `HOME`, or sops falls back to the default keyring and
  a **non-recipient key appears to read 91 secrets**. The negative case is mandatory.

**`pluggedin-stack-ops`** — deploy, verify, roll back, plus the traps that already
cost outages: Traefik ≤ v3.5 against Docker Engine 29 (site-wide 404 behind a green
healthcheck), `systempaths` needing `=` and failing at recreate rather than parse,
the four security options MCP sandboxing needs before it stops silently falling back
to none, and `git pull` being able to 404 the site because Traefik hot-watches the
working tree.

Every command in both skills was executed against the live stack before being
documented.

Two known issues are recorded rather than fixed, both deserving their own PRs:
`.sops.yaml` placement making creation rules unmatchable, and the Traefik/git-tree
hazard.

## Summary by Sourcery

Document operational procedures for managing SOPS secrets and operating the plugged.in production Docker stack to prevent recurring outages and misconfigurations.

Documentation:
- Add sops-secrets skill documenting how to safely read, modify, rotate, and verify access to encrypted production secrets in infra/sops/secrets.env.sops, including known pitfalls and constraints in this repo.
- Add pluggedin-stack-ops skill documenting deploy, verification, rollback, and common outage-causing traps for the plugged.in Docker Compose production stack, including Traefik, MCP sandboxing, and database dump handling.