### PR TITLE
fix(mcp): let discovery reach the connector without a credential, and make §2 real

### DIFF
--- a/app/api/mcp/route.ts
+++ b/app/api/mcp/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth/next';
 
 import { authOptions } from '@/lib/auth';
-import { handleConnectorRequest } from '@/lib/mcp/connector/handle-request';
+import { handleConnectorRequest, isPublicConnectorRequest } from '@/lib/mcp/connector/handle-request';
 import { getSessionManager } from '@/lib/mcp/sessions/SessionManager';
 import { handleStreamableHTTPRequest } from '@/lib/mcp/streamable-http/handler';
 import { buildUnauthorizedResponse } from '@/lib/oauth/provider/authenticate';
@@ -40,11 +40,25 @@ export async function POST(req: NextRequest) {
     // unauthenticated caller would get a 500 instead of the challenge — so a
     // client whose first probe is empty never learns where to authenticate,
     // which is the failure this endpoint exists to avoid.
-    if (req.headers.get('authorization')?.startsWith('Bearer ')) {
-      let body: unknown;
-      try {
-        body = await req.json();
-      } catch {
+    const hasBearer = req.headers.get('authorization')?.startsWith('Bearer ') ?? false;
+
+    // The body is needed to route, not only to serve: server/discover is
+    // answerable without any credential, so a request carrying no token still
+    // belongs to the connector when that is what it asks for. Gating the
+    // connector on the bearer header alone sent an unauthenticated discover to
+    // the session path, which answered 401 — leaving a client unable to
+    // negotiate before authenticating, which is the one thing discovery exists
+    // to make possible.
+    let body: unknown;
+    let parsed = true;
+    try {
+      body = await req.json();
+    } catch {
+      parsed = false;
+    }
+
+    if (hasBearer) {
+      if (!parsed) {
         return NextResponse.json(
           { jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } },
           { status: 400 }
@@ -52,6 +66,14 @@ export async function POST(req: NextRequest) {
       }
       return handleConnectorRequest(req, body);
     }
+
+    if (parsed && isPublicConnectorRequest(body)) {
+      return handleConnectorRequest(req, body);
+    }
+
+    // An unparseable body from an unauthenticated caller still gets the
+    // challenge rather than an error: the header is how they learn where to
+    // authenticate, and a first probe with no payload is the obvious one.
 
     // Get user session for authentication
     const session = await getServerSession(authOptions);
@@ -64,7 +86,6 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const body = await req.json();
 
     // Handle the Streamable HTTP request
     const result = await handleStreamableHTTPRequest({

--- a/docs/ops/hosted-connector-deploy-checks.md
+++ b/docs/ops/hosted-connector-deploy-checks.md
@@ -123,8 +123,12 @@ Then check the case that actually happens in production — a token that has
 expired or been revoked. It must also challenge, not answer:
 
 ```bash
+# Any string that is not a live token will do; the point is that an
+# unrecognised one is challenged rather than answered.
+BOGUS=$(head -c 16 /dev/urandom | base64)
+
 curl -si -X POST "$BASE/api/mcp" \
-  -H 'Authorization: Bearer not-a-real-token' \
+  -H "Authorization: Bearer $BOGUS" \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | head -5
 #  expect: 401 with the same WWW-Authenticate header

--- a/docs/ops/hosted-connector-deploy-checks.md
+++ b/docs/ops/hosted-connector-deploy-checks.md
@@ -99,37 +99,64 @@ test "$(curl -s "$BASE/.well-known/oauth-protected-resource" | jq -r .resource)"
 
 ---
 
-## 2. The 401 challenge — not wired yet, and that is expected
+## 2. The 401 challenge
 
-`/api/mcp` returns a bare `401` today, with **no** `WWW-Authenticate` header.
-Check it and move on:
+This is now a real check. The `WWW-Authenticate` header is how Claude learns
+where the authorization server is, and it is ignored on a `200` — so it has to
+arrive on the `401`.
 
 ```bash
 curl -si -X POST "$BASE/api/mcp" -H 'Content-Type: application/json' -d '{}' | head -10
-#  expect: HTTP/2 401, and no WWW-Authenticate line
 ```
 
-**Use POST.** A GET returns `400 {"error":"Missing Mcp-Session-Id header"}`,
-which is the session check firing before authentication is ever reached — a
-different failure that looks like a broken deploy. Verified against production:
-GET → 400, POST → 401.
-
-That route still authenticates with a NextAuth session cookie; it predates this
-work. `buildUnauthorizedResponse()` and `authenticateConnectorRequest()` shipped
-in #175 but nothing calls them yet — wiring them to the MCP route is Phase B.
-
-**So do not treat a missing challenge as a broken deploy.** It is the single
-most likely thing to be misread here, because everything around it works: the
-discovery documents resolve, the consent screen renders, tokens issue.
-
-When Phase B lands, this section becomes a real check and the expected header is:
+Expect `401` and a header of this shape:
 
 ```
 WWW-Authenticate: Bearer resource_metadata="https://plugged.in/.well-known/oauth-protected-resource"
 ```
 
-with the rule that matters — it is ignored on a `200`, so it has to arrive on
-the `401`.
+**Use POST.** A GET returns `400 {"error":"Missing Mcp-Session-Id header"}` from
+the older session transport, which is a different failure that reads like a
+broken deploy.
+
+Then check the case that actually happens in production — a token that has
+expired or been revoked. It must also challenge, not answer:
+
+```bash
+curl -si -X POST "$BASE/api/mcp" \
+  -H 'Authorization: Bearer not-a-real-token' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | head -5
+#  expect: 401 with the same WWW-Authenticate header
+```
+
+The body has to be a valid JSON-RPC request here. `-d '{}'` is valid JSON but
+not a valid request, so the envelope is rejected with `400` before the token is
+ever examined — which looks like the token was accepted.
+
+And the probe most likely to be typed first, which must also challenge rather
+than error:
+
+```bash
+curl -si -X POST "$BASE/api/mcp" | head -5
+#  expect: 401 — not 500
+```
+
+That last one is a check, not a formality. The route used to read the request
+body before deciding which credential was in play, so an empty or malformed body
+threw first and produced a `500`. A client whose opening probe carries no
+payload would never have seen the header telling it where to authenticate.
+
+### Discovery answers without a token
+
+`server/discover` is the negotiation, so it precedes authentication — a client
+that cannot discover what we speak has no route to authenticating at all:
+
+```bash
+curl -s -X POST "$BASE/api/mcp" -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"server/discover"}' | jq '.result.protocolVersions'
+#  expect: ["2026-07-28"]
+```
 
 ---
 
@@ -270,10 +297,10 @@ make discovery unavailable — the flow cannot start without it.
 
 ## 8. Known gaps, so they are not mistaken for faults
 
-- **Phase B has not shipped.** Users can complete authorization, but there is no
-  tool surface behind it yet, and `/api/mcp` still answers with a bare `401`
-  rather than the bearer challenge (section 2). A connection that authorizes and
-  then exposes no tools is the expected state, not a bug.
+- **The tool surface is partial.** Hub selection ships — `pluggedin_list_hubs`
+  and `pluggedin_open_hub`. Library, clipboard, tasks and memory are Phase C, so
+  a connection that authorizes and shows only the two Hub tools is the expected
+  state, not a bug.
 - **204 test failures exist on `main`** and are unrelated to this work — they
   predate both branches and are untouched by them. Compare against `main` before
   attributing a failure to the connector.

--- a/lib/mcp/connector/handle-request.ts
+++ b/lib/mcp/connector/handle-request.ts
@@ -33,6 +33,18 @@ function json(body: unknown, status = 200): Response {
   });
 }
 
+/**
+ * Whether a body asks for something answerable without a credential.
+ *
+ * The route needs this before it can decide where to send the request: a
+ * discover call carries no token and still belongs here, because negotiating
+ * is what a client does *before* it can authenticate.
+ */
+export function isPublicConnectorRequest(raw: unknown): boolean {
+  const parsed = parseJsonRpc(raw);
+  return parsed.ok && isPublicMethod(parsed.request.method);
+}
+
 export async function handleConnectorRequest(req: Request, raw: unknown): Promise<Response> {
   const parsed = parseJsonRpc(raw);
   if (!parsed.ok) {

--- a/tests/mcp/connector-route.test.ts
+++ b/tests/mcp/connector-route.test.ts
@@ -114,3 +114,45 @@ describe('session path', () => {
     expect(handleStreamableHTTPRequest).toHaveBeenCalledOnce();
   });
 });
+
+describe('discovery without a credential', () => {
+  it('answers server/discover with no Authorization header at all', async () => {
+    // The bug this exists for: the route gated the connector on the bearer
+    // header, so an unauthenticated discover fell through to the session path
+    // and was answered 401. Negotiating is what a client does *before* it can
+    // authenticate, so that made discovery unreachable in exactly the case it
+    // is for.
+    //
+    // The earlier route test asked for discover *with* a bearer token, which
+    // passes either way — choosing the authenticated case is what hid this.
+    const response = await POST(
+      post(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'server/discover' }))
+    );
+
+    expect(response.status).toBe(200);
+    expect((await response.json()).result.protocolVersions[0]).toBe('2026-07-28');
+    expect(handleStreamableHTTPRequest).not.toHaveBeenCalled();
+  });
+
+  it('still challenges an unauthenticated call to a non-public method', async () => {
+    const response = await POST(
+      post(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }))
+    );
+
+    expect(response.status).toBe(401);
+    expect(response.headers.get('www-authenticate')).toContain('resource_metadata');
+  });
+
+  it('does not let a session-transport request be mistaken for discovery', async () => {
+    sessionValue.current = { user: { id: 'user-1' } };
+
+    const response = await POST(
+      post(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }), {
+        'Mcp-Session-Id': 'legacy-session',
+      })
+    );
+
+    expect(handleStreamableHTTPRequest).toHaveBeenCalledOnce();
+    expect(response.status).toBe(200);
+  });
+});


### PR DESCRIPTION
Found by running the deploy doc's own commands against a live server rather than trusting the tests.

### The bug

`server/discover` is answerable without a token, and `handleConnectorRequest` implements that correctly. **The route never got there** — it sent a request to the connector only when `Authorization: Bearer` was present, so an unauthenticated discover fell through to the session path and was answered `401`. Negotiating is what a client does *before* it can authenticate, so discovery was unreachable in precisely the case it exists for.

The route now parses the body first and routes on *what was asked*, not only on which credential arrived.

### Why the tests missed it — the fourth time

| Test | Entered at | Missed |
|---|---|---|
| `connector-endpoint.test.ts` | `handleConnectorRequest` | the routing decision above it |
| `connector-route.test.ts` | the route, **with a bearer token** | the credential-free case |

The second one was written in the same sitting to cover exactly this layer. Choosing the authenticated case is what hid it.

That's now four times in this work that a test entered below the layer holding the bug: seeded authorization codes hid a consent-path fault, a pre-parsed body hid a route ordering fault, and now a supplied credential hid a routing fault. **Coverage was never the problem. Where the test enters is.**

### §2 of the deploy doc

Rewritten from "not wired yet, expect a bare 401" to a real check, since #188 made the challenge live. Also corrects a command this uncovered: the expired-token check used `-d '{}'`, which is valid JSON but *not* a valid JSON-RPC request — so the envelope was rejected with `400` before the token was examined. It would have passed while proving nothing about tokens.

**All five commands were run against a running server before committing.** Their real outputs are what the section now claims:

```
POST {}                    -> 401 + www-authenticate: Bearer resource_metadata="…"
GET                        -> 400 (session transport, as the doc warns)
POST, no body              -> 401
server/discover, no token  -> 200 {"protocolVersions":["2026-07-28"]}
bogus bearer + valid RPC   -> 401 + header
```

§8 also updated: the tool surface is partial (Hub tools ship, the rest is Phase C) rather than absent.

Mutation: removing the public-method route fails 1 test. Full suite 1297 passing, same 204 pre-existing failures, build clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788650740&installation_model_id=430597&pr_number=190&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F190&signature=467b9024933294c59ac9c76b636b5866cb88280ed321d36585b6923a9e4a4d96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Ensure MCP connector discovery can be reached without credentials while still challenging unauthenticated non-public calls, and update deploy checks to reflect the live bearer challenge and current tool surface.

New Features:
- Allow unauthenticated server/discover requests to be routed to and answered by the MCP connector.

Bug Fixes:
- Fix routing so credential-free discovery requests no longer fall through to the session path and incorrectly return 401.
- Return a proper bearer challenge instead of a 500 for unauthenticated requests with empty or malformed bodies.

Enhancements:
- Refine MCP routing logic to consider the parsed JSON-RPC body and distinguish public connector methods from session transport.
- Clarify expected behaviour when legacy session transport is in play so it is not mistaken for discovery.

Documentation:
- Convert the MCP 401 challenge section of the hosted-connector deploy checks into a real bearer challenge verification, including expired-token and no-body probes.
- Update known gaps to describe the partial tool surface (Hub tools only) instead of a completely absent tool surface.

Tests:
- Add route-level tests covering discovery without credentials, unauthenticated non-public method calls, and interaction with legacy session transport.