### PR TITLE
infra: close the four open hardening items from the migration

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -17,6 +17,14 @@ creation_rules:
   # earlier version anchored on `\.(env|yaml)$`, which silently matched
   # nothing, so newly created files fell through to sops' "no matching
   # creation rule" error.
+  #
+  # This file must live at the REPO ROOT, not in infra/sops/. sops searches
+  # for .sops.yaml upward from the working directory, and matches path_regex
+  # against the path as given. With the config inside infra/sops/, neither
+  # location worked: from the repo root sops reported "Config file not
+  # found", and from inside the directory it found the config but matched
+  # against a bare filename and reported "no matching creation rules found".
+  # `sops updatekeys` was unusable either way.
   - path_regex: infra/sops/.*\.(env|yaml|yml|json)\.sops$
     encrypted_regex: "^(.*)$"
     # Generated at Phase 0 (2026-07-31). Public recipients only — safe to

--- a/infra/README.md
+++ b/infra/README.md
@@ -50,7 +50,7 @@ sudo dpkg -i /tmp/sops.deb
 sudo mkdir -p /etc/sops/age
 sudo age-keygen -o /etc/sops/age/keys.txt
 sudo chmod 0400 /etc/sops/age/keys.txt
-# Add the public key (`age1...`) to infra/sops/.sops.yaml
+# Add the public key (`age1...`) to .sops.yaml at the repo root
 # BACK UP THE PRIVATE KEY OFFLINE.
 
 # UID/GID alignment for bind-mounted host dirs: nothing to do.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -4,8 +4,9 @@
 #   infra/scripts/deploy.sh
 # which decrypts infra/sops/secrets.env.sops into /run/sops/secrets.env
 # (tmpfs) and exports IMAGE_TAG before invoking compose. Running compose
-# by hand without the wrapper will fail because env_file points at the
-# decrypted file.
+# by hand without the wrapper will fail: the secrets file and the staged
+# Traefik dynamic config both live under /run/sops and are produced by
+# deploy.sh.
 #
 # Single host, single app instance. Traefik is the only thing bound to
 # host ports 80/443. Routing rules and per-route middlewares live in
@@ -20,10 +21,22 @@
 
 x-app-environment: &app-env
   NODE_ENV: production
+  # Secrets are NOT in this container's environment. They are mounted as a
+  # file and loaded into the Node process at startup instead, because
+  # anything in `environment:`/`env_file:` lands in Docker's Config.Env and
+  # is readable by anything that can reach the Docker API — which includes
+  # Traefik through the socket proxy, since the docker provider needs
+  # container inspect to read routing labels.
+  #
+  # NODE_OPTIONS applies to every node process in the image, so `server.js`,
+  # `drizzle-kit migrate` and the re-encryption script all get the secrets
+  # without each invocation having to remember a flag.
+  NODE_OPTIONS: "-r dotenv/config"
+  DOTENV_CONFIG_PATH: /run/secrets/app.env
   # The bug class that triggered the docker migration: ZVEC_DATA_PATH
   # was not propagating from workspace .env into the standalone build.
-  # In the container env_file is the single source of truth, but we
-  # still set ZVEC_DATA_PATH here so the value is visible in
+  # In the container the mounted secrets file is the single source of
+  # truth, but we still set ZVEC_DATA_PATH here so the value is visible in
   # `docker compose config` and impossible to forget on a fresh deploy.
   ZVEC_DATA_PATH: /app/data/vectors
   ZVEC_ALLOW_EXTERNAL_PATH: "false"
@@ -142,11 +155,12 @@ services:
     restart: always
     container_name: pluggedin-app
     hostname: pluggedin-app
-    env_file:
-      - /run/sops/secrets.env
     environment:
       <<: *app-env
     volumes:
+      # The decrypted secrets, as a file rather than environment. See the
+      # NODE_OPTIONS note in x-app-environment above.
+      - /run/sops/secrets.env:/run/secrets/app.env:ro
       - /home/pluggedin/zvec-data:/app/data/vectors:rw
       - /home/pluggedin/uploads:/app/uploads:rw
       - /var/mcp-packages:/app/.cache/mcp-packages:rw
@@ -265,14 +279,17 @@ services:
     image: pgvector/pgvector:pg16
     restart: always
     container_name: postgres
