### PR TITLE
docs: fix three checks in the hosted-connector deploy doc

### DIFF
--- a/docs/ops/hosted-connector-deploy-checks.md
+++ b/docs/ops/hosted-connector-deploy-checks.md
@@ -23,8 +23,15 @@ cosmetic.**
 | `0100_known_prowler` | Makes `(issuer, client_id)` a **unique** index | Duplicate client rows become possible, and a duplicate can revoke a legitimate client's whole token family |
 
 ```bash
-pnpm db:migrate
+docker compose -f infra/docker-compose.yml run --rm pluggedin-app \
+  node_modules/.bin/drizzle-kit migrate
 ```
+
+`pnpm` is deliberately absent from the runtime image — it shipped as a dangling
+symlink and aborted a cutover mid-window, so the migration path now invokes
+`drizzle-kit` directly. `pnpm db:migrate` on the host would also target the
+wrong database: the app's Postgres is the containerised one, not whatever the
+host shell resolves.
 
 Then confirm, rather than assuming the command's exit code told the truth:
 
@@ -98,9 +105,14 @@ test "$(curl -s "$BASE/.well-known/oauth-protected-resource" | jq -r .resource)"
 Check it and move on:
 
 ```bash
-curl -si "$BASE/api/mcp" | head -10
-#  expect: HTTP/1.1 401, and no WWW-Authenticate line
+curl -si -X POST "$BASE/api/mcp" -H 'Content-Type: application/json' -d '{}' | head -10
+#  expect: HTTP/2 401, and no WWW-Authenticate line
 ```
+
+**Use POST.** A GET returns `400 {"error":"Missing Mcp-Session-Id header"}`,
+which is the session check firing before authentication is ever reached — a
+different failure that looks like a broken deploy. Verified against production:
+GET → 400, POST → 401.
 
 That route still authenticates with a NextAuth session cookie; it predates this
 work. `buildUnauthorizedResponse()` and `authenticateConnectorRequest()` shipped
@@ -192,12 +204,20 @@ a made-up refresh token and a real one belonging to another client. Both must
 return the identical message. Different wording is an oracle for sorting stolen
 tokens.
 
-**The token endpoint takes form encoding, not JSON.** A JSON body returns 415,
-which reads like an outage rather than a content-type mistake:
+**The token endpoint takes form encoding, not JSON.** A JSON body returns
+`400` naming the problem outright:
 
 ```bash
 curl -si -X POST "$BASE/api/oauth/token" -H 'Content-Type: application/json' -d '{}' | head -3
+#  expect: HTTP/2 400
+#  body:   {"error":"invalid_request",
+#           "error_description":"Body must be application/x-www-form-urlencoded"}
 ```
+
+An earlier version of this section said 415, and warned the response "reads
+like an outage rather than a content-type mistake". Neither holds: the status
+is 400 and the body states the exact cause. Left in as a check because it is
+still worth knowing the endpoint refuses JSON — just not as a trap.
 
 ---
 


### PR DESCRIPTION
Worked [`docs/ops/hosted-connector-deploy-checks.md`](https://github.com/VeriTeknik/pluggedin-app/blob/main/docs/ops/hosted-connector-deploy-checks.md) top to bottom against production after deploying #175/#176.

**It holds up well.** §0's insistence on confirming migrations with SQL rather than trusting an exit code is the right instinct, and every one of those assertions passed:

| Check | Result |
|---|---|
| `family_id` uuid NOT NULL | ✅ `family_id \| uuid \| NO` |
| `oauth_clients_issuer_client_id_idx` unique | ✅ `indisunique = t` |
| `client_id_metadata_document_supported` | ✅ `true` |
| `none` in `token_endpoint_auth_methods_supported` | ✅ |
| `code_challenge_methods_supported` | ✅ `["S256"]` |
| `issuer` byte-equal to `$BASE` | ✅ |
| `resource` = `$BASE/api/mcp` | ✅ match |
| 401 carries no `WWW-Authenticate` | ✅ (Phase B pending, as documented) |

Three things did not.

**§2 — the command is a GET.** `curl -si "$BASE/api/mcp"` returns `400 {"error":"Missing Mcp-Session-Id header"}`; the session check fires before authentication is reached. Only POST returns the documented 401. The section warns this is *"the single most likely thing to be misread"* — and the command it supplied was the cause. Verified: GET → 400, POST → 401.

**§4 — the 415 claim.** A JSON body returns **400**, not 415, with `{"error":"invalid_request","error_description":"Body must be application/x-www-form-urlencoded"}`. So the framing is also wrong: the response names the exact cause rather than "reading like an outage". Kept as a check, reframed.

**§0 — `pnpm db:migrate` no longer works here.** pnpm is deliberately absent from the runtime image; it shipped as a dangling symlink and aborted a cutover mid-window, which is why the migration path calls `drizzle-kit` directly now. Running it on the host would also hit the wrong database.

Every replacement command was executed as written before committing.

**Not verified, deliberately left alone:** the consent-screen walkthrough (§3) and the single-use-code / refresh-replay / wrong-client controls (§4). Those need a real authorization flow, not probes against production.

## Summary by Sourcery

Update hosted connector deployment checks documentation to reflect current migration commands and HTTP behaviors observed in production.

Documentation:
- Document the correct container-based database migration command using drizzle-kit instead of pnpm.
- Clarify that the MCP route check must use POST to yield a 401 without WWW-Authenticate, and explain the misleading GET behavior.
- Correct the token endpoint JSON request behavior to return 400 with a descriptive error instead of 415, reframing the check accordingly.