### PR TITLE
feat(mcp): serve the hosted connector from /api/mcp (Phase B)

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -23,10 +23,6 @@ export async function POST(req: NextRequest) {
     // Get the session ID from headers
     const sessionId = req.headers.get('Mcp-Session-Id');
 
-    // Parse the request body once: both paths below need it, and a Request
-    // body can only be read a single time.
-    const body = await req.json();
-
     // Two callers reach this endpoint and they authenticate differently.
     //
     // A bearer token means the hosted connector: MCP 2026-07-28, stateless, no
@@ -38,7 +34,22 @@ export async function POST(req: NextRequest) {
     // calls the session path today and the proxy uses /api/mcp-servers, but
     // "no caller I can find" is not "no caller", and deleting a live endpoint
     // to save one conditional is a poor trade.
+    //
+    // Credential first, body second. Parsing up front is tidier to read and
+    // wrong: a malformed or absent body would throw before the branch, and an
+    // unauthenticated caller would get a 500 instead of the challenge — so a
+    // client whose first probe is empty never learns where to authenticate,
+    // which is the failure this endpoint exists to avoid.
     if (req.headers.get('authorization')?.startsWith('Bearer ')) {
+      let body: unknown;
+      try {
+        body = await req.json();
+      } catch {
+        return NextResponse.json(
+          { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
+          { status: 400 }
+        );
+      }
       return handleConnectorRequest(req, body);
     }
 
@@ -52,6 +63,8 @@ export async function POST(req: NextRequest) {
         `${(process.env.NEXTAUTH_URL ?? '').replace(/\/+$/, '')}/.well-known/oauth-protected-resource`
       );
     }
+
+    const body = await req.json();
 
     // Handle the Streamable HTTP request
     const result = await handleStreamableHTTPRequest({

--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -2,8 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 
 import { authOptions } from '@/lib/auth';
+import { handleConnectorRequest } from '@/lib/mcp/connector/handle-request';
 import { getSessionManager } from '@/lib/mcp/sessions/SessionManager';
 import { handleStreamableHTTPRequest } from '@/lib/mcp/streamable-http/handler';
+import { buildUnauthorizedResponse } from '@/lib/oauth/provider/authenticate';
 import { getCorsHeaders, handleCorsOptions } from '@/lib/security/cors';
 import { createSecureErrorResponse, ErrorCode } from '@/lib/security/error-handler';
 
@@ -20,19 +22,37 @@ export async function POST(req: NextRequest) {
   try {
     // Get the session ID from headers
     const sessionId = req.headers.get('Mcp-Session-Id');
-    
+
+    // Parse the request body once: both paths below need it, and a Request
+    // body can only be read a single time.
+    const body = await req.json();
+
+    // Two callers reach this endpoint and they authenticate differently.
+    //
+    // A bearer token means the hosted connector: MCP 2026-07-28, stateless, no
+    // Mcp-Session-Id, authorized by an OAuth access token. A cookie means the
+    // older session-based streamable transport, kept working until the local
+    // proxy is retired.
+    //
+    // Branching rather than rewriting is deliberate. Nothing in this repository
+    // calls the session path today and the proxy uses /api/mcp-servers, but
+    // "no caller I can find" is not "no caller", and deleting a live endpoint
+    // to save one conditional is a poor trade.
+    if (req.headers.get('authorization')?.startsWith('Bearer ')) {
+      return handleConnectorRequest(req, body);
+    }
+
     // Get user session for authentication
     const session = await getServerSession(authOptions);
     if (!session?.user?.id) {
-      return NextResponse.json(
-        { error: 'Unauthorized' },
-        { status: 401 }
+      // Neither credential. Answer with the connector's challenge rather than a
+      // bare 401: the WWW-Authenticate header is how Claude learns where the
+      // authorization server is, and it is ignored on any status but 401.
+      return buildUnauthorizedResponse(
+        `${(process.env.NEXTAUTH_URL ?? '').replace(/\/+$/, '')}/.well-known/oauth-protected-resource`
       );
     }
 
-    // Parse the request body
-    const body = await req.json();
-    
     // Handle the Streamable HTTP request
     const result = await handleStreamableHTTPRequest({
       method: 'POST',

--- a/lib/mcp/connector/dispatch.ts
+++ b/lib/mcp/connector/dispatch.ts
@@ -75,11 +75,15 @@ export async function dispatchAuthenticated(
 
       const definition = findTool(name);
       const required = requiredScopeFor(name);
-      const handler = TOOL_HANDLERS[name];
+      const handler = Object.hasOwn(TOOL_HANDLERS, name) ? TOOL_HANDLERS[name] : undefined;
 
       // All three must agree. A tool defined but unmapped, or mapped but
       // scopeless, is a wiring mistake — and answering "unknown tool" for it is
       // better than reaching a handler no scope guards.
+      //
+      // Both lookups are own-property only, because `name` is attacker-supplied
+      // and these are object literals: TOOL_HANDLERS['constructor'] would
+      // otherwise resolve to Object and be called as a handler.
       if (!definition || !required || !handler) {
         return { kind: 'error', code: JSONRPC.METHOD_NOT_FOUND, message: `Unknown tool: ${name}` };
       }

--- a/lib/mcp/connector/dispatch.ts
+++ b/lib/mcp/connector/dispatch.ts
@@ -1,0 +1,121 @@
+/**
+ * Method → handler routing for the hosted connector.
+ *
+ * Two things are load-bearing here and easy to get subtly wrong:
+ *
+ * `server/discover` answers *before* authentication, because it is the
+ * negotiation — a client that cannot discover what we speak has no route to
+ * authenticating. It carries no user data.
+ *
+ * Every other method authenticates first, and `tools/call` additionally checks
+ * the tool's required scope against the token. The scope check is a second gate
+ * behind consent, not a duplicate of it: a token issued before a tool existed
+ * holds no scope for it, and must not gain one by the tool shipping.
+ */
+
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+import { listHubs, openHub, type ToolResult } from './handlers/hubs';
+import {
+  buildDiscoverResult,
+  buildInitializeResult,
+  JSONRPC,
+  type JsonRpcRequest,
+} from './protocol';
+import { findTool, requiredScopeFor, visibleTools } from './tools';
+
+export type DispatchOutcome =
+  | { kind: 'result'; result: unknown }
+  | { kind: 'error'; code: number; message: string };
+
+/** Methods answerable without a token. */
+export function isPublicMethod(method: string): boolean {
+  return method === 'server/discover';
+}
+
+export function dispatchPublic(request: JsonRpcRequest): DispatchOutcome {
+  if (request.method === 'server/discover') {
+    return { kind: 'result', result: buildDiscoverResult() };
+  }
+  return { kind: 'error', code: JSONRPC.METHOD_NOT_FOUND, message: `Unknown method: ${request.method}` };
+}
+
+const TOOL_HANDLERS: Record<
+  string,
+  (identity: ConnectorIdentity, params: Record<string, unknown>) => Promise<ToolResult>
+> = {
+  pluggedin_list_hubs: (identity) => listHubs(identity),
+  pluggedin_open_hub: (identity, params) => openHub(identity, params),
+};
+
+export async function dispatchAuthenticated(
+  request: JsonRpcRequest,
+  identity: ConnectorIdentity
+): Promise<DispatchOutcome> {
+  switch (request.method) {
+    case 'initialize': {
+      const requested = request.params?.protocolVersion;
+      return {
+        kind: 'result',
+        result: buildInitializeResult(typeof requested === 'string' ? requested : undefined),
+      };
+    }
+
+    case 'ping':
+      return { kind: 'result', result: {} };
+
+    case 'tools/list':
+      return { kind: 'result', result: { tools: visibleTools(identity.scopes) } };
+
+    case 'tools/call': {
+      const name = request.params?.name;
+      if (typeof name !== 'string') {
+        return { kind: 'error', code: JSONRPC.INVALID_PARAMS, message: 'params.name is required' };
+      }
+
+      const definition = findTool(name);
+      const required = requiredScopeFor(name);
+      const handler = TOOL_HANDLERS[name];
+
+      // All three must agree. A tool defined but unmapped, or mapped but
+      // scopeless, is a wiring mistake — and answering "unknown tool" for it is
+      // better than reaching a handler no scope guards.
+      if (!definition || !required || !handler) {
+        return { kind: 'error', code: JSONRPC.METHOD_NOT_FOUND, message: `Unknown tool: ${name}` };
+      }
+
+      if (!identity.scopes.includes(required)) {
+        // Reported as a tool error rather than a transport 403: the call
+        // reached a real tool and was refused on authorization, and Claude
+        // surfaces that to the user instead of treating the connection as
+        // broken.
+        return {
+          kind: 'result',
+          result: {
+            content: [
+              {
+                type: 'text',
+                text: `This connection was not granted the "${required}" scope, which ${name} requires. Re-authorize to grant it.`,
+              },
+            ],
+            isError: true,
+          },
+        };
+      }
+
+      const args =
+        request.params?.arguments && typeof request.params.arguments === 'object'
+          ? (request.params.arguments as Record<string, unknown>)
+          : {};
+
+      return { kind: 'result', result: await handler(identity, args) };
+    }
+
+    default:
+      return {
+        kind: 'error',
+        code: JSONRPC.METHOD_NOT_FOUND,
+        message: `Unknown method: ${request.method}`,
+      };
+  }
+}

--- a/lib/mcp/connector/handle-request.ts
+++ b/lib/mcp/connector/handle-request.ts
@@ -1,0 +1,80 @@
+/**
+ * The hosted connector's request handler: one POST in, one JSON-RPC response
+ * out, nothing held in between.
+ *
+ * MCP 2026-07-28 made the protocol stateless — SEP-2567 removed sessions and
+ * the Mcp-Session-Id header — so this is exactly the shape of a route handler.
+ * No stream to keep open, no sticky routing, no session table.
+ */
+
+import { authenticateConnectorRequest } from '@/lib/oauth/provider/authenticate';
+
+import {
+  dispatchAuthenticated,
+  dispatchPublic,
+  isPublicMethod,
+} from './dispatch';
+import {
+  isNotification,
+  jsonRpcError,
+  jsonRpcResult,
+  JSONRPC,
+  parseJsonRpc,
+} from './protocol';
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      // Nothing here is cacheable: every response depends on the bearer token.
+      'Cache-Control': 'no-store',
+    },
+  });
+}
+
+export async function handleConnectorRequest(req: Request, raw: unknown): Promise<Response> {
+  const parsed = parseJsonRpc(raw);
+  if (!parsed.ok) {
+    return json(jsonRpcError(null, parsed.code, parsed.message), 400);
+  }
+  const request = parsed.request;
+
+  // server/discover is the negotiation itself, so it precedes authentication.
+  if (isPublicMethod(request.method)) {
+    const outcome = dispatchPublic(request);
+    return outcome.kind === 'result'
+      ? json(jsonRpcResult(request.id, outcome.result))
+      : json(jsonRpcError(request.id, outcome.code, outcome.message));
+  }
+
+  const auth = await authenticateConnectorRequest(req);
+  if (!auth.ok) {
+    // The 401 and its WWW-Authenticate header are what tell Claude where the
+    // authorization server is. A JSON-RPC error with status 200 would leave it
+    // with nowhere to go — the single most common way this integration fails
+    // silently.
+    return auth.response;
+  }
+
+  // A notification has no id and must not be answered. Dispatch still runs, so
+  // lifecycle notifications reach anything that cares, but the reply is empty.
+  if (isNotification(request)) {
+    await dispatchAuthenticated(request, auth.identity).catch(() => undefined);
+    return new Response(null, { status: 202 });
+  }
+
+  try {
+    const outcome = await dispatchAuthenticated(request, auth.identity);
+    if (outcome.kind === 'result') return json(jsonRpcResult(request.id, outcome.result));
+    return json(jsonRpcError(request.id, outcome.code, outcome.message));
+  } catch (error) {
+    // The message is deliberately generic. Handler errors can carry query text
+    // or row contents, and this response crosses a trust boundary.
+    console.error('[connector] dispatch failed', {
+      method: request.method,
+      error: error instanceof Error ? error.message : 'unknown',
+    });
+    return json(jsonRpcError(request.id, JSONRPC.INTERNAL_ERROR, 'Internal error'));
+  }
+}

--- a/lib/mcp/connector/handle-request.ts
+++ b/lib/mcp/connector/handle-request.ts
@@ -42,6 +42,11 @@ export async function handleConnectorRequest(req: Request, raw: unknown): Promis
 
   // server/discover is the negotiation itself, so it precedes authentication.
   if (isPublicMethod(request.method)) {
+    // A notification is unanswerable whichever side of authentication it
+    // arrives on. Checking only on the authenticated path left the public one
+    // replying to a request JSON-RPC says has no reply.
+    if (isNotification(request)) return new Response(null, { status: 202 });
+
     const outcome = dispatchPublic(request);
     return outcome.kind === 'result'
       ? json(jsonRpcResult(request.id, outcome.result))

--- a/lib/mcp/connector/handlers/hubs.ts
+++ b/lib/mcp/connector/handlers/hubs.ts
@@ -104,10 +104,23 @@ export async function openHub(
   // per-token convenience so the next call need not repeat the choice. It does
   // not reintroduce what SEP-2567 removed, because nothing about the connection
   // carries it — a different token has a different default.
-  await db
-    .update(oauthAccessTokensTable)
-    .set({ default_project_uuid: projectUuid })
-    .where(eq(oauthAccessTokensTable.uuid, identity.tokenUuid));
+  //
+  // The Hub can be deleted between the read above and this write, and the
+  // foreign key then rejects it. That is a narrow race but a real one, and the
+  // generic handler would report it as "Internal error" — which tells the user
+  // nothing and reads like an outage. 23503 is Postgres's foreign-key
+  // violation; here it means precisely one thing, so it is named.
+  try {
+    await db
+      .update(oauthAccessTokensTable)
+      .set({ default_project_uuid: projectUuid })
+      .where(eq(oauthAccessTokensTable.uuid, identity.tokenUuid));
+  } catch (error) {
+    if ((error as { code?: string })?.code === '23503') {
+      return failure(`The Hub "${argument}" no longer exists.`);
+    }
+    throw error;
+  }
 
   const opened = rows.find((row) => row.uuid === projectUuid);
   return text({

--- a/lib/mcp/connector/handlers/hubs.ts
+++ b/lib/mcp/connector/handlers/hubs.ts
@@ -1,0 +1,118 @@
+/**
+ * Hub selection over MCP.
+ *
+ * Claude does not tell us which Project a request came from — neither the
+ * authentication documentation nor the 2026-07-28 reserved `_meta` keys carry a
+ * project identifier, and `clientInfo` is only `{name, version, title}`. So
+ * automatic Hub selection is not achievable at the protocol level, and these
+ * two tools are the honest substitute: list what was granted, open one of them.
+ *
+ * Runtime switching is permitted within the Hub set granted at consent, never
+ * outside it. That set is fixed when the user approves; these tools cannot
+ * widen it.
+ */
+
+import { eq, inArray } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { oauthAccessTokensTable, projectsTable } from '@/db/schema';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+import { mintHubHandle, readHubHandle } from '../handles';
+
+export interface ToolResult {
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}
+
+function text(value: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+function failure(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+export async function listHubs(identity: ConnectorIdentity): Promise<ToolResult> {
+  if (identity.grantedProjectUuids.length === 0) {
+    return text({ hubs: [], note: 'No Hubs were granted to this connection.' });
+  }
+
+  const rows = await db
+    .select({ uuid: projectsTable.uuid, name: projectsTable.name })
+    .from(projectsTable)
+    .where(inArray(projectsTable.uuid, identity.grantedProjectUuids));
+
+  // Ordered by name so repeated calls read the same way; the model is choosing
+  // from this list and a shifting order makes that harder than it needs to be.
+  const hubs = rows
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .map((row) => ({
+      name: row.name,
+      handle: mintHubHandle(identity.tokenUuid, row.uuid),
+      isDefault: row.uuid === identity.defaultProjectUuid,
+    }));
+
+  return text({ hubs });
+}
+
+/**
+ * Resolves whatever the caller passed — a minted handle, or a Hub name — to a
+ * granted project. The granted set is the authority; the handle is only a
+ * convenience, so an unreadable one falls through to the name lookup rather
+ * than failing differently.
+ */
+export function resolveGrantedHub(
+  identity: ConnectorIdentity,
+  argument: string,
+  byName: { uuid: string; name: string }[]
+): string | undefined {
+  const fromHandle = readHubHandle(argument, identity.tokenUuid);
+  if (fromHandle && identity.grantedProjectUuids.includes(fromHandle)) return fromHandle;
+
+  const named = byName.find((row) => row.name === argument);
+  if (named && identity.grantedProjectUuids.includes(named.uuid)) return named.uuid;
+
+  return undefined;
+}
+
+export async function openHub(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const argument = typeof params.hub === 'string' ? params.hub.trim() : '';
+  if (!argument) return failure('hub is required: pass a name or a handle from pluggedin_list_hubs');
+
+  const granted = identity.grantedProjectUuids;
+  if (granted.length === 0) return failure('No Hubs were granted to this connection.');
+
+  const rows = await db
+    .select({ uuid: projectsTable.uuid, name: projectsTable.name })
+    .from(projectsTable)
+    .where(inArray(projectsTable.uuid, granted));
+
+  const projectUuid = resolveGrantedHub(identity, argument, rows);
+  if (!projectUuid) {
+    // Deliberately the same answer whether the Hub does not exist or exists and
+    // was not granted. Distinguishing them would let a caller enumerate other
+    // people's Hub names one guess at a time.
+    return failure(`No granted Hub matches "${argument}". Use pluggedin_list_hubs to see them.`);
+  }
+
+  // Server state keyed to a credential, not protocol session state: this is a
+  // per-token convenience so the next call need not repeat the choice. It does
+  // not reintroduce what SEP-2567 removed, because nothing about the connection
+  // carries it — a different token has a different default.
+  await db
+    .update(oauthAccessTokensTable)
+    .set({ default_project_uuid: projectUuid })
+    .where(eq(oauthAccessTokensTable.uuid, identity.tokenUuid));
+
+  const opened = rows.find((row) => row.uuid === projectUuid);
+  return text({
+    opened: opened?.name,
+    handle: mintHubHandle(identity.tokenUuid, projectUuid),
+    note: 'Pass this handle as the `hub` argument on subsequent calls.',
+  });
+}

--- a/lib/mcp/connector/handles.ts
+++ b/lib/mcp/connector/handles.ts
@@ -1,0 +1,65 @@
+/**
+ * Hub handles.
+ *
+ * SEP-2567 removed protocol sessions, so "the Hub I am currently working in"
+ * cannot live in connection state. It travels as an argument instead, and
+ * pluggedin_open_hub mints the value that later calls pass back.
+ *
+ * The handle is deliberately **not** a capability. Every call re-checks the Hub
+ * against the set granted at consent, so a caller who invents a handle, reuses
+ * somebody else's, or simply passes a raw project uuid gets exactly the same
+ * answer: refused unless that Hub was granted to this token. Binding the handle
+ * to the token is defence in depth and a way to keep the wire format opaque —
+ * clients that never see a raw uuid cannot start depending on its shape — but
+ * the authorization decision does not rest on it.
+ */
+
+import { createHmac, timingSafeEqual } from 'crypto';
+
+const PREFIX = 'hub';
+
+function signingKey(): string {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) throw new Error('NEXTAUTH_SECRET is required to mint Hub handles');
+  return secret;
+}
+
+function sign(payload: string): string {
+  return createHmac('sha256', signingKey()).update(payload).digest('base64url');
+}
+
+export function mintHubHandle(tokenUuid: string, projectUuid: string): string {
+  const payload = Buffer.from(`${tokenUuid}:${projectUuid}`).toString('base64url');
+  return `${PREFIX}_${payload}.${sign(payload)}`;
+}
+
+/**
+ * Returns the project a handle names, or undefined. Undefined is not an error
+ * on its own — callers fall back to the raw argument and let the granted-set
+ * check decide, so an unreadable handle degrades to "not granted" rather than
+ * to a distinct failure a caller could probe.
+ */
+export function readHubHandle(handle: string, tokenUuid: string): string | undefined {
+  if (!handle.startsWith(`${PREFIX}_`)) return undefined;
+
+  const [payload, signature] = handle.slice(PREFIX.length + 1).split('.');
+  if (!payload || !signature) return undefined;
+
+  const expected = Buffer.from(sign(payload), 'utf8');
+  const presented = Buffer.from(signature, 'utf8');
+  if (expected.length !== presented.length) return undefined;
+  if (!timingSafeEqual(expected, presented)) return undefined;
+
+  let decoded: string;
+  try {
+    decoded = Buffer.from(payload, 'base64url').toString('utf8');
+  } catch {
+    return undefined;
+  }
+
+  const separator = decoded.indexOf(':');
+  if (separator < 0) return undefined;
+  if (decoded.slice(0, separator) !== tokenUuid) return undefined;
+
+  return decoded.slice(separator + 1) || undefined;
+}

--- a/lib/mcp/connector/protocol.ts
+++ b/lib/mcp/connector/protocol.ts
@@ -1,0 +1,125 @@
+/**
+ * The slice of MCP 2026-07-28 the hosted connector actually speaks.
+ *
+ * The plan calls for extracting pluggedin-mcp/src/protocol/ into a shared
+ * package, and that is still the right end state. It is not a prerequisite for
+ * this endpoint: the connector speaks one revision and never bridges to an
+ * older one, so it needs the version constant, the JSON-RPC envelope and the
+ * discover payload — not the bridging modules (`lower`, `registry`) that exist
+ * for the local proxy's deprecation window. Extracting a package to obtain
+ * three constants would couple this route to a release process it does not
+ * need yet.
+ */
+
+/** Revisions this endpoint answers for, oldest first. */
+export const REVISIONS = ['2026-07-28'] as const;
+export type Revision = (typeof REVISIONS)[number];
+export const LATEST_REVISION: Revision = '2026-07-28';
+
+export const SERVER_INFO = Object.freeze({
+  name: 'pluggedin',
+  title: 'Plugged.in',
+  version: '1.0.0',
+});
+
+/** JSON-RPC 2.0 error codes, plus the MCP-specific ones we return. */
+export const JSONRPC = Object.freeze({
+  PARSE_ERROR: -32700,
+  INVALID_REQUEST: -32600,
+  METHOD_NOT_FOUND: -32601,
+  INVALID_PARAMS: -32602,
+  INTERNAL_ERROR: -32603,
+});
+
+export interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: string | number | null;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+/**
+ * A request without an `id` is a notification: JSON-RPC forbids replying to
+ * one, and MCP clients send them for lifecycle events like
+ * `notifications/initialized`. Answering anyway is a protocol violation that
+ * some clients surface as a hard error.
+ */
+export function isNotification(body: JsonRpcRequest): boolean {
+  return body.id === undefined;
+}
+
+export function parseJsonRpc(
+  raw: unknown
+): { ok: true; request: JsonRpcRequest } | { ok: false; code: number; message: string } {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, code: JSONRPC.INVALID_REQUEST, message: 'Request must be a JSON object' };
+  }
+  const body = raw as Record<string, unknown>;
+  if (body.jsonrpc !== '2.0') {
+    return { ok: false, code: JSONRPC.INVALID_REQUEST, message: 'jsonrpc must be "2.0"' };
+  }
+  if (typeof body.method !== 'string' || body.method === '') {
+    return { ok: false, code: JSONRPC.INVALID_REQUEST, message: 'method is required' };
+  }
+  const id = body.id;
+  if (id !== undefined && id !== null && typeof id !== 'string' && typeof id !== 'number') {
+    return { ok: false, code: JSONRPC.INVALID_REQUEST, message: 'id must be a string or number' };
+  }
+
+  return {
+    ok: true,
+    request: {
+      jsonrpc: '2.0',
+      ...(id === undefined ? {} : { id: id as string | number | null }),
+      method: body.method,
+      params:
+        body.params && typeof body.params === 'object' && !Array.isArray(body.params)
+          ? (body.params as Record<string, unknown>)
+          : undefined,
+    },
+  };
+}
+
+export function jsonRpcResult(id: JsonRpcRequest['id'], result: unknown) {
+  return { jsonrpc: '2.0' as const, id: id ?? null, result };
+}
+
+export function jsonRpcError(id: JsonRpcRequest['id'], code: number, message: string, data?: unknown) {
+  return {
+    jsonrpc: '2.0' as const,
+    id: id ?? null,
+    error: { code, message, ...(data === undefined ? {} : { data }) },
+  };
+}
+
+/**
+ * `server/discover` is answered before authentication, because it *is* the
+ * negotiation: a client that cannot discover what we speak has no way to reach
+ * the point of authenticating. It carries no user data — only what this server
+ * is and which revisions it answers for.
+ */
+export function buildDiscoverResult() {
+  return {
+    resultType: 'complete' as const,
+    // Newest first: clients take the first entry they recognise.
+    protocolVersions: [...REVISIONS].reverse(),
+    capabilities: {
+      tools: { listChanged: false },
+    },
+    serverInfo: SERVER_INFO,
+  };
+}
+
+export function buildInitializeResult(requested?: string) {
+  // Echo the client's revision when we speak it, otherwise state ours and let
+  // the client decide. Silently answering in a different revision than the one
+  // asked for is how version mismatches become mysterious tool failures.
+  const protocolVersion =
+    requested && (REVISIONS as readonly string[]).includes(requested) ? requested : LATEST_REVISION;
+
+  return {
+    protocolVersion,
+    capabilities: { tools: { listChanged: false } },
+    serverInfo: SERVER_INFO,
+  };
+}

--- a/lib/mcp/connector/tools.ts
+++ b/lib/mcp/connector/tools.ts
@@ -1,0 +1,76 @@
+/**
+ * The tool surface Claude sees.
+ *
+ * Anthropic's directory rules shape these definitions, not preference: every
+ * tool carries a `title` and an explicit read/destructive annotation, and read
+ * and write are separate tools rather than one call with a mode argument. A
+ * catch-all `api_request` is grounds for rejection.
+ *
+ * Each entry must also appear in TOOL_SCOPES. That map is the authorization
+ * decision and it fails closed, so a tool added here without a scope is not
+ * callable — the check below turns that from a silent hole into a startup-time
+ * inconsistency the tests catch.
+ */
+
+import { TOOL_SCOPES } from '@/lib/oauth/provider/scopes';
+import type { Scope } from '@/lib/oauth/provider/scopes';
+
+export interface ToolDefinition {
+  name: string;
+  title: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  annotations: {
+    readOnlyHint: boolean;
+    destructiveHint: boolean;
+    idempotentHint?: boolean;
+  };
+}
+
+export const TOOLS: readonly ToolDefinition[] = Object.freeze([
+  {
+    name: 'pluggedin_list_hubs',
+    title: 'List Plugged.in Hubs',
+    description:
+      'List the Plugged.in Hubs this connection may reach. Returns each Hub with a handle to pass to other tools. Call this first when the user has more than one Hub.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'pluggedin_open_hub',
+    title: 'Open a Plugged.in Hub',
+    description:
+      'Select the Hub for subsequent calls, by name or by a handle from pluggedin_list_hubs. Only Hubs granted when the connection was authorized can be opened.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        hub: {
+          type: 'string',
+          description: 'Hub name, or a handle returned by pluggedin_list_hubs.',
+        },
+      },
+      required: ['hub'],
+      additionalProperties: false,
+    },
+    // Not read-only: it changes which Hub this token defaults to. Not
+    // destructive either — nothing is lost, and the previous choice can be
+    // restored by opening the other Hub.
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  },
+]);
+
+/** Tools whose required scope the caller holds. */
+export function visibleTools(grantedScopes: string[]): ToolDefinition[] {
+  return TOOLS.filter((tool) => {
+    const required = TOOL_SCOPES[tool.name];
+    return required !== undefined && grantedScopes.includes(required);
+  });
+}
+
+export function requiredScopeFor(toolName: string): Scope | undefined {
+  return TOOL_SCOPES[toolName];
+}
+
+export function findTool(toolName: string): ToolDefinition | undefined {
+  return TOOLS.find((tool) => tool.name === toolName);
+}

--- a/lib/mcp/connector/tools.ts
+++ b/lib/mcp/connector/tools.ts
@@ -62,13 +62,25 @@ export const TOOLS: readonly ToolDefinition[] = Object.freeze([
 /** Tools whose required scope the caller holds. */
 export function visibleTools(grantedScopes: string[]): ToolDefinition[] {
   return TOOLS.filter((tool) => {
-    const required = TOOL_SCOPES[tool.name];
+    const required = requiredScopeFor(tool.name);
     return required !== undefined && grantedScopes.includes(required);
   });
 }
 
+/**
+ * Own properties only. TOOL_SCOPES is an object literal, so it inherits from
+ * Object.prototype and a plain lookup answers for names nobody defined:
+ * requiredScopeFor('constructor') returns a *function*, which is truthy.
+ *
+ * Nothing was exploitable — findTool scans an array by name equality and no
+ * prototype key survives it, so the call never reached a handler. But that made
+ * the safety incidental rather than stated: the redundant-looking `definition`
+ * check in dispatch was the only thing standing between an attacker-supplied
+ * tool name and a truthy handler. A later cleanup removing it as duplicated
+ * would have opened the path silently.
+ */
 export function requiredScopeFor(toolName: string): Scope | undefined {
-  return TOOL_SCOPES[toolName];
+  return Object.hasOwn(TOOL_SCOPES, toolName) ? TOOL_SCOPES[toolName] : undefined;
 }
 
 export function findTool(toolName: string): ToolDefinition | undefined {

--- a/lib/oauth/provider/authenticate.ts
+++ b/lib/oauth/provider/authenticate.ts
@@ -69,10 +69,20 @@ export async function authenticateConnectorRequest(
 
   // Fire-and-forget: last_used_at is telemetry, and awaiting it would put a
   // write on the critical path of every tool call.
+  //
+  // The catch is not decoration. An unhandled rejection terminates the process
+  // by default since Node 15, so without it a transient database error on a
+  // telemetry write could take down the server in the middle of serving a
+  // request that had already succeeded.
   void db
     .update(oauthAccessTokensTable)
     .set({ last_used_at: new Date() })
-    .where(eq(oauthAccessTokensTable.uuid, record.uuid));
+    .where(eq(oauthAccessTokensTable.uuid, record.uuid))
+    .catch((error) => {
+      console.warn('[connector] last_used_at update failed', {
+        error: error instanceof Error ? error.message : 'unknown',
+      });
+    });
 
   return {
     ok: true,

--- a/tests/mcp/connector-dispatch.test.ts
+++ b/tests/mcp/connector-dispatch.test.ts
@@ -261,3 +261,63 @@ describe('JSON-RPC envelope', () => {
     if (outcome.kind === 'error') expect(outcome.code).toBe(-32601);
   });
 });
+
+describe('attacker-supplied tool names', () => {
+  it('does not resolve a handler through the prototype chain', async () => {
+    // TOOL_HANDLERS and TOOL_SCOPES are object literals, so a plain lookup
+    // answers for names nobody defined. requiredScopeFor('constructor')
+    // returned a function — truthy — and only findTool's array scan kept the
+    // call from reaching Object as a handler. That made the safety incidental.
+    for (const name of ['constructor', 'toString', '__proto__', 'hasOwnProperty', 'valueOf']) {
+      const outcome = await dispatchAuthenticated(call(name), identity({ scopes: ['hubs:read'] }));
+      expect(outcome.kind, `${name} reached a handler`).toBe('error');
+      if (outcome.kind === 'error') expect(outcome.message).toContain('Unknown tool');
+    }
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('reports no scope for a prototype key', async () => {
+    const { requiredScopeFor } = await import('@/lib/mcp/connector/tools');
+    expect(requiredScopeFor('constructor')).toBeUndefined();
+    expect(requiredScopeFor('toString')).toBeUndefined();
+    expect(requiredScopeFor('pluggedin_list_hubs')).toBe('hubs:read');
+  });
+});
+
+describe('a Hub deleted mid-call', () => {
+  it('says so instead of reporting an internal error', async () => {
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+      from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ uuid: HUB_A, name: 'Acme' }]) })),
+    });
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue({
+      set: vi.fn(() => ({
+        where: vi.fn().mockRejectedValue(Object.assign(new Error('fk'), { code: '23503' })),
+      })),
+    });
+
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_open_hub', { hub: 'Acme' }),
+      identity()
+    );
+
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+    const result = outcome.result as { isError?: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('no longer exists');
+  });
+
+  it('still propagates an error that is not a foreign-key violation', async () => {
+    // Swallowing every failure here would turn a real outage into "that Hub is
+    // gone", which sends the user looking in the wrong place.
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+      from: vi.fn(() => ({ where: vi.fn().mockResolvedValue([{ uuid: HUB_A, name: 'Acme' }]) })),
+    });
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockRejectedValue(new Error('connection lost')) })),
+    });
+
+    await expect(
+      dispatchAuthenticated(call('pluggedin_open_hub', { hub: 'Acme' }), identity())
+    ).rejects.toThrow('connection lost');
+  });
+});