-    env_file:
-      - /run/sops/secrets.env
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-v220_prod}
       POSTGRES_USER: ${POSTGRES_USER:-pluggedin}
-      # POSTGRES_PASSWORD comes from secrets.env via env_file.
+      # _FILE indirection keeps the password out of Config.Env. The official
+      # image reads it only when initialising a fresh data directory, so on
+      # an existing volume this is inert — but disaster recovery restores
+      # into an empty volume, which is exactly when it matters.
+      POSTGRES_PASSWORD_FILE: /run/secrets/pg_password
       PGDATA: /var/lib/postgresql/data/pgdata
     volumes:
+      - /run/sops/pg-password:/run/secrets/pg_password:ro
       - pgdata:/var/lib/postgresql/data
       - ./postgres/init.sql:/docker-entrypoint-initdb.d/00-init.sql:ro
     networks:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -65,8 +65,11 @@ services:
       - "${TRAEFIK_HTTP_PORT:-80}:80"
       - "${TRAEFIK_HTTPS_PORT:-443}:443"
     volumes:
+      # traefik.yml is static config, read once at start and never watched,
+      # so mounting it from the working tree is safe. The dynamic directory
+      # is NOT mounted here — it is staged into /run/sops/traefik-dynamic by
+      # deploy.sh, out of reach of git. See providers.file in traefik.yml.
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./traefik/dynamic:/etc/traefik/dynamic:ro
       - traefik-acme:/letsencrypt
       - /run/sops:/run/sops:ro
       # No docker.sock here any more — router discovery goes through

--- a/infra/ofelia/config.ini
+++ b/infra/ofelia/config.ini
@@ -5,11 +5,23 @@
 #   - job-run:  runs a one-shot container (we don't use this; the existing
 #               cron scripts all hit the live app).
 #
-# CRON_SECRET is resolved inside the *target* container (pluggedin-app), not
-# inside ofelia itself: job-exec spawns the shell with `docker exec`, so the
-# expansion happens against pluggedin-app's environment, which already has
-# CRON_SECRET via env_file: /run/sops/secrets.env. Ofelia therefore needs no
-# access to the SOPS directory.
+# Two authentication styles, because the routes genuinely differ — verified
+# against app/api/*/route.ts, not assumed:
+#   x-cron-secret:          /api/memory/{process,cbp,decay}
+#   Authorization: Bearer:  /api/oauth/{refresh-tokens,cleanup-pkce},
+#                           /api/emails/process-scheduled,
+#                           /api/clipboard/cleanup
+# All four Bearer routes were being sent x-cron-secret and had been returning
+# 401 since cutover, unnoticed because nothing reads Ofelia's logs. The
+# cleanup-pkce job was additionally pointed at /api/oauth/pkce-cleanup, which
+# does not exist — the real route transposes the words.
+#
+# Each job reads CRON_SECRET out of /run/secrets/app.env inside pluggedin-app
+# rather than from its environment. Secrets are no longer in the container's
+# environment at all — they are mounted as a file so they stay out of Docker's
+# Config.Env — and `docker exec` spawns a fresh process that inherits the
+# CONTAINER's environment, not the Node process's, so it would never see a
+# value loaded by dotenv. Ofelia still needs no access to the SOPS directory.
 
 [global]
 save-folder = /var/log/ofelia
@@ -18,40 +30,40 @@ save-folder = /var/log/ofelia
 [job-exec "memory-process"]
 schedule = @every 15m
 container = pluggedin-app
-command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/process"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CS\" --post-data='' http://127.0.0.1:3000/api/memory/process"
 
 # ─── Memory CBP promotion (daily at 03:00) ─────────────────────────
 [job-exec "memory-cbp"]
 schedule = 0 0 3 * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/cbp"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CS\" --post-data='' http://127.0.0.1:3000/api/memory/cbp"
 
 # ─── Memory decay (daily at 04:00) ─────────────────────────────────
 [job-exec "memory-decay"]
 schedule = 0 0 4 * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/memory/decay"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header='Content-Type: application/json' --header=\"x-cron-secret: $CS\" --post-data='' http://127.0.0.1:3000/api/memory/decay"
 
 # ─── OAuth token refresh (every 10 min) ────────────────────────────
 [job-exec "oauth-refresh"]
 schedule = @every 10m
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/refresh-tokens"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header=\"Authorization: Bearer $CS\" --post-data='' http://127.0.0.1:3000/api/oauth/refresh-tokens"
 
 # ─── OAuth 2.1 PKCE state cleanup (every 10 min) ───────────────────
 [job-exec "pkce-cleanup"]
 schedule = @every 10m
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/oauth/pkce-cleanup"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header=\"Authorization: Bearer $CS\" --post-data='' http://127.0.0.1:3000/api/oauth/cleanup-pkce"
 
 # ─── Scheduled emails (every hour) ─────────────────────────────────
 [job-exec "process-emails"]
 schedule = 0 0 * * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/emails/process-scheduled"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header=\"Authorization: Bearer $CS\" --post-data='' http://127.0.0.1:3000/api/emails/process-scheduled"
 
 # ─── Clipboard cleanup (every hour) ────────────────────────────────
 [job-exec "clipboard-cleanup"]
 schedule = 0 0 * * * *
 container = pluggedin-app
