### PR TITLE
feat(mcp): library tools, behind a Hub boundary that cannot be skipped

### DIFF
--- a/lib/mcp/connector/dispatch.ts
+++ b/lib/mcp/connector/dispatch.ts
@@ -15,8 +15,9 @@
 
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
-import { listHubs, openHub, type ToolResult } from './handlers/hubs';
+import { listHubs, openHub } from './handlers/hubs';
 import { askKnowledge, getDocument, listDocuments } from './handlers/library';
+import type { ToolResult } from './tool-result';
 import {
   buildDiscoverResult,
   buildInitializeResult,

--- a/lib/mcp/connector/dispatch.ts
+++ b/lib/mcp/connector/dispatch.ts
@@ -16,6 +16,7 @@
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
 import { listHubs, openHub, type ToolResult } from './handlers/hubs';
+import { askKnowledge, getDocument, listDocuments } from './handlers/library';
 import {
   buildDiscoverResult,
   buildInitializeResult,
@@ -46,6 +47,9 @@ const TOOL_HANDLERS: Record<
 > = {
   pluggedin_list_hubs: (identity) => listHubs(identity),
   pluggedin_open_hub: (identity, params) => openHub(identity, params),
+  pluggedin_list_documents: (identity, params) => listDocuments(identity, params),
+  pluggedin_get_document: (identity, params) => getDocument(identity, params),
+  pluggedin_ask_knowledge_base: (identity, params) => askKnowledge(identity, params),
 };
 
 export async function dispatchAuthenticated(

--- a/lib/mcp/connector/handlers/hubs.ts
+++ b/lib/mcp/connector/handlers/hubs.ts
@@ -18,7 +18,8 @@ import { db } from '@/db';
 import { oauthAccessTokensTable, projectsTable } from '@/db/schema';
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
-import { mintHubHandle, readHubHandle } from '../handles';
+import { mintHubHandle } from '../handles';
+import { requireGrantedHub } from '../hub-scope';
 
 export interface ToolResult {
   content: { type: 'text'; text: string }[];
@@ -57,26 +58,6 @@ export async function listHubs(identity: ConnectorIdentity): Promise<ToolResult>
   return text({ hubs });
 }
 
-/**
- * Resolves whatever the caller passed — a minted handle, or a Hub name — to a
- * granted project. The granted set is the authority; the handle is only a
- * convenience, so an unreadable one falls through to the name lookup rather
- * than failing differently.
- */
-export function resolveGrantedHub(
-  identity: ConnectorIdentity,
-  argument: string,
-  byName: { uuid: string; name: string }[]
-): string | undefined {
-  const fromHandle = readHubHandle(argument, identity.tokenUuid);
-  if (fromHandle && identity.grantedProjectUuids.includes(fromHandle)) return fromHandle;
-
-  const named = byName.find((row) => row.name === argument);
-  if (named && identity.grantedProjectUuids.includes(named.uuid)) return named.uuid;
-
-  return undefined;
-}
-
 export async function openHub(
   identity: ConnectorIdentity,
   params: Record<string, unknown>
@@ -84,21 +65,10 @@ export async function openHub(
   const argument = typeof params.hub === 'string' ? params.hub.trim() : '';
   if (!argument) return failure('hub is required: pass a name or a handle from pluggedin_list_hubs');
 
-  const granted = identity.grantedProjectUuids;
-  if (granted.length === 0) return failure('No Hubs were granted to this connection.');
-
-  const rows = await db
-    .select({ uuid: projectsTable.uuid, name: projectsTable.name })
-    .from(projectsTable)
-    .where(inArray(projectsTable.uuid, granted));
-
-  const projectUuid = resolveGrantedHub(identity, argument, rows);
-  if (!projectUuid) {
-    // Deliberately the same answer whether the Hub does not exist or exists and
-    // was not granted. Distinguishing them would let a caller enumerate other
-    // people's Hub names one guess at a time.
-    return failure(`No granted Hub matches "${argument}". Use pluggedin_list_hubs to see them.`);
-  }
+  // The same gate every other handler goes through, so opening a Hub cannot
+  // reach one that was never granted.
+  const resolved = await requireGrantedHub(identity, argument);
+  if (!resolved.ok) return failure(resolved.message);
 
   // Server state keyed to a credential, not protocol session state: this is a
   // per-token convenience so the next call need not repeat the choice. It does
@@ -113,7 +83,7 @@ export async function openHub(
   try {
     await db
       .update(oauthAccessTokensTable)
-      .set({ default_project_uuid: projectUuid })
+      .set({ default_project_uuid: resolved.hub })
       .where(eq(oauthAccessTokensTable.uuid, identity.tokenUuid));
   } catch (error) {
     if ((error as { code?: string })?.code === '23503') {
@@ -122,10 +92,9 @@ export async function openHub(
     throw error;
   }
 
-  const opened = rows.find((row) => row.uuid === projectUuid);
   return text({
-    opened: opened?.name,
-    handle: mintHubHandle(identity.tokenUuid, projectUuid),
+    opened: resolved.name,
+    handle: mintHubHandle(identity.tokenUuid, resolved.hub),
     note: 'Pass this handle as the `hub` argument on subsequent calls.',
   });
 }

--- a/lib/mcp/connector/handlers/hubs.ts
+++ b/lib/mcp/connector/handlers/hubs.ts
@@ -18,21 +18,10 @@ import { db } from '@/db';
 import { oauthAccessTokensTable, projectsTable } from '@/db/schema';
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
+import { toolFailure as failure, toolText as text, type ToolResult } from '../tool-result';
+
 import { mintHubHandle } from '../handles';
 import { requireGrantedHub } from '../hub-scope';
-
-export interface ToolResult {
-  content: { type: 'text'; text: string }[];
-  isError?: boolean;
-}
-
-function text(value: unknown): ToolResult {
-  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
-}
-
-function failure(message: string): ToolResult {
-  return { content: [{ type: 'text', text: message }], isError: true };
-}
 
 export async function listHubs(identity: ConnectorIdentity): Promise<ToolResult> {
   if (identity.grantedProjectUuids.length === 0) {

--- a/lib/mcp/connector/handlers/library.ts
+++ b/lib/mcp/connector/handlers/library.ts
@@ -17,21 +17,10 @@
 import { askKnowledgeBase, getDocByUuid, getDocs } from '@/app/actions/library';
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
+import { toolFailure as failure, toolText as text, type ToolResult } from '../tool-result';
+
 import type { GrantedHub } from '../hub-scope';
 import { requireGrantedHub } from '../hub-scope';
-
-export interface ToolResult {
-  content: { type: 'text'; text: string }[];
-  isError?: boolean;
-}
-
-function text(value: unknown): ToolResult {
-  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
-}
-
-function failure(message: string): ToolResult {
-  return { content: [{ type: 'text', text: message }], isError: true };
-}
 
 /** What a model is given about a document. Deliberately narrower than Doc. */
 function summarise(doc: {

--- a/lib/mcp/connector/handlers/library.ts
+++ b/lib/mcp/connector/handlers/library.ts
@@ -1,0 +1,117 @@
+/**
+ * Library tools: the documents and knowledge base of a granted Hub.
+ *
+ * Every function here takes a `GrantedHub`, never a string. The shared actions
+ * underneath accept `projectUuid?: string` and fall back to every document the
+ * *user* owns when it is missing — harmless for the web UI, where the boundary
+ * is the user, and a silent widening here, where the boundary is the Hub set
+ * granted at consent. The branded type makes forgetting it a compile error
+ * instead of a quiet leak with no symptom: the wrong documents come back and
+ * the call looks like it worked.
+ *
+ * Results are shaped for a model to read, not for a UI to render. File paths,
+ * internal profile ids and RAG document ids stay behind — a model does not need
+ * them, and everything sent crosses a trust boundary.
+ */
+
+import { askKnowledgeBase, getDocByUuid, getDocs } from '@/app/actions/library';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+import type { GrantedHub } from '../hub-scope';
+import { requireGrantedHub } from '../hub-scope';
+
+export interface ToolResult {
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}
+
+function text(value: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+function failure(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}
+
+/** What a model is given about a document. Deliberately narrower than Doc. */
+function summarise(doc: {
+  uuid: string;
+  name: string;
+  description?: string | null;
+  mime_type: string;
+  file_size: number;
+  tags?: string[] | null;
+  created_at?: Date | string;
+}) {
+  return {
+    id: doc.uuid,
+    name: doc.name,
+    description: doc.description ?? undefined,
+    mimeType: doc.mime_type,
+    sizeBytes: doc.file_size,
+    tags: doc.tags ?? undefined,
+    createdAt: doc.created_at,
+  };
+}
+
+export async function listDocuments(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const resolved = await requireGrantedHub(identity, params.hub);
+  if (!resolved.ok) return failure(resolved.message);
+
+  const result = await getDocs(identity.userId, resolved.hub);
+  if (!result.success) return failure(result.error ?? 'Could not list documents.');
+
+  const docs = (result.docs ?? []).map(summarise);
+  return text({ hub: resolved.name, count: docs.length, documents: docs });
+}
+
+export async function getDocument(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const id = typeof params.id === 'string' ? params.id.trim() : '';
+  if (!id) return failure('id is required: pass a document id from pluggedin_list_documents');
+
+  const resolved = await requireGrantedHub(identity, params.hub);
+  if (!resolved.ok) return failure(resolved.message);
+
+  const doc = await getDocByUuid(identity.userId, id, resolved.hub);
+  if (!doc) {
+    // The same answer whether the document does not exist or lives in a Hub
+    // this token was not granted. Distinguishing them would confirm the
+    // existence of documents the caller may not read.
+    return failure(`No document ${id} in Hub "${resolved.name}".`);
+  }
+
+  return text({ hub: resolved.name, document: summarise(doc) });
+}
+
+export async function askKnowledge(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const query = typeof params.query === 'string' ? params.query.trim() : '';
+  if (!query) return failure('query is required');
+
+  const resolved = await requireGrantedHub(identity, params.hub);
+  if (!resolved.ok) return failure(resolved.message);
+
+  const result = await askKnowledgeBase(identity.userId, query, resolved.hub);
+  if (!result.success) return failure(result.error ?? 'The knowledge base could not answer.');
+
+  return text({
+    hub: resolved.name,
+    answer: result.answer,
+    sources: result.sources ?? [],
+  });
+}
+
+/**
+ * Exported for the type test: proves a handler cannot reach the shared actions
+ * without a hub that requireGrantedHub produced. If this ever accepts a plain
+ * string the boundary has stopped existing.
+ */
+export type LibraryScoped = (userId: string, hub: GrantedHub) => unknown;

--- a/lib/mcp/connector/hub-scope.ts
+++ b/lib/mcp/connector/hub-scope.ts
@@ -69,6 +69,19 @@ export async function requireGrantedHub(
     .from(projectsTable)
     .where(inArray(projectsTable.uuid, granted));
 
+  // The granted set can outlive the Hubs in it: a Hub deleted after consent
+  // leaves its uuid on the token. Without this the caller fell through to
+  // "several Hubs are available, open one" — false, since none are, and it
+  // pointed at a tool that would fail the same way. A wrong message that
+  // recommends a dead end is worse than no message.
+  if (rows.length === 0) {
+    return {
+      ok: false,
+      message:
+        'The Hubs granted to this connection no longer exist. Re-authorize the connector to choose current ones.',
+    };
+  }
+
   const asked = typeof argument === 'string' ? argument.trim() : '';
   if (asked) {
     const fromHandle = readHubHandle(asked, identity.tokenUuid);

--- a/lib/mcp/connector/hub-scope.ts
+++ b/lib/mcp/connector/hub-scope.ts
@@ -1,0 +1,107 @@
+/**
+ * The one way a connector handler obtains a Hub.
+ *
+ * The shared library actions take `projectUuid?: string` and fall back to every
+ * document the *user* owns when it is absent:
+ *
+ *     } else {
+ *       // Fallback: get all documents for user
+ *       docs = await db.query.docsTable.findMany({ where: eq(docsTable.user_id, userId) })
+ *     }
+ *
+ * In the web UI that is defensible — the boundary there is the user, browsing
+ * their own data in their own session, and showing everything when no Hub is
+ * selected is a product decision. In the connector the boundary is different:
+ * it is the Hub set granted at consent. A token granted Hub A must not read Hub
+ * B, even though one person owns both. So the same fallback that is harmless in
+ * one caller silently widens authorization in the other.
+ *
+ * Making projectUuid required in the shared actions would fix the connector by
+ * breaking the UI, for no gain on the UI's side. The boundary belongs here.
+ *
+ * `GrantedHub` is a branded string that only requireGrantedHub can produce, and
+ * handlers take that type rather than `string`. Passing a raw uuid, a Hub from
+ * another user, or nothing at all is then a compile error rather than a silent
+ * widening — which matters more than a runtime check, because the failure this
+ * guards has no symptom: the wrong documents come back and everything looks
+ * like it worked.
+ */
+
+import { inArray } from 'drizzle-orm';
+
+import { db } from '@/db';
+import { projectsTable } from '@/db/schema';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+import { readHubHandle } from './handles';
+
+declare const grantedHubBrand: unique symbol;
+
+/** A project uuid proven to be in this token's granted set. */
+export type GrantedHub = string & { readonly [grantedHubBrand]: 'GrantedHub' };
+
+export type HubResolution =
+  | { ok: true; hub: GrantedHub; name: string }
+  | { ok: false; message: string };
+
+/**
+ * Resolves the Hub a call should run against.
+ *
+ * Order: what the caller named, then this token's remembered default, then the
+ * only granted Hub if there is exactly one. Anything else asks rather than
+ * guesses — picking a Hub for a user who has several would put their documents
+ * in front of a model they did not point at them.
+ */
+export async function requireGrantedHub(
+  identity: ConnectorIdentity,
+  argument?: unknown
+): Promise<HubResolution> {
+  const granted = identity.grantedProjectUuids;
+  if (granted.length === 0) {
+    return { ok: false, message: 'No Hubs were granted to this connection.' };
+  }
+
+  // Read the granted Hubs once. Names are needed to answer by name and to
+  // report back, and the query is bounded by the granted set, so a Hub outside
+  // it cannot appear here at all.
+  const rows = await db
+    .select({ uuid: projectsTable.uuid, name: projectsTable.name })
+    .from(projectsTable)
+    .where(inArray(projectsTable.uuid, granted));
+
+  const asked = typeof argument === 'string' ? argument.trim() : '';
+  if (asked) {
+    const fromHandle = readHubHandle(asked, identity.tokenUuid);
+    const match =
+      rows.find((row) => row.uuid === fromHandle) ?? rows.find((row) => row.name === asked);
+
+    if (!match) {
+      // The same answer whether the Hub does not exist or exists and was not
+      // granted. Telling them apart would let a caller enumerate other people's
+      // Hub names one guess at a time.
+      return {
+        ok: false,
+        message: `No granted Hub matches "${asked}". Use pluggedin_list_hubs to see them.`,
+      };
+    }
+    return { ok: true, hub: match.uuid as GrantedHub, name: match.name };
+  }
+
+  // The remembered default, but only if it is still granted. A Hub can leave
+  // the set — re-authorization with a narrower selection — while the column
+  // still points at it.
+  const remembered = rows.find((row) => row.uuid === identity.defaultProjectUuid);
+  if (remembered) {
+    return { ok: true, hub: remembered.uuid as GrantedHub, name: remembered.name };
+  }
+
+  if (rows.length === 1) {
+    return { ok: true, hub: rows[0].uuid as GrantedHub, name: rows[0].name };
+  }
+
+  return {
+    ok: false,
+    message:
+      'Several Hubs are available and none is open. Call pluggedin_open_hub first, or pass one as the `hub` argument.',
+  };
+}

--- a/lib/mcp/connector/tool-result.ts
+++ b/lib/mcp/connector/tool-result.ts
@@ -1,0 +1,28 @@
+/**
+ * The shape every connector tool answers in.
+ *
+ * Centralised because it was already copied between two handler files and four
+ * more groups are coming. Duplicated response shaping drifts quietly: one file
+ * starts pretty-printing, another stops setting isError, and a model sees two
+ * different conventions from one server.
+ */
+
+export interface ToolResult {
+  content: { type: 'text'; text: string }[];
+  isError?: boolean;
+}
+
+/** A successful result. Indented because a model reads this, not a parser. */
+export function toolText(value: unknown): ToolResult {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+/**
+ * A refusal the model should surface to the user.
+ *
+ * isError marks it as a tool-level failure rather than a transport one, so
+ * Claude reports it instead of treating the connection as broken.
+ */
+export function toolFailure(message: string): ToolResult {
+  return { content: [{ type: 'text', text: message }], isError: true };
+}

--- a/lib/mcp/connector/tools.ts
+++ b/lib/mcp/connector/tools.ts
@@ -57,6 +57,64 @@ export const TOOLS: readonly ToolDefinition[] = Object.freeze([
     // restored by opening the other Hub.
     annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
   },
+  {
+    name: 'pluggedin_list_documents',
+    title: 'List documents in a Hub',
+    description:
+      'List the documents stored in a Plugged.in Hub. Returns each document with an id to pass to pluggedin_get_document.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        hub: {
+          type: 'string',
+          description:
+            'Optional. Hub name or handle from pluggedin_list_hubs. Defaults to the open Hub, or the only Hub if there is one.',
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'pluggedin_get_document',
+    title: 'Get a document',
+    description:
+      'Fetch one document from a Plugged.in Hub by the id returned from pluggedin_list_documents.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Document id.' },
+        hub: {
+          type: 'string',
+          description:
+            'Optional. Hub name or handle from pluggedin_list_hubs. Defaults to the open Hub, or the only Hub if there is one.',
+        },
+      },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'pluggedin_ask_knowledge_base',
+    title: 'Ask the Hub knowledge base',
+    description:
+      "Ask a question answered from the documents in a Plugged.in Hub, with the sources it drew on. Use this instead of listing and reading documents when the user asks something the Hub's contents would answer.",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: { type: 'string', description: 'The question to answer.' },
+        hub: {
+          type: 'string',
+          description:
+            'Optional. Hub name or handle from pluggedin_list_hubs. Defaults to the open Hub, or the only Hub if there is one.',
+        },
+      },
+      required: ['query'],
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false },
+  },
 ]);
 
 /** Tools whose required scope the caller holds. */

--- a/tests/mcp/connector-dispatch.test.ts
+++ b/tests/mcp/connector-dispatch.test.ts
@@ -94,16 +94,28 @@ describe('tools/list', () => {
       { jsonrpc: '2.0', id: 1, method: 'tools/list' },
       identity({ scopes: ['hubs:read'] })
     );
-    const withoutHubs = await dispatchAuthenticated(
+    const withLibrary = await dispatchAuthenticated(
       { jsonrpc: '2.0', id: 1, method: 'tools/list' },
       identity({ scopes: ['library:read'] })
+    );
+    const withNothing = await dispatchAuthenticated(
+      { jsonrpc: '2.0', id: 1, method: 'tools/list' },
+      identity({ scopes: [] })
     );
 
     const names = (o: typeof withHubs) =>
       o.kind === 'result' ? (o.result as { tools: { name: string }[] }).tools.map((t) => t.name) : [];
 
-    expect(names(withHubs)).toContain('pluggedin_list_hubs');
-    expect(names(withoutHubs)).toHaveLength(0);
+    // Each scope shows its own group and nothing else — the interesting
+    // assertion is the exclusion, since a leaking tool list is how a model
+    // learns to call something it will only be refused for.
+    expect(names(withHubs)).toEqual(['pluggedin_list_hubs', 'pluggedin_open_hub']);
+    expect(names(withLibrary)).toEqual([
+      'pluggedin_list_documents',
+      'pluggedin_get_document',
+      'pluggedin_ask_knowledge_base',
+    ]);
+    expect(names(withNothing)).toHaveLength(0);
   });
 
   it('gives every listed tool a title and an explicit read/destructive hint', async () => {

--- a/tests/mcp/connector-library.test.ts
+++ b/tests/mcp/connector-library.test.ts
@@ -232,3 +232,26 @@ describe('what is handed to the model', () => {
     expect(result.text).toContain('No document');
   });
 });
+
+describe('grants that outlived their Hubs', () => {
+  it('says the Hubs are gone rather than telling the user to open one', async () => {
+    // A Hub deleted after consent leaves its uuid on the token, so the granted
+    // set is non-empty while the query returns nothing. The fallthrough used to
+    // answer "several Hubs are available, open one" — false, since none are,
+    // and it pointed at a tool that would fail the same way. A wrong message
+    // recommending a dead end is worse than no message.
+    grantedHubs([]);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(
+        call('pluggedin_list_documents'),
+        identity({ grantedProjectUuids: [HUB_A], defaultProjectUuid: HUB_A })
+      )
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('no longer exist');
+    expect(result.text).not.toContain('pluggedin_open_hub');
+    expect(actions.getDocs).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mcp/connector-library.test.ts
+++ b/tests/mcp/connector-library.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Library tools, and the Hub boundary they run behind.
+ *
+ * The shared actions take `projectUuid?: string` and fall back to every
+ * document the *user* owns when it is absent. That is fine for the web UI,
+ * whose boundary is the user; it is a silent widening here, whose boundary is
+ * the Hub set granted at consent. The failure has no symptom — the wrong
+ * documents come back and the call looks like it worked — so these tests assert
+ * on what reached the action, not only on what came out.
+ */
+
+const { mockDb, actions } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn(), update: vi.fn() },
+  actions: {
+    getDocs: vi.fn(),
+    getDocByUuid: vi.fn(),
+    askKnowledgeBase: vi.fn(),
+  },
+}));
+
+vi.mock('@/db', () => ({ db: mockDb }));
+vi.mock('@/app/actions/library', () => actions);
+
+process.env.NEXTAUTH_SECRET = 'connector-library-test-secret';
+process.env.NEXTAUTH_URL = 'https://plugged.in';
+
+import { db } from '@/db';
+import { dispatchAuthenticated } from '@/lib/mcp/connector/dispatch';
+import { mintHubHandle } from '@/lib/mcp/connector/handles';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+const HUB_A = '11111111-1111-1111-1111-111111111111';
+const HUB_B = '22222222-2222-2222-2222-222222222222';
+const TOKEN = '33333333-3333-3333-3333-333333333333';
+
+function identity(overrides: Partial<ConnectorIdentity> = {}): ConnectorIdentity {
+  return {
+    userId: 'user-1',
+    grantedProjectUuids: [HUB_A],
+    defaultProjectUuid: HUB_A,
+    scopes: ['library:read'],
+    tokenUuid: TOKEN,
+    ...overrides,
+  };
+}
+
+/** Rows the granted-Hub query returns. Bounded by the granted set in the real query. */
+function grantedHubs(rows: { uuid: string; name: string }[]) {
+  (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+    from: vi.fn(() => ({ where: vi.fn().mockResolvedValue(rows) })),
+  });
+}
+
+function call(name: string, args: Record<string, unknown> = {}) {
+  return { jsonrpc: '2.0' as const, id: 1, method: 'tools/call', params: { name, arguments: args } };
+}
+
+function payloadOf(outcome: Awaited<ReturnType<typeof dispatchAuthenticated>>) {
+  if (outcome.kind !== 'result') throw new Error('expected a result');
+  const result = outcome.result as { isError?: boolean; content: { text: string }[] };
+  return { isError: result.isError, text: result.content[0].text };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  actions.getDocs.mockResolvedValue({ success: true, docs: [] });
+  actions.getDocByUuid.mockResolvedValue(null);
+  actions.askKnowledgeBase.mockResolvedValue({ success: true, answer: 'because', sources: [] });
+});
+
+describe('the Hub always reaches the action', () => {
+  it('passes the resolved Hub to getDocs', async () => {
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+
+    await dispatchAuthenticated(call('pluggedin_list_documents'), identity());
+
+    // The second argument is what stops the action falling back to every
+    // document the user owns. Asserting only on the output would pass while
+    // that fallback ran.
+    expect(actions.getDocs).toHaveBeenCalledWith('user-1', HUB_A);
+  });
+
+  it('passes it to getDocByUuid and to askKnowledgeBase too', async () => {
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+
+    await dispatchAuthenticated(call('pluggedin_get_document', { id: 'doc-1' }), identity());
+    expect(actions.getDocByUuid).toHaveBeenCalledWith('user-1', 'doc-1', HUB_A);
+
+    await dispatchAuthenticated(call('pluggedin_ask_knowledge_base', { query: 'why' }), identity());
+    expect(actions.askKnowledgeBase).toHaveBeenCalledWith('user-1', 'why', HUB_A);
+  });
+
+  it('never calls an action when no Hub could be resolved', async () => {
+    grantedHubs([]);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(
+        call('pluggedin_list_documents'),
+        identity({ grantedProjectUuids: [], defaultProjectUuid: null })
+      )
+    );
+
+    expect(result.isError).toBe(true);
+    expect(actions.getDocs).not.toHaveBeenCalled();
+  });
+
+  it('refuses an ungranted Hub named explicitly', async () => {
+    // The query is bounded by the granted set, so an ungranted Hub is simply
+    // not among the rows.
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(
+        call('pluggedin_list_documents', { hub: 'Someone Elses Hub' }),
+        identity()
+      )
+    );
+
+    expect(result.isError).toBe(true);
+    expect(actions.getDocs).not.toHaveBeenCalled();
+  });
+
+  it('refuses a handle minted for another token', async () => {
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+    const foreign = mintHubHandle('a-different-token', HUB_A);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(call('pluggedin_list_documents', { hub: foreign }), identity())
+    );
+
+    expect(result.isError).toBe(true);
+    expect(actions.getDocs).not.toHaveBeenCalled();
+  });
+});
+
+describe('choosing the Hub', () => {
+  it('uses the remembered default when nothing is named', async () => {
+    grantedHubs([
+      { uuid: HUB_A, name: 'Acme' },
+      { uuid: HUB_B, name: 'Beta' },
+    ]);
+
+    await dispatchAuthenticated(
+      call('pluggedin_list_documents'),
+      identity({ grantedProjectUuids: [HUB_A, HUB_B], defaultProjectUuid: HUB_B })
+    );
+
+    expect(actions.getDocs).toHaveBeenCalledWith('user-1', HUB_B);
+  });
+
+  it('ignores a remembered default that is no longer granted', async () => {
+    // Re-authorizing with a narrower selection leaves the column pointing at a
+    // Hub the token may no longer read.
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+
+    await dispatchAuthenticated(
+      call('pluggedin_list_documents'),
+      identity({ grantedProjectUuids: [HUB_A], defaultProjectUuid: HUB_B })
+    );
+
+    expect(actions.getDocs).toHaveBeenCalledWith('user-1', HUB_A);
+  });
+
+  it('asks rather than guessing when several are granted and none is open', async () => {
+    grantedHubs([
+      { uuid: HUB_A, name: 'Acme' },
+      { uuid: HUB_B, name: 'Beta' },
+    ]);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(
+        call('pluggedin_list_documents'),
+        identity({ grantedProjectUuids: [HUB_A, HUB_B], defaultProjectUuid: null })
+      )
+    );
+
+    // Picking one would put a user's documents in front of a model they did
+    // not point at them.
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('pluggedin_open_hub');
+    expect(actions.getDocs).not.toHaveBeenCalled();
+  });
+});
+
+describe('what is handed to the model', () => {
+  it('reports documents without file paths or internal ids', async () => {
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+    actions.getDocs.mockResolvedValue({
+      success: true,
+      docs: [
+        {
+          uuid: 'doc-1',
+          user_id: 'user-1',
+          profile_uuid: 'profile-secret',
+          name: 'Notes',
+          description: null,
+          file_name: 'notes.md',
+          file_size: 12,
+          mime_type: 'text/markdown',
+          file_path: '/srv/uploads/user-1/notes.md',
+          rag_document_id: 'rag-secret',
+          source: 'upload',
+        },
+      ],
+    });
+
+    const result = payloadOf(
+      await dispatchAuthenticated(call('pluggedin_list_documents'), identity())
+    );
+
+    expect(result.text).toContain('Notes');
+    // Everything sent crosses a trust boundary, and a model has no use for any
+    // of these.
+    expect(result.text).not.toContain('/srv/uploads');
+    expect(result.text).not.toContain('profile-secret');
+    expect(result.text).not.toContain('rag-secret');
+  });
+
+  it('answers a missing document the same way as an unreadable one', async () => {
+    grantedHubs([{ uuid: HUB_A, name: 'Acme' }]);
+    actions.getDocByUuid.mockResolvedValue(null);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(call('pluggedin_get_document', { id: 'nope' }), identity())
+    );
+
+    expect(result.isError).toBe(true);
+    // Distinguishing them would confirm the existence of documents the caller
+    // may not read.
+    expect(result.text).toContain('No document');
+  });
+});


### PR DESCRIPTION
Fixes the risk flagged while scoping Phase C, then builds the first tool group on top of it.

### The risk

The shared library actions take `projectUuid?: string` and fall back to **every document the user owns** when it is absent:

```ts
} else {
  // Fallback: get all documents for user
  docs = await db.query.docsTable.findMany({ where: eq(docsTable.user_id, userId) })
}
```

Defensible in the web UI, whose boundary is the user browsing their own data. A silent widening in the connector, whose boundary is the **Hub set granted at consent** — a token granted Hub A must not read Hub B, even though one person owns both.

Note where the rule already held: `createDoc` requires `projectUuid` and throws without it. The read paths don't. **Written down on the write side, left off the read side** — the shape most findings in this work have had.

### The fix

Making `projectUuid` required in the shared actions would fix the connector by breaking the UI, for no gain there. So the boundary lives in the connector: `requireGrantedHub` returns a branded `GrantedHub`, handlers take that type rather than `string`, and passing a raw uuid is a **compile error**.

```
error TS2345: Argument of type 'string' is not assignable to parameter of type 'GrantedHub'.
```

A type check rather than a runtime one because this failure **has no symptom**: a missing Hub doesn't throw, doesn't log, doesn't return an error. The wrong documents come back and the call looks like it worked.

### Resolution asks rather than guesses

Named Hub → the token's remembered default *if still granted* (re-authorizing with a narrower selection leaves that column pointing at a Hub the token may no longer read) → the only Hub if there is exactly one. Several granted and none open: it says so. Picking one would put a user's documents in front of a model they never pointed at them.

### Three tools

`pluggedin_list_documents`, `pluggedin_get_document`, `pluggedin_ask_knowledge_base`. Results are shaped for a model, not a UI — file paths, profile uuids and RAG ids stay behind. A missing document and an unreadable one get the same answer, so the tool can't confirm the existence of documents the caller may not read.

### Verification

Tests assert on **what reached the action**, not only on what came back — asserting on output alone would pass while the fallback ran, which is the whole problem.

| Mutation | Result |
|---|---|
| Hub not passed to `getDocs` | 3 fail |
| granted-set bound removed from the query | 14 fail |
| stale default not re-checked | 1 fail |
| silently picking one of several Hubs | 1 fail |

The `tools/list` scope test correctly failed when the surface grew; updated so each scope shows its own group and nothing else.

Full suite **1307 passing** vs **1297** on main, same 204 pre-existing failures. Build clean.

### Not yet

`pluggedin_search_documents` and `pluggedin_update_document` have no shared action to wrap and need one written. Clipboard, tasks and memory follow.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788741212&installation_model_id=430597&pr_number=191&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F191&signature=ecc3b0b1c0a83de752b958deea2d652950c8b03baab63d203e23c4949566ff57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Introduce library-focused MCP tools for listing, fetching, and querying Hub documents, enforcing Hub grant boundaries via a shared resolution layer and branded Hub type so connectors cannot silently widen access beyond the granted Hub set.

New Features:
- Add MCP tools to list documents, fetch a document, and query a Hub knowledge base, exposed under the library scope.
- Return library tool results in a model-friendly summary format that omits internal file paths and identifiers while including key document metadata.

Enhancements:
- Centralize Hub resolution logic in a dedicated requireGrantedHub helper with a branded GrantedHub type, ensuring all connector handlers respect the granted Hub boundary.
- Update the Hub-opening handler to rely on the shared Hub resolution layer and reuse the same authorization boundary.
- Tighten tools/list behavior so that each scope only exposes its corresponding tool group without leaking other tools.

Tests:
- Add connector-library test suite covering Hub resolution behavior, authorization boundaries, error semantics, and the shape of data returned to models.
- Expand tools/list dispatch tests to verify that hubs and library scopes expose only their respective tools, and no tools are returned without appropriate scopes.