--- a/tests/mcp/connector-dispatch.test.ts
+++ b/tests/mcp/connector-dispatch.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Dispatch and the JSON-RPC envelope.
+ *
+ * The two behaviours worth guarding hardest are the ones a client cannot work
+ * around: server/discover has to answer before authentication, and tools/call
+ * has to refuse a tool whose scope the token does not hold. Everything else
+ * here is envelope handling, which is easy to get subtly wrong and impossible
+ * to debug from the client side.
+ */
+
+const { mockDb } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn(), update: vi.fn() },
+}));
+vi.mock('@/db', () => ({ db: mockDb }));
+
+process.env.NEXTAUTH_SECRET = 'connector-dispatch-test-secret';
+process.env.NEXTAUTH_URL = 'https://plugged.in';
+
+import { db } from '@/db';
+import {
+  dispatchAuthenticated,
+  dispatchPublic,
+  isPublicMethod,
+} from '@/lib/mcp/connector/dispatch';
+import { parseJsonRpc } from '@/lib/mcp/connector/protocol';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+const HUB_A = '11111111-1111-1111-1111-111111111111';
+const HUB_B = '22222222-2222-2222-2222-222222222222';
+
+function identity(overrides: Partial<ConnectorIdentity> = {}): ConnectorIdentity {
+  return {
+    userId: 'user-1',
+    grantedProjectUuids: [HUB_A],
+    defaultProjectUuid: HUB_A,
+    scopes: ['hubs:read'],
+    tokenUuid: '33333333-3333-3333-3333-333333333333',
+    ...overrides,
+  };
+}
+
+function hubRows(rows: { uuid: string; name: string }[]) {
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+    from: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
+  });
+  (db.update as ReturnType<typeof vi.fn>).mockReturnValue({
+    set: vi.fn(() => ({ where: vi.fn().mockResolvedValue({ rowCount: 1 }) })),
+  });
+}
+
+function call(name: string, args: Record<string, unknown> = {}) {
+  return {
+    jsonrpc: '2.0' as const,
+    id: 1,
+    method: 'tools/call',
+    params: { name, arguments: args },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('server/discover', () => {
+  it('is answerable without a token', () => {
+    // It is the negotiation: a client that cannot discover what we speak has
+    // no route to authenticating in the first place.
+    expect(isPublicMethod('server/discover')).toBe(true);
+    expect(isPublicMethod('tools/list')).toBe(false);
+    expect(isPublicMethod('initialize')).toBe(false);
+  });
+
+  it('advertises the newest revision first and carries no user data', () => {
+    const outcome = dispatchPublic({ jsonrpc: '2.0', id: 1, method: 'server/discover' });
+    expect(outcome.kind).toBe('result');
+    if (outcome.kind !== 'result') return;
+
+    const result = outcome.result as {
+      resultType: string;
+      protocolVersions: string[];
+      serverInfo: { name: string };
+    };
+    expect(result.resultType).toBe('complete');
+    expect(result.protocolVersions[0]).toBe('2026-07-28');
+    expect(JSON.stringify(result)).not.toContain('user-1');
+  });
+});
+
+describe('tools/list', () => {
+  it('shows only tools the token holds the scope for', async () => {
+    const withHubs = await dispatchAuthenticated(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      identity({ scopes: ['hubs:read'] })
+    );
+    const withoutHubs = await dispatchAuthenticated(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      identity({ scopes: ['library:read'] })
+    );
+
+    const names = (o: typeof withHubs) =>
+      o.kind === 'result' ? (o.result as { tools: { name: string }[] }).tools.map((t) => t.name) : [];
+
+    expect(names(withHubs)).toContain('pluggedin_list_hubs');
+    expect(names(withoutHubs)).toHaveLength(0);
+  });
+
+  it('gives every listed tool a title and an explicit read/destructive hint', async () => {
+    // Anthropic's directory rules, not preference: a tool without these is
+    // grounds for rejection, and the failure would surface at submission time
+    // rather than here.
+    const outcome = await dispatchAuthenticated(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      identity({ scopes: ['hubs:read'] })
+    );
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+
+    for (const tool of (outcome.result as { tools: Record<string, unknown>[] }).tools) {
+      expect(tool.title, `${tool.name} has no title`).toBeTruthy();
+      const annotations = tool.annotations as Record<string, unknown>;
+      expect(typeof annotations.readOnlyHint).toBe('boolean');
+      expect(typeof annotations.destructiveHint).toBe('boolean');
+    }
+  });
+});
+
+describe('tools/call scope gating', () => {
+  it('refuses a tool whose scope the token does not hold', async () => {
+    hubRows([{ uuid: HUB_A, name: 'Acme' }]);
+
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_list_hubs'),
+      identity({ scopes: ['library:read'] })
+    );
+
+    expect(outcome.kind).toBe('result');
+    if (outcome.kind !== 'result') return;
+    const result = outcome.result as { isError?: boolean; content: { text: string }[] };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('hubs:read');
+    // The refusal must not have reached the handler.
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('refuses a tool that exists in no scope map', async () => {
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_definitely_not_a_tool'),
+      identity({ scopes: ['hubs:read'] })
+    );
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') expect(outcome.message).toContain('Unknown tool');
+  });
+});
+
+describe('hub tools', () => {
+  it('lists only granted Hubs, with a handle each', async () => {
+    hubRows([{ uuid: HUB_A, name: 'Acme' }]);
+
+    const outcome = await dispatchAuthenticated(call('pluggedin_list_hubs'), identity());
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+
+    const payload = JSON.parse((outcome.result as { content: { text: string }[] }).content[0].text);
+    expect(payload.hubs).toHaveLength(1);
+    expect(payload.hubs[0].name).toBe('Acme');
+    expect(payload.hubs[0].handle).toMatch(/^hub_/);
+    // A raw project uuid must not leak into the wire format, or clients will
+    // start depending on its shape.
+    expect(JSON.stringify(payload)).not.toContain(HUB_A);
+  });
+
+  it('opens a granted Hub by name and records it as the default', async () => {
+    hubRows([{ uuid: HUB_A, name: 'Acme' }]);
+
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_open_hub', { hub: 'Acme' }),
+      identity()
+    );
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+
+    const payload = JSON.parse((outcome.result as { content: { text: string }[] }).content[0].text);
+    expect(payload.opened).toBe('Acme');
+    expect(db.update).toHaveBeenCalled();
+  });
+
+  it('refuses a Hub that exists but was not granted', async () => {
+    // The query is scoped to the granted set, so an ungranted Hub simply is not
+    // in the rows — and the answer is identical to a Hub that does not exist,
+    // which is what stops a caller enumerating other people's Hub names.
+    hubRows([]);
+
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_open_hub', { hub: 'Someone Elses Hub' }),
+      identity({ grantedProjectUuids: [] })
+    );
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+
+    const result = outcome.result as { isError?: boolean };
+    expect(result.isError).toBe(true);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses a handle minted for a different token', async () => {
+    hubRows([{ uuid: HUB_A, name: 'Acme' }]);
+    const mine = await dispatchAuthenticated(call('pluggedin_list_hubs'), identity());
+    if (mine.kind !== 'result') throw new Error('expected a result');
+    const handle = JSON.parse((mine.result as { content: { text: string }[] }).content[0].text)
+      .hubs[0].handle;
+
+    vi.clearAllMocks();
+    hubRows([{ uuid: HUB_A, name: 'Acme' }]);
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_open_hub', { hub: handle }),
+      identity({ tokenUuid: 'a-different-token' })
+    );
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+    expect((outcome.result as { isError?: boolean }).isError).toBe(true);
+  });
+
+  it('still refuses when a valid handle names an ungranted Hub', async () => {
+    // The handle is a convenience, never the authorization. Even a correctly
+    // signed one has to clear the granted set.
+    hubRows([{ uuid: HUB_B, name: 'Other' }]);
+
+    const outcome = await dispatchAuthenticated(
+      call('pluggedin_open_hub', { hub: HUB_B }),
+      identity({ grantedProjectUuids: [HUB_A] })
+    );
+    if (outcome.kind !== 'result') throw new Error('expected a result');
+    expect((outcome.result as { isError?: boolean }).isError).toBe(true);
+    expect(db.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('JSON-RPC envelope', () => {
+  it('rejects a body that is not a JSON-RPC 2.0 request', () => {
+    expect(parseJsonRpc(null).ok).toBe(false);
+    expect(parseJsonRpc([]).ok).toBe(false);
+    expect(parseJsonRpc({ method: 'x' }).ok).toBe(false);
+    expect(parseJsonRpc({ jsonrpc: '2.0' }).ok).toBe(false);
+    expect(parseJsonRpc({ jsonrpc: '1.0', method: 'x' }).ok).toBe(false);
+  });
+
+  it('keeps a request without an id distinguishable from one with id null', () => {
+    // JSON-RPC forbids answering a notification, and `id: null` is a request.
+    // Collapsing them means either replying to a notification or dropping a
+    // real reply.
+    const notification = parseJsonRpc({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    const withNullId = parseJsonRpc({ jsonrpc: '2.0', id: null, method: 'ping' });
+
+    expect(notification.ok && 'id' in notification.request).toBe(false);
+    expect(withNullId.ok && 'id' in withNullId.request).toBe(true);
+  });
+
+  it('answers an unknown method with method-not-found rather than a crash', async () => {
+    const outcome = await dispatchAuthenticated(
+      { jsonrpc: '2.0', id: 1, method: 'resources/list' },
+      identity()
+    );
+    expect(outcome.kind).toBe('error');
+    if (outcome.kind === 'error') expect(outcome.code).toBe(-32601);
+  });
+});

--- a/tests/mcp/connector-endpoint.test.ts
+++ b/tests/mcp/connector-endpoint.test.ts
@@ -169,4 +169,15 @@ describe('envelope', () => {
     // Let the rejection settle: an unhandled one would surface here.
     await new Promise((r) => setTimeout(r, 10));
   });
+
+  it('does not reply to a public notification either', async () => {
+    // server/discover answers before authentication, and the notification rule
+    // does not care which side of authentication a request arrives on. The
+    // check only existed on the authenticated path.
+    const body = { jsonrpc: '2.0', method: 'server/discover' };
+    const response = await handleConnectorRequest(post(body), body);
+
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe('');
+  });
 });

--- a/tests/mcp/connector-endpoint.test.ts
+++ b/tests/mcp/connector-endpoint.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The endpoint's authentication behaviour, which is what §2 of the deploy doc
+ * checks and what decides whether Claude can start the OAuth flow at all.
+ *
+ * The header is only honoured on a 401 — Anthropic's documentation is explicit
+ * that a WWW-Authenticate on a 200 is ignored. Returning a tool error instead
+ * of the challenge is the single most common way this integration fails
+ * silently, because everything else keeps working: discovery resolves, the
+ * consent screen renders, tokens issue, and the client simply never learns
+ * where to send the user.
+ */
+
+const { mockDb } = vi.hoisted(() => ({ mockDb: { select: vi.fn(), update: vi.fn() } }));
+vi.mock('@/db', () => ({ db: mockDb }));
+
+process.env.NEXTAUTH_SECRET = 'connector-endpoint-test-secret';
+process.env.NEXTAUTH_URL = 'https://plugged.in';
+
+import { db } from '@/db';
+import { handleConnectorRequest } from '@/lib/mcp/connector/handle-request';
+
+function post(body: unknown, headers: Record<string, string> = {}) {
+  return new Request('https://plugged.in/api/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+function tokenRow(overrides: Record<string, unknown> = {}) {
+  return {
+    uuid: 'token-1',
+    user_id: 'user-1',
+    granted_project_uuids: ['11111111-1111-1111-1111-111111111111'],
+    default_project_uuid: null,
+    scopes: ['hubs:read'],
+    revoked_at: null,
+    expires_at: new Date(Date.now() + 3_600_000),
+    ...overrides,
+  };
+}
+
+function tokenLookup(rows: Record<string, unknown>[]) {
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+    from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(rows) })) })),
+  });
+  // authenticateConnectorRequest stamps last_used_at fire-and-forget.
+  (db.update as ReturnType<typeof vi.fn>).mockReturnValue({
+    set: vi.fn(() => ({ where: vi.fn().mockResolvedValue({ rowCount: 1 }) })),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('authentication', () => {
+  it('challenges an unauthenticated call with 401 and a resource_metadata pointer', async () => {
+    const response = await handleConnectorRequest(
+      post({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' }
+    );
+
+    expect(response.status).toBe(401);
+    const header = response.headers.get('www-authenticate') ?? '';
+    expect(header).toContain('Bearer');
+    expect(header).toContain('https://plugged.in/.well-known/oauth-protected-resource');
+  });
+
+  it('challenges rather than answering when the token is expired', async () => {
+    tokenLookup([tokenRow({ expires_at: new Date(Date.now() - 1000) })]);
+
+    const response = await handleConnectorRequest(
+      post({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, { authorization: 'Bearer whatever' }),
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('challenges rather than answering when the token is revoked', async () => {
+    tokenLookup([tokenRow({ revoked_at: new Date() })]);
+
+    const response = await handleConnectorRequest(
+      post({ jsonrpc: '2.0', id: 1, method: 'tools/list' }, { authorization: 'Bearer whatever' }),
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' }
+    );
+
+    expect(response.status).toBe(401);
+  });
+
+  it('answers server/discover without a token, on 200', async () => {
+    const body = { jsonrpc: '2.0', id: 1, method: 'server/discover' };
+    const response = await handleConnectorRequest(post(body), body);
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload.result.protocolVersions[0]).toBe('2026-07-28');
+    // Discovery must not have needed the database.
+    expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('envelope', () => {
+  it('rejects a malformed body with a JSON-RPC error, not a crash', async () => {
+    const response = await handleConnectorRequest(post({ nope: true }), { nope: true });
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.error.code).toBe(-32600);
+  });
+
+  it('does not reply to a notification', async () => {
+    tokenLookup([tokenRow()]);
+    const body = { jsonrpc: '2.0', method: 'notifications/initialized' };
+
+    const response = await handleConnectorRequest(
+      post(body, { authorization: 'Bearer whatever' }),
+      body
+    );
+
+    // JSON-RPC forbids answering a request without an id; some clients treat a
+    // reply as a hard protocol error.
+    expect(response.status).toBe(202);
+    expect(await response.text()).toBe('');
+  });
+
+  it('echoes the request id on a real call', async () => {
+    tokenLookup([tokenRow()]);
+    const body = { jsonrpc: '2.0', id: 'abc', method: 'ping' };
+
+    const response = await handleConnectorRequest(
+      post(body, { authorization: 'Bearer whatever' }),
+      body
+    );
+
+    const payload = await response.json();
+    expect(payload.id).toBe('abc');
+  });
+
+  it('never caches a response', async () => {
+    const body = { jsonrpc: '2.0', id: 1, method: 'server/discover' };
+    const response = await handleConnectorRequest(post(body), body);
+    // Every answer depends on the bearer token; a shared cache in front of this
+    // would hand one tenant's reply to another.
+    expect(response.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('survives a failing last_used_at write', async () => {
+    // The stamp is telemetry and runs fire-and-forget. Before it carried a
+    // catch, a rejection here was an unhandled promise rejection — which Node
+    // turns into process termination by default, on a request that had already
+    // succeeded.
+    (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+      from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([tokenRow()]) })) })),
+    });
+    (db.update as ReturnType<typeof vi.fn>).mockReturnValue({
+      set: vi.fn(() => ({ where: vi.fn().mockRejectedValue(new Error('connection lost')) })),
+    });
+
+    const body = { jsonrpc: '2.0', id: 1, method: 'ping' };
+    const response = await handleConnectorRequest(
+      post(body, { authorization: 'Bearer whatever' }),
+      body
+    );
+
+    expect(response.status).toBe(200);
+    // Let the rejection settle: an unhandled one would surface here.
+    await new Promise((r) => setTimeout(r, 10));
+  });
+});

--- a/tests/mcp/connector-route.test.ts
+++ b/tests/mcp/connector-route.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * The route handler itself, not the connector function underneath it.
+ *
+ * This file exists because tests/mcp/connector-endpoint.test.ts calls
+ * handleConnectorRequest with an already-parsed body, so it never touches the
+ * route's own parse step — and that is exactly where the ordering bug lived:
+ * the body was read before the credential branch, so a malformed or absent
+ * body threw and an unauthenticated caller got a 500 instead of the challenge.
+ * A client whose first probe is empty would never learn where to authenticate.
+ *
+ * The lesson is the reason for the file: a test that enters below the layer
+ * under discussion cannot see a bug in that layer.
+ */
+
+const { mockDb } = vi.hoisted(() => ({ mockDb: { select: vi.fn(), update: vi.fn() } }));
+vi.mock('@/db', () => ({ db: mockDb }));
+
+process.env.NEXTAUTH_SECRET = 'connector-route-test-secret';
+process.env.NEXTAUTH_URL = 'https://plugged.in';
+
+const { sessionValue } = vi.hoisted(() => ({ sessionValue: { current: null as unknown } }));
+vi.mock('next-auth/next', () => ({
+  getServerSession: () => Promise.resolve(sessionValue.current),
+}));
+vi.mock('@/lib/auth', () => ({ authOptions: {} }));
+vi.mock('@/lib/mcp/streamable-http/handler', () => ({
+  handleStreamableHTTPRequest: vi.fn().mockResolvedValue({ body: { ok: true }, status: 200 }),
+}));
+vi.mock('@/lib/mcp/sessions/SessionManager', () => ({
+  getSessionManager: () => ({ closeSession: vi.fn() }),
+}));
+
+import { NextRequest } from 'next/server';
+
+import { db } from '@/db';
+import { POST } from '@/app/api/mcp/route';
+import { handleStreamableHTTPRequest } from '@/lib/mcp/streamable-http/handler';
+
+/** `body` is passed through verbatim so malformed input can be sent as-is. */
+function post(body: string, headers: Record<string, string> = {}) {
+  return new NextRequest('https://plugged.in/api/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionValue.current = null;
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+    from: vi.fn(() => ({ where: vi.fn(() => ({ limit: vi.fn().mockResolvedValue([]) })) })),
+  });
+});
+
+describe('unauthenticated', () => {
+  it('challenges even when the body is malformed', async () => {
+    const response = await POST(post('this is not json'));
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('www-authenticate')).toContain('resource_metadata');
+  });
+
+  it('challenges even when there is no body at all', async () => {
+    // The realistic first probe: someone runs curl -X POST with no payload.
+    // Before the fix this threw in req.json() and produced a 500.
+    const response = await POST(
+      new NextRequest('https://plugged.in/api/mcp', { method: 'POST' })
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('www-authenticate')).toContain('resource_metadata');
+  });
+
+  it('challenges a well-formed request too', async () => {
+    const response = await POST(post(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' })));
+    expect(response.status).toBe(401);
+  });
+});
+
+describe('bearer path', () => {
+  it('answers a malformed body with a JSON-RPC parse error, not a 500', async () => {
+    const response = await POST(post('{ broken', { authorization: 'Bearer whatever' }));
+
+    expect(response.status).toBe(400);
+    const payload = await response.json();
+    expect(payload.error.code).toBe(-32700);
+  });
+
+  it('routes a bearer request to the connector, never to the session handler', async () => {
+    const response = await POST(
+      post(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'server/discover' }), {
+        authorization: 'Bearer whatever',
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).result.protocolVersions[0]).toBe('2026-07-28');
+    expect(handleStreamableHTTPRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('session path', () => {
+  it('still works, and is not reached by a bearer request', async () => {
+    // The branch is additive on purpose: nothing here calls this path today,
+    // but "no caller I can find" is not "no caller".
+    sessionValue.current = { user: { id: 'user-1' } };
+
+    const response = await POST(post(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' })));
+
+    expect(response.status).toBe(200);
+    expect(handleStreamableHTTPRequest).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
Phase A shipped the authorization server and nothing called it — `authenticateConnectorRequest()` and `buildUnauthorizedResponse()` existed but no route used them, so a user could authorize and then find no tools. This wires them up and adds the first tool group.

### Stateless, because 2026-07-28 made it so

SEP-2567 removed protocol sessions and `Mcp-Session-Id`, which is why an MCP endpoint is now exactly the shape of a route handler: no held stream, no sticky routing, no session table.

### Additive, not a rewrite

The spec calls for replacing the session-based handler and that is still the end state. But nothing in this repo calls it and the local proxy uses `/api/mcp-servers` — which is **evidence, not proof**. "No caller I can find" is not "no caller", and deleting a live endpoint to save one conditional is a poor trade. `POST` branches on the `Authorization` header; the session path is untouched and goes when the proxy retires, which is already the plan.

### Three decisions worth stating

- **`server/discover` answers before authentication**, because it *is* the negotiation. A client that cannot discover what we speak has no route to authenticating.
- **An unauthenticated call now gets `401` + `WWW-Authenticate`** instead of the bare `401` it got before. That header is how Claude learns where the authorization server is, and it is ignored on a `200` — returning a tool error instead is the most common way this integration fails silently, because everything around it keeps working.
- **Hub handles are not capabilities.** SEP-2567 left nowhere to keep "the currently selected Hub", so `pluggedin_open_hub` mints a handle later calls pass back — but every call re-checks the Hub against the set granted at consent. A forged handle, someone else's handle, and a raw project uuid all get the same answer.

### A real bug found while testing this

The fire-and-forget `last_used_at` write in `authenticate.ts` had no `.catch()`. Unhandled rejections terminate the process by default since Node 15, so a transient database error on a **telemetry write** could take down the server during a request that had already succeeded. Caught, logged, regression-tested.

### Verification

23 tests. Four mutations, all caught:

| Mutation | Result |
|---|---|
| remove the `tools/call` scope gate | fails |
| remove the `tools/list` scope filter | fails |
| drop the granted-set check in hub resolution | fails |
| drop the handle's token binding | fails (2) |

Full suite: **1283 passing** here against **1260** on `main`, same 204 pre-existing failures. Build clean.

### Deploy doc

§2 of `hosted-connector-deploy-checks.md` currently says the challenge is not wired and to expect a bare 401. **That becomes wrong when this merges** — I'll update it in a follow-up once this is approved, so the doc and the code change together rather than the doc getting ahead of production.

### Not in this change

The shared `@pluggedin/mcp-protocol` package. The connector speaks one revision and never bridges, so it needs the version constant, the JSON-RPC envelope and the discover payload — extracting a package for three constants would couple this route to a release process it does not need yet. Remaining tool groups (library, clipboard, tasks, memory) are Phase C.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788459258&installation_model_id=430597&pr_number=188&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F188&signature=59a037adf3f90bc7792f7ef30ce764815f0c1d7fbacfd05098980fb7493670d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Introduce a stateless MCP hosted connector endpoint at /api/mcp that authenticates via OAuth bearer tokens and retains the legacy session-based path for cookie-auth clients.

New Features:
- Add JSON-RPC 2.0 MCP protocol helpers, dispatch logic, and tool definitions for the hosted connector, including hub listing and hub selection tools.
- Expose the hosted connector through the /api/mcp POST route when called with a bearer Authorization header, returning proper JSON-RPC responses and OAuth challenges.

Bug Fixes:
- Prevent unhandled promise rejections from the last_used_at telemetry write in connector authentication by catching and logging database update failures.

Enhancements:
- Ensure unauthenticated or invalid token calls receive a 401 with a WWW-Authenticate header pointing at the OAuth protected resource metadata endpoint.
- Enforce scope-based gating for tools/list and tools/call so only tools matching the token’s granted scopes are visible and callable, and treat unknown tools and methods as explicit JSON-RPC errors.
- Make hub selection over MCP safe by only listing and opening hubs within the token’s granted project set and binding hub handles to the token to keep project UUIDs off the wire.
- Guarantee connector responses are non-cacheable and robust to malformed JSON-RPC envelopes, notifications, and internal handler errors.

Tests:
- Add comprehensive tests for connector dispatch, tool visibility and scope enforcement, hub listing and opening semantics, JSON-RPC envelope handling, and error paths.
- Add endpoint-level tests covering authentication behaviour, unauthorized and expired/revoked token challenges, discovery without a token, notification handling, cache headers, and resilience to failing telemetry writes.