-command = sh -c "wget -q -O- --header=\"x-cron-secret: $CRON_SECRET\" --post-data='' http://127.0.0.1:3000/api/clipboard/cleanup"
+command = sh -c "CS=$(grep '^CRON_SECRET=' /run/secrets/app.env | cut -d= -f2-); wget -q -O- --header=\"Authorization: Bearer $CS\" --post-data='' http://127.0.0.1:3000/api/clipboard/cleanup"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -104,6 +104,32 @@ sed 's/\$/$$/g' "$SECRETS_RAW" > "$SECRETS_DECRYPTED"
 chmod 0400 "$SECRETS_DECRYPTED"
 shred -uf "$SECRETS_RAW" 2>/dev/null || rm -f "$SECRETS_RAW"
 
+# 3c. Stage Traefik's dynamic config into tmpfs, out of reach of git.
+#     Traefik watches this directory and reloads on any change. When it was
+#     bind-mounted from the working tree, `git pull` — which the documented
+#     deploy runs immediately before this script — could be observed
+#     mid-write: Traefik loaded a file missing a middleware, every router
+#     referencing it errored, and the site 404'd until the next reload.
+#
+#     Copy to a temp name then rename. rename(2) within a directory is
+#     atomic, so the watcher only ever sees a complete file; without it we
+#     would just move the same race here.
+log "staging traefik dynamic config"
+TRAEFIK_DYNAMIC_DIR="${RUNTIME_DIR}/traefik-dynamic"
+mkdir -p "$TRAEFIK_DYNAMIC_DIR"
+chmod 0755 "$TRAEFIK_DYNAMIC_DIR"
+staged=0
+for src in "${INFRA_DIR}"/traefik/dynamic/*.yml; do
+  [ -f "$src" ] || continue
+  base="$(basename "$src")"
+  cp "$src" "${TRAEFIK_DYNAMIC_DIR}/.${base}.tmp"
+  chmod 0444 "${TRAEFIK_DYNAMIC_DIR}/.${base}.tmp"
+  mv -f "${TRAEFIK_DYNAMIC_DIR}/.${base}.tmp" "${TRAEFIK_DYNAMIC_DIR}/${base}"
+  staged=$((staged + 1))
+done
+[ "$staged" -gt 0 ] || die "no dynamic config staged — Traefik would start with no middlewares"
+log "staged ${staged} dynamic config file(s)"
+
 # 4. Pull image (skip with --no-pull)
 if [ "$PULL" -eq 1 ]; then
   log "pulling images"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -54,17 +54,18 @@ command -v docker >/dev/null || die "docker not installed"
 #    isn't root for the deploy.
 mkdir -p "$RUNTIME_DIR"
 chmod 0700 "$RUNTIME_DIR"
-trap 'shred -uf "$SECRETS_DECRYPTED" "${RUNTIME_DIR}/.secrets.raw" 2>/dev/null || rm -f "$SECRETS_DECRYPTED" "${RUNTIME_DIR}/.secrets.raw"' EXIT
+# The decrypted secrets outlive this script: containers mount the file for
+# the lifetime of the stack, so it must NOT be shredded on exit. It lives on
+# tmpfs and is mode 0400.
 
 # 3. Decrypt.
 #    --input-type/--output-type are mandatory here: sops infers format from
 #    the file extension, and `.sops` is not a format it knows, so it falls
 #    back to JSON and dies on the first `#` comment in the dotenv payload.
 log "decrypting secrets"
-SECRETS_RAW="${RUNTIME_DIR}/.secrets.raw"
 sops --decrypt --input-type dotenv --output-type dotenv \
-  "$SECRETS_ENCRYPTED" > "$SECRETS_RAW"
-chmod 0400 "$SECRETS_RAW"
+  "$SECRETS_ENCRYPTED" > "$SECRETS_DECRYPTED"
+chmod 0400 "$SECRETS_DECRYPTED"
 
 # 3a. Project specific secrets out of the env file into single-line files
 #     under /run/sops/, because Traefik and a few other services consume
@@ -75,7 +76,7 @@ extract_secret() {
   local key="$1" dest="${RUNTIME_DIR}/$2"
   # shellcheck disable=SC2002  # explicit cat keeps the awk pipeline simple
   local value
-  value=$(grep -E "^${key}=" "$SECRETS_RAW" | head -1 | cut -d= -f2- | sed -E 's/^"//; s/"$//')
+  value=$(grep -E "^${key}=" "$SECRETS_DECRYPTED" | head -1 | cut -d= -f2- | sed -E 's/^"//; s/"$//')
   if [ -z "$value" ]; then
     log "WARN: ${key} missing from secrets.env (skipping ${dest})"
     return
@@ -85,24 +86,19 @@ extract_secret() {
 }
 
 extract_secret TRAEFIK_DASHBOARD_AUTH traefik-users
+# Postgres reads POSTGRES_PASSWORD_FILE instead of an environment variable,
+# so the password never appears in Config.Env.
+extract_secret POSTGRES_PASSWORD pg-password
 # traefik/dynamic/middlewares.yml references this file directly via
 # `usersFile:`. No rewriting of committed files at deploy time. Traefik's
 # TLS issuance uses HTTP-01, so no DNS-provider token needs extracting.
 
-# 3b. Escape `$` for Compose.
-#     Compose runs variable interpolation over env_file contents, so a value
-#     containing `$` is silently truncated at the `$`: a bcrypt hash
-#     `ops:$2b$10$abc...` reaches the container as `ops:$2b$10`. It warns
-#     ("variable is not set") but exits 0, and the corrupted value only
-#     surfaces as an auth failure at runtime. Doubling `$` makes Compose
-#     emit a literal one.
-#
-#     This runs AFTER extract_secret, which must see the raw value — the
-#     htpasswd file Traefik reads is consumed directly, not through Compose.
-log "escaping \$ for compose interpolation"
-sed 's/\$/$$/g' "$SECRETS_RAW" > "$SECRETS_DECRYPTED"
-chmod 0400 "$SECRETS_DECRYPTED"
-shred -uf "$SECRETS_RAW" 2>/dev/null || rm -f "$SECRETS_RAW"
+# NOTE: there is deliberately no `$`-escaping step here any more.
+#     While services used `env_file:`, Compose interpolated the file and
+#     truncated any value at its first `$`, so deploy.sh doubled them. No
+#     service uses env_file now — the app parses the mounted file with dotenv
+#     and Postgres reads a *_FILE — and neither interpolates. Re-introducing
+#     the escaping would hand both of them literal `$$`.
 
 # 3c. Stage Traefik's dynamic config into tmpfs, out of reach of git.
 #     Traefik watches this directory and reloads on any change. When it was

--- a/infra/traefik/traefik.yml
+++ b/infra/traefik/traefik.yml
@@ -62,7 +62,18 @@ entryPoints:
 
 providers:
   file:
-    directory: /etc/traefik/dynamic
+    # Deliberately NOT /etc/traefik/dynamic bind-mounted from the git working
+    # tree. `watch: true` means any rewrite of those files is picked up
+    # immediately — including a rewrite by `git pull` or `git checkout`, which
+    # the documented deploy performs on every release. Observed: a checkout
+    # where the before and after content were byte-identical still 404'd the
+    # site for ~40s, because the watcher read the file mid-write, found no
+    # `compress` middleware, and every router referencing it failed. Content
+    # equality is not write atomicity.
+    #
+    # deploy.sh now stages this directory into tmpfs with atomic renames, so
+    # git never touches what Traefik reads and a partial file is unobservable.
+    directory: /run/sops/traefik-dynamic
     watch: true
   docker:
     # docker-socket-proxy, not the raw socket. Mounting /var/run/docker.sock


### PR DESCRIPTION
Closes the four items left open after #177. All applied to the live stack and
verified there; the site stayed up throughout.

## Secrets are no longer in container environment

`environment:`/`env_file:` land in Docker's `Config.Env`, readable by anything
that reaches the Docker API — including Traefik via the socket proxy, since the
docker provider needs container inspect for routing labels. #177 closed
host-root escalation but not this.

The app now loads a mounted file (`NODE_OPTIONS=-r dotenv/config`, so
`server.js`, `drizzle-kit` and the re-encryption script all get it without each
call site remembering a flag). Postgres uses `POSTGRES_PASSWORD_FILE`.

Measured live: **108 → 19 env vars, 28 secret-bearing → 0**, while the process
still has all 111.

Also removed the `$`-escaping step. It existed for Compose's env_file
interpolation; with env_file gone, keeping it would have handed dotenv literal
`$$` — silently corrupting exactly the bcrypt-shaped secrets it was added to
protect. Verified dotenv parses all 91 keys byte-identically.

## Two pre-existing cron faults, silent since cutover

Auditing Ofelia (it can no longer read the env, since `docker exec` inherits
the *container's* env, not the Node process's) surfaced two unrelated bugs:

- **four of seven jobs** sent `x-cron-secret` to routes checking
  `Authorization: Bearer` → 401 since cutover
- the PKCE job called `/api/oauth/pkce-cleanup`; the route is
  `/api/oauth/cleanup-pkce` → 404

Fixed against what `app/api/*/route.ts` actually checks. All seven verified:
200 with the real secret, 401/403 with a wrong one — the control proves auth is
enforced, not that the endpoint is open.

## Traefik no longer watches the git working tree

`git pull` rewriting `infra/traefik/dynamic/` could be observed mid-write; a
`checkout` with byte-identical content still 404'd the site for ~40s. Content
equality is not write atomicity. `deploy.sh` now stages the directory into
tmpfs with atomic renames, and fails closed if it stages nothing.

Verified: six consecutive git rewrites of `middlewares.yml` → zero reloads,
zero errors, 200 on every probe.

## `.sops.yaml` moved to the repo root

sops matches `path_regex` against the path as given and searches upward from
the working directory. Inside `infra/sops/`, neither location worked — repo
root gave `Config file not found`, inside the directory gave `no matching
creation rules found`. `sops updatekeys` was unusable, which is the supported
way to add an age recipient. Verified after the move: updatekeys adds a
recipient, that recipient reads all 91 keys, a non-recipient reads none — both
with `HOME` isolated so the default keyring cannot mask the result.

## Key custody

The duplicate deploy key and the backup key under `~/.config/sops/age/` are
shredded; operator confirmed a cold copy of the backup key. Side effect: the
default-keyring false positive is gone, so decryption tests are now honest
without needing `HOME` isolation.

---

Local pre-validation: shellcheck, `compose config`, Traefik config parse,
Ofelia INI parse and `assert_compose_ports.py` all pass.

## Summary by Sourcery

Harden production infrastructure by removing container-level secrets, stabilizing Traefik’s dynamic config, fixing cron job authentication and endpoints, and making sops key management usable and consistent.

Bug Fixes:
- Correct Ofelia cron jobs to use the expected authentication scheme per route and point the PKCE cleanup job at the existing /api/oauth/cleanup-pkce endpoint.

Enhancements:
- Load application secrets from a mounted dotenv file via NODE_OPTIONS instead of Docker environment/env_file, keeping secrets out of Docker’s Config.Env while preserving shared access for all Node entrypoints.
- Switch Postgres to POSTGRES_PASSWORD_FILE backed by a mounted secret file so database credentials no longer appear in container environment metadata.
- Stage Traefik’s dynamic configuration into a tmpfs directory with atomic renames, decoupling it from the git working tree and preventing partial reads during deploy-time git operations.
- Relocate .sops.yaml from infra/sops/ to the repository root so sops creation rules and updatekeys work reliably across the infra paths.

Deployment:
- Adjust deploy.sh to decrypt secrets directly into the long-lived tmpfs file used by containers, drop legacy $-escaping for compose interpolation, and stage Traefik dynamic config into /run/sops/traefik-dynamic before starting the stack.

Documentation:
- Update infra README to point age public keys at the root-level .sops.yaml for key management.