### PR TITLE
fix: stop SecurityError crash when Web Storage is blocked (Mobile Safari)

### DIFF
--- a/app/(sidebar-layout)/(container)/mcp-playground/hooks/usePlayground.ts
+++ b/app/(sidebar-layout)/(container)/mcp-playground/hooks/usePlayground.ts
@@ -26,6 +26,7 @@ import { McpServerStatus } from '@/db/schema';
 import { useProfiles } from '@/hooks/use-profiles';
 import { useToast } from '@/hooks/use-toast';
 import { notifications } from '@/lib/notification-helper';
+import { safeLocalStorage } from '@/lib/storage-utils';
 import { McpServer } from '@/types/mcp-server';
 
 type LogLevel = 'error' | 'warn' | 'info' | 'debug';
@@ -797,7 +798,7 @@ export function usePlayground() {
 
       try {
         // Check localStorage for session hint
-        const sessionHint = localStorage.getItem(`playground-session-${profileUuid}`);
+        const sessionHint = safeLocalStorage.getItem(`playground-session-${profileUuid}`);
         if (!sessionHint) {
           setSessionRestored(true);
           return;
@@ -868,7 +869,7 @@ export function usePlayground() {
         } else {
           // Restoration failed, clear localStorage
           addLog('error', `Session restoration failed: ${restoreResult.error || 'Unknown error'}`);
-          localStorage.removeItem(`playground-session-${profileUuid}`);
+          safeLocalStorage.removeItem(`playground-session-${profileUuid}`);
           
           toast({
             title: 'Session Lost',
@@ -878,11 +879,11 @@ export function usePlayground() {
         }
       } else {
         // Clear localStorage if server session doesn't exist
-        localStorage.removeItem(`playground-session-${profileUuid}`);
+        safeLocalStorage.removeItem(`playground-session-${profileUuid}`);
       }
       } catch (error) {
         console.error('Error restoring session:', error);
-        localStorage.removeItem(`playground-session-${profileUuid}`);
+        safeLocalStorage.removeItem(`playground-session-${profileUuid}`);
       } finally {
         setSessionRestored(true);
         // Clear the mutex flag in finally block to ensure it's always cleared
@@ -896,9 +897,9 @@ export function usePlayground() {
   // Effect to store session hint in localStorage when session becomes active
   useEffect(() => {
     if (isSessionActive && profileUuid) {
-      localStorage.setItem(`playground-session-${profileUuid}`, 'active');
+      safeLocalStorage.setItem(`playground-session-${profileUuid}`, 'active');
     } else if (!isSessionActive && profileUuid) {
-      localStorage.removeItem(`playground-session-${profileUuid}`);
+      safeLocalStorage.removeItem(`playground-session-${profileUuid}`);
     }
   }, [isSessionActive, profileUuid]);
 

--- a/app/(sidebar-layout)/(container)/mcp-playground/page.tsx
+++ b/app/(sidebar-layout)/(container)/mcp-playground/page.tsx
@@ -7,6 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { PageContainer } from '@/components/ui/page-container';
 import { useProfiles } from '@/hooks/use-profiles';
+import { safeLocalStorage } from '@/lib/storage-utils';
 import { McpServer } from '@/types/mcp-server';
 
 import { ChatHeader } from './components/chat-header';
@@ -71,7 +72,7 @@ export default function McpPlaygroundPage() {
         setSidebarCollapsed(true);
       } else if (window.innerWidth >= 1280) {
         // Auto-expand on larger screens if no preference saved
-        const saved = localStorage.getItem('playground-sidebar-collapsed');
+        const saved = safeLocalStorage.getItem('playground-sidebar-collapsed');
         if (saved === null) {
           setSidebarCollapsed(false);
         }
@@ -85,16 +86,16 @@ export default function McpPlaygroundPage() {
 
   // Load sidebar state from localStorage
   useEffect(() => {
-    const saved = localStorage.getItem('playground-sidebar-collapsed');
+    const saved = safeLocalStorage.getItem('playground-sidebar-collapsed');
     if (saved !== null && !isMobile) {
-      setSidebarCollapsed(JSON.parse(saved));
+      setSidebarCollapsed(saved === 'true');
     }
   }, [isMobile]);
 
   // Save sidebar state to localStorage
   useEffect(() => {
     if (!isMobile) {
-      localStorage.setItem('playground-sidebar-collapsed', JSON.stringify(sidebarCollapsed));
+      safeLocalStorage.setJSON('playground-sidebar-collapsed', sidebarCollapsed);
     }
   }, [sidebarCollapsed, isMobile]);
 

--- a/app/(sidebar-layout)/(container)/search/components/ClaimServerDialog.tsx
+++ b/app/(sidebar-layout)/(container)/search/components/ClaimServerDialog.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { safeLocalStorage } from '@/lib/storage-utils';
 
 interface ClaimServerDialogProps {
   open: boolean;
@@ -50,7 +51,7 @@ export function ClaimServerDialog({ open, onOpenChange, server }: ClaimServerDia
       checkGitHub();
       
       // Check if we're returning from OAuth flow
-      const savedState = localStorage.getItem('claim_server_state');
+      const savedState = safeLocalStorage.getItem('claim_server_state');
       if (savedState) {
         try {
           const state = JSON.parse(savedState);
@@ -60,11 +61,11 @@ export function ClaimServerDialog({ open, onOpenChange, server }: ClaimServerDia
           }
           // Clean up saved state if it's older than 5 minutes
           if (Date.now() - state.timestamp > 5 * 60 * 1000) {
-            localStorage.removeItem('claim_server_state');
+            safeLocalStorage.removeItem('claim_server_state');
           }
         } catch (e) {
           console.error('Error restoring claim state:', e);
-          localStorage.removeItem('claim_server_state');
+          safeLocalStorage.removeItem('claim_server_state');
         }
       }
     }
@@ -81,7 +82,7 @@ export function ClaimServerDialog({ open, onOpenChange, server }: ClaimServerDia
       returnUrl: window.location.pathname + window.location.search,
       timestamp: Date.now()
     };
-    localStorage.setItem('claim_server_state', JSON.stringify(claimState));
+    safeLocalStorage.setJSON('claim_server_state', claimState);
     
     // Get GitHub client ID based on environment
     const getGitHubClientId = () => {

--- a/app/(sidebar-layout)/(container)/settings/components/appearance-section.tsx
+++ b/app/(sidebar-layout)/(container)/settings/components/appearance-section.tsx
@@ -24,6 +24,7 @@ import {
 } from '@/components/ui/select';
 import { useMounted } from '@/hooks/use-mounted';
 import { fontFamilies, FontFamily, setFont } from '@/lib/font-utils';
+import { safeLocalStorage } from '@/lib/storage-utils';
 
 const fonts = [
   { value: 'geist', label: 'settings.appearance.fonts.geist' },
@@ -46,7 +47,7 @@ export function AppearanceSection() {
   
   // Get the saved font on component mount
   useEffect(() => {
-    const savedFont = localStorage.getItem('pluggedin-font') as FontFamily;
+    const savedFont = safeLocalStorage.getItem('pluggedin-font') as FontFamily | null;
     if (savedFont && savedFont in fontFamilies) {
       setCurrentFont(savedFont);
       setFont(savedFont);

--- a/app/(sidebar-layout)/(container)/settings/components/settings-form.tsx
+++ b/app/(sidebar-layout)/(container)/settings/components/settings-form.tsx
@@ -41,6 +41,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { users } from '@/db/schema';
 import { useLanguage } from '@/hooks/use-language';
 import { localeNames,locales } from '@/i18n/config'; // Import locales and names
+import { safeLocalStorage, safeSessionStorage } from '@/lib/storage-utils';
 
 import { type ConnectedAccount, removeConnectedAccount, removePassword, setPassword } from '../actions';
 import { AppearanceSection } from './appearance-section';
@@ -235,8 +236,8 @@ export function SettingsForm({ user, connectedAccounts }: SettingsFormProps) {
       }
 
       // Clear any local session data
-      window.localStorage.clear();
-      window.sessionStorage.clear();
+      safeLocalStorage.clear();
+      safeSessionStorage.clear();
       
       // Note: serverLogout() is not needed here because the DELETE endpoint
       // already handles session cleanup as part of the CASCADE deletion

--- a/components/auth/last-used-sso.tsx
+++ b/components/auth/last-used-sso.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { Badge } from '@/components/ui/badge';
+import { safeLocalStorage } from '@/lib/storage-utils';
 
 interface LastUsedSSO {
   provider: string;
@@ -16,7 +17,7 @@ export function LastUsedSSO() {
   
   useEffect(() => {
     // Get last used SSO from localStorage
-    const stored = localStorage.getItem('last-used-sso');
+    const stored = safeLocalStorage.getItem('last-used-sso');
     if (stored) {
       try {
         const parsed = JSON.parse(stored) as LastUsedSSO;

--- a/components/auth/sso-tracker.tsx
+++ b/components/auth/sso-tracker.tsx
@@ -2,16 +2,19 @@
 
 import { signIn as nextAuthSignIn } from 'next-auth/react';
 
+import { safeLocalStorage } from '@/lib/storage-utils';
+
 /**
  * Wrapper for signIn that tracks the last used SSO provider
  */
 export function trackAndSignIn(provider: string) {
-  // Store the provider and timestamp in localStorage
-  localStorage.setItem('last-used-sso', JSON.stringify({
+  // Store the provider and timestamp in localStorage (best-effort: sign-in must
+  // still work when storage is blocked)
+  safeLocalStorage.setJSON('last-used-sso', {
     provider,
     timestamp: Date.now(),
-  }));
-  
+  });
+
   // Proceed with the sign in
   return nextAuthSignIn(provider, { redirect: true });
 }

--- a/components/providers/i18n-provider.tsx
+++ b/components/providers/i18n-provider.tsx
@@ -6,6 +6,7 @@ import { I18nextProvider } from 'react-i18next';
 import { useSafeSession } from '@/hooks/use-safe-session';
 import i18n from '@/i18n/client';
 import { Locale, locales } from '@/i18n/config';
+import { safeLocalStorage } from '@/lib/storage-utils';
 
 export function I18nProvider({
   children,
@@ -38,7 +39,7 @@ export function I18nProvider({
               if (i18n.language !== language) {
                 i18n.changeLanguage(language);
               }
-              localStorage.setItem('pluggedin_language', language);
+              safeLocalStorage.setItem('pluggedin_language', language);
               return;
             }
           }
@@ -53,7 +54,7 @@ export function I18nProvider({
       }
 
       // 2. Check localStorage
-      const storedLang = localStorage.getItem('pluggedin_language');
+      const storedLang = safeLocalStorage.getItem('pluggedin_language');
       if (storedLang && locales.includes(storedLang as Locale)) {
         if (i18n.language !== storedLang) {
           i18n.changeLanguage(storedLang);
@@ -68,7 +69,7 @@ export function I18nProvider({
           console.debug(`Detected browser language: ${browserLang}, setting language.`);
         }
         i18n.changeLanguage(browserLang);
-        localStorage.setItem('pluggedin_language', browserLang);
+        safeLocalStorage.setItem('pluggedin_language', browserLang);
       }
 
       // 4. If nothing else, use initialLocale (fallback)
@@ -77,7 +78,11 @@ export function I18nProvider({
       }
     }
 
-    loadLanguage();
+    // Never let this become an unhandled rejection — language detection is
+    // best-effort and must not surface as a global error.
+    loadLanguage().catch((error) => {
+      console.warn('Failed to resolve preferred language:', error);
+    });
   }, [mounted, session, status, initialLocale]);
 
   return (

--- a/components/providers/theme-provider.tsx
+++ b/components/providers/theme-provider.tsx
@@ -2,6 +2,8 @@
 
 import { createContext, useContext, useEffect, useState } from "react";
 
+import { safeLocalStorage } from "@/lib/storage-utils";
+
 type Theme = "light" | "dark" | "system";
 
 type ThemeProviderProps = {
@@ -34,18 +36,13 @@ export function ThemeProvider({
   // Ensure we only access localStorage on the client side
   useEffect(() => {
     setMounted(true);
-    
-    // Only access localStorage after component is mounted on client
-    if (typeof window !== 'undefined') {
-      try {
-        const savedTheme = localStorage.getItem(storageKey);
-        if (savedTheme && (savedTheme === 'light' || savedTheme === 'dark' || savedTheme === 'system')) {
-          setTheme(savedTheme as Theme);
-        }
-      } catch (error) {
-        // localStorage might be disabled, use default theme
-        console.warn('localStorage is not available, using default theme');
-      }
+
+    // Only access localStorage after component is mounted on client.
+    // safeLocalStorage returns null when storage is blocked, so the default
+    // theme is used without throwing.
+    const savedTheme = safeLocalStorage.getItem(storageKey);
+    if (savedTheme === 'light' || savedTheme === 'dark' || savedTheme === 'system') {
+      setTheme(savedTheme);
     }
   }, [storageKey]);
 
@@ -71,14 +68,8 @@ export function ThemeProvider({
   const value = {
     theme,
     setTheme: (theme: Theme) => {
-      // Only access localStorage on client side
-      if (typeof window !== 'undefined') {
-        try {
-          localStorage.setItem(storageKey, theme);
-        } catch (error) {
-          console.warn('localStorage is not available');
-        }
-      }
+      // Persistence is best-effort; the theme still applies for this session
+      safeLocalStorage.setItem(storageKey, theme);
       setTheme(theme);
     },
   };

--- a/components/sidebar-layout.tsx
+++ b/components/sidebar-layout.tsx
@@ -59,6 +59,7 @@ import { useCodes } from '@/hooks/use-codes';
 import { useProjects } from '@/hooks/use-projects';
 import { useThemeLogo } from '@/hooks/use-theme-logo';
 import { useToast } from '@/hooks/use-toast';
+import { safeLocalStorage } from '@/lib/storage-utils';
 import { Code } from '@/types/code';
 
 import { NotificationBell } from './notification-bell';
@@ -94,38 +95,26 @@ export default function SidebarLayout({
   const { t } = useTranslation();
 
   // State for sidebar expansion
-  const [sidebarExpanded, setSidebarExpanded] = useState(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem(SIDEBAR_STATE_KEY);
-      return saved !== null ? JSON.parse(saved) : true;
-    }
-    return true;
-  });
+  const [sidebarExpanded, setSidebarExpanded] = useState<boolean>(() =>
+    safeLocalStorage.getJSON(SIDEBAR_STATE_KEY, true)
+  );
 
   // Load sidebar state from localStorage on mount
   useEffect(() => {
     setMounted(true);
-    try {
-      const savedState = localStorage.getItem(SIDEBAR_STATE_KEY);
-      if (savedState !== null) {
-        setSidebarExpanded(savedState === 'true');
-      }
-    } catch (error) {
-      console.error('Failed to load sidebar state from localStorage:', error);
+    const savedState = safeLocalStorage.getItem(SIDEBAR_STATE_KEY);
+    if (savedState !== null) {
+      setSidebarExpanded(savedState === 'true');
     }
   }, []);
 
   // Save sidebar state to localStorage when it changes
   useEffect(() => {
     if (mounted) {
-      try {
-        localStorage.setItem(SIDEBAR_STATE_KEY, JSON.stringify(sidebarExpanded));
+      safeLocalStorage.setJSON(SIDEBAR_STATE_KEY, sidebarExpanded);
 
-        // Also update via cookie to ensure the sidebar.tsx component picks it up
-        document.cookie = `sidebar:state=${sidebarExpanded}; path=/; max-age=${60 * 60 * 24 * 7}`;
-      } catch (error) {
-        console.error('Failed to save sidebar state to localStorage:', error);
-      }
+      // Also update via cookie to ensure the sidebar.tsx component picks it up
+      document.cookie = `sidebar:state=${sidebarExpanded}; path=/; max-age=${60 * 60 * 24 * 7}`;
     }
   }, [sidebarExpanded, mounted]);
 

--- a/hooks/use-language.ts
+++ b/hooks/use-language.ts
@@ -1,27 +1,22 @@
 'use client';
 
-import { useCallback, useRef } from 'react';
 import debounce from 'lodash/debounce';
+import { useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from '@/hooks/use-auth';
 import { isRTL, type Locale } from '@/i18n/config';
+import { safeLocalStorage } from '@/lib/storage-utils';
 
 class LanguageStorage {
   private static readonly LANGUAGE_KEY = 'pluggedin_language';
-  
+
   static getStoredLanguage(): string | null {
-    if (typeof window === 'undefined') {
-      return null;
-    }
-    return localStorage.getItem(this.LANGUAGE_KEY);
+    return safeLocalStorage.getItem(this.LANGUAGE_KEY);
   }
 
   static setStoredLanguage(language: string): void {
-    if (typeof window === 'undefined') {
-      return;
-    }
-    localStorage.setItem(this.LANGUAGE_KEY, language);
+    safeLocalStorage.setItem(this.LANGUAGE_KEY, language);
   }
 }
 

--- a/hooks/use-local-storage-state.ts
+++ b/hooks/use-local-storage-state.ts
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { safeLocalStorage } from '@/lib/storage-utils';
+
 type Updater<T> = T | ((prev: T) => T);
 
 /**
@@ -10,26 +12,17 @@ type Updater<T> = T | ((prev: T) => T);
  * nullish to avoid stale entries.
  */
 export function useLocalStorageState<T>(key: string, defaultValue: T) {
-  const isBrowser = typeof window !== 'undefined';
-
   const readValue = () => {
-    if (!isBrowser) {
+    const storedValue = safeLocalStorage.getItem(key);
+    if (storedValue === null) {
       return defaultValue;
     }
 
     try {
-      const storedValue = window.localStorage.getItem(key);
-      if (storedValue === null) {
-        return defaultValue;
-      }
-      try {
-        return JSON.parse(storedValue) as T;
-      } catch {
-        return storedValue as unknown as T;
-      }
-    } catch (error) {
-      console.warn(`Failed to read localStorage key "${key}":`, error);
-      return defaultValue;
+      return JSON.parse(storedValue) as T;
+    } catch {
+      // Legacy values may have been stored unserialised
+      return storedValue as unknown as T;
     }
   };
 
@@ -43,20 +36,12 @@ export function useLocalStorageState<T>(key: string, defaultValue: T) {
   );
 
   useEffect(() => {
-    if (!isBrowser) {
-      return;
+    if (state === null || state === undefined) {
+      safeLocalStorage.removeItem(key);
+    } else {
+      safeLocalStorage.setJSON(key, state);
     }
-
-    try {
-      if (state === null || state === undefined) {
-        window.localStorage.removeItem(key);
-      } else {
-        window.localStorage.setItem(key, JSON.stringify(state));
-      }
-    } catch (error) {
-      console.warn(`Failed to persist localStorage key "${key}":`, error);
-    }
-  }, [key, state, isBrowser]);
+  }, [key, state]);
 
   return [state, setLocalStorageState] as const;
 }

--- a/lib/font-utils.ts
+++ b/lib/font-utils.ts
@@ -1,3 +1,5 @@
+import { safeLocalStorage } from '@/lib/storage-utils';
+
 // Font families map for easy access
 export const fontFamilies = {
   geist: 'var(--font-geist-sans)',
@@ -16,16 +18,9 @@ export type FontFamily = keyof typeof fontFamilies;
 
 // Initialize font from localStorage or use default on client
 export function initializeFont() {
-  if (typeof window !== 'undefined') {
-    try {
-      const savedFont = localStorage.getItem('pluggedin-font') as FontFamily;
-      if (savedFont && savedFont in fontFamilies) {
-        setFont(savedFont);
-      }
-    } catch (error) {
-      // localStorage might be disabled, silently continue
-      console.warn('localStorage is not available for font preferences');
-    }
+  const savedFont = safeLocalStorage.getItem('pluggedin-font') as FontFamily | null;
+  if (savedFont && savedFont in fontFamilies) {
+    setFont(savedFont);
   }
 }
 
@@ -43,12 +38,8 @@ export function setFont(fontFamily: FontFamily) {
       // Add the new font class
       document.documentElement.classList.add(`font-${fontFamily}`);
       
-      // Save to localStorage with error handling
-      try {
-        localStorage.setItem('pluggedin-font', fontFamily);
-      } catch (storageError) {
-        console.warn('Could not save font preference to localStorage');
-      }
+      // Save to localStorage (no-op when storage is unavailable)
+      safeLocalStorage.setItem('pluggedin-font', fontFamily);
     } catch (error) {
       console.warn('Could not apply font changes to document');
     }

--- a/lib/storage-utils.ts
+++ b/lib/storage-utils.ts
@@ -1,9 +1,171 @@
 /**
  * Safe localStorage utilities with validation
+ *
+ * Browsers can make Web Storage completely unavailable: Safari in Lockdown /
+ * "Block All Cookies" mode, iOS private browsing, and embedded webviews all
+ * throw `SecurityError: The operation is insecure.` — not only from
+ * `getItem`/`setItem`, but from merely *reading* the `window.localStorage`
+ * property. Every access in the app must therefore go through the helpers
+ * below so a hostile storage environment degrades to "no persistence" instead
+ * of crashing the React tree.
  */
 
 // UUID v4 regex pattern
 const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type StorageKind = 'localStorage' | 'sessionStorage';
+
+// Warn at most once per storage area so a blocked browser does not flood the
+// console (and Sentry breadcrumbs) on every read/write.
+const warnedAreas = new Set<string>();
+
+function warnOnce(area: string, error: unknown): void {
+  if (warnedAreas.has(area)) {
+    return;
+  }
+  warnedAreas.add(area);
+  console.warn(`[storage] ${area} is unavailable, continuing without persistence:`, error);
+}
+
+/**
+ * Resolves a storage area, returning null when it is unavailable.
+ * Accessing `window.localStorage` itself throws in some browsers, so the
+ * property read is inside the try block.
+ */
+function getStorage(kind: StorageKind): Storage | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window[kind] ?? null;
+  } catch (error) {
+    warnOnce(kind, error);
+    return null;
+  }
+}
+
+export interface SafeStorage {
+  /** Reads a key, returning null when storage is unavailable or the key is missing. */
+  getItem(key: string): string | null;
+  /** Writes a key. Returns true when the value was persisted. */
+  setItem(key: string, value: string): boolean;
+  /** Removes a key. Returns true when the removal was persisted. */
+  removeItem(key: string): boolean;
+  /** Clears the storage area. Returns true when the clear was performed. */
+  clear(): boolean;
+  /** Reads and JSON-parses a key, falling back when unavailable or malformed. */
+  getJSON<T>(key: string, fallback: T): T;
+  /** JSON-serialises and writes a key. Returns true when the value was persisted. */
+  setJSON(key: string, value: unknown): boolean;
+  /** Whether the storage area can actually be written to. */
+  isAvailable(): boolean;
+}
+
+function createSafeStorage(kind: StorageKind): SafeStorage {
+  return {
+    getItem(key) {
+      const storage = getStorage(kind);
+      if (!storage) {
+        return null;
+      }
+      try {
+        return storage.getItem(key);
+      } catch (error) {
+        warnOnce(kind, error);
+        return null;
+      }
+    },
+
+    setItem(key, value) {
+      const storage = getStorage(kind);
+      if (!storage) {
+        return false;
+      }
+      try {
+        storage.setItem(key, value);
+        return true;
+      } catch (error) {
+        // Also covers QuotaExceededError when the storage area is full.
+        warnOnce(kind, error);
+        return false;
+      }
+    },
+
+    removeItem(key) {
+      const storage = getStorage(kind);
+      if (!storage) {
+        return false;
+      }
+      try {
+        storage.removeItem(key);
+        return true;
+      } catch (error) {
+        warnOnce(kind, error);
+        return false;
+      }
+    },
+
+    clear() {
+      const storage = getStorage(kind);
+      if (!storage) {
+        return false;
+      }
+      try {
+        storage.clear();
+        return true;
+      } catch (error) {
+        warnOnce(kind, error);
+        return false;
+      }
+    },
+
+    getJSON<T>(key: string, fallback: T): T {
+      const raw = this.getItem(key);
+      if (raw === null) {
+        return fallback;
+      }
+      try {
+        return JSON.parse(raw) as T;
+      } catch {
+        return fallback;
+      }
+    },
+
+    setJSON(key, value) {
+      let serialised: string;
+      try {
+        serialised = JSON.stringify(value);
+      } catch (error) {
+        console.warn(`[storage] Failed to serialise value for key "${key}":`, error);
+        return false;
+      }
+      return this.setItem(key, serialised);
+    },
+
+    isAvailable() {
+      const storage = getStorage(kind);
+      if (!storage) {
+        return false;
+      }
+      try {
+        const probe = '__storage_test__';
+        storage.setItem(probe, probe);
+        storage.removeItem(probe);
+        return true;
+      } catch (error) {
+        warnOnce(kind, error);
+        return false;
+      }
+    },
+  };
+}
+
+/** localStorage wrapper that never throws. */
+export const safeLocalStorage: SafeStorage = createSafeStorage('localStorage');
+
+/** sessionStorage wrapper that never throws. */
+export const safeSessionStorage: SafeStorage = createSafeStorage('sessionStorage');
 
 /**
  * Validates if a string is a valid UUID v4
@@ -19,27 +181,21 @@ export function isValidUUID(uuid: string): boolean {
  * @returns Valid UUID string or null if invalid/missing
  */
 export function getUUIDFromLocalStorage(key: string): string | null {
-  try {
-    const value = localStorage.getItem(key);
+  const value = safeLocalStorage.getItem(key);
 
-    if (!value) {
-      return null;
-    }
-
-    // Validate UUID format to prevent injection attacks
-    if (!isValidUUID(value)) {
-      console.warn(`Invalid UUID found in localStorage for key "${key}": ${value}`);
-      // Remove invalid value
-      localStorage.removeItem(key);
-      return null;
-    }
-
-    return value;
-  } catch (error) {
-    // localStorage might be unavailable (private browsing, quota exceeded)
-    console.warn(`Failed to access localStorage for key "${key}":`, error);
+  if (!value) {
     return null;
   }
+
+  // Validate UUID format to prevent injection attacks
+  if (!isValidUUID(value)) {
+    console.warn(`Invalid UUID found in localStorage for key "${key}": ${value}`);
+    // Remove invalid value
+    safeLocalStorage.removeItem(key);
+    return null;
+  }
+
+  return value;
 }
 
 /**
@@ -56,14 +212,7 @@ export function setUUIDInLocalStorage(key: string, uuid: string): boolean {
     return false;
   }
 
-  try {
-    localStorage.setItem(key, uuid);
-    return true;
-  } catch (error) {
-    // localStorage might be unavailable (private browsing, quota exceeded)
-    console.warn(`Failed to set localStorage for key "${key}":`, error);
-    return false;
-  }
+  return safeLocalStorage.setItem(key, uuid);
 }
 
 /**
@@ -72,23 +221,12 @@ export function setUUIDInLocalStorage(key: string, uuid: string): boolean {
  * @param key - localStorage key
  */
 export function removeFromLocalStorage(key: string): void {
-  try {
-    localStorage.removeItem(key);
-  } catch (error) {
-    console.warn(`Failed to remove localStorage key "${key}":`, error);
-  }
+  safeLocalStorage.removeItem(key);
 }
 
 /**
  * Check if localStorage is available
  */
 export function isLocalStorageAvailable(): boolean {
-  try {
-    const test = '__localStorage_test__';
-    localStorage.setItem(test, test);
-    localStorage.removeItem(test);
-    return true;
-  } catch {
-    return false;
-  }
+  return safeLocalStorage.isAvailable();
 }

--- a/tests/lib/storage-utils.test.ts
+++ b/tests/lib/storage-utils.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Reload the module under test so its per-area "warn once" state is fresh.
+ */
+async function loadStorageUtils() {
+  vi.resetModules();
+  return import('@/lib/storage-utils');
+}
+
+/**
+ * Replaces window.localStorage / window.sessionStorage with a definition whose
+ * getter throws, mirroring Safari with "Block All Cookies" / Lockdown Mode,
+ * where even reading the property raises SecurityError.
+ */
+function makeStorageAccessThrow(kind: 'localStorage' | 'sessionStorage') {
+  Object.defineProperty(window, kind, {
+    configurable: true,
+    get() {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    },
+  });
+}
+
+function installStorage(kind: 'localStorage' | 'sessionStorage', storage: unknown) {
+  Object.defineProperty(window, kind, {
+    configurable: true,
+    writable: true,
+    value: storage,
+  });
+}
+
+function createMemoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (key: string) => (map.has(key) ? map.get(key)! : null),
+    key: (index: number) => Array.from(map.keys())[index] ?? null,
+    removeItem: (key: string) => map.delete(key) as unknown as void,
+    setItem: (key: string, value: string) => {
+      map.set(key, value);
+    },
+  } as Storage;
+}
+
+const originalLocal = Object.getOwnPropertyDescriptor(window, 'localStorage');
+const originalSession = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+
+describe('safeLocalStorage', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalLocal) {
+      Object.defineProperty(window, 'localStorage', originalLocal);
+    }
+    if (originalSession) {
+      Object.defineProperty(window, 'sessionStorage', originalSession);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('reads and writes when storage works', async () => {
+    installStorage('localStorage', createMemoryStorage());
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    expect(safeLocalStorage.setItem('key', 'value')).toBe(true);
+    expect(safeLocalStorage.getItem('key')).toBe('value');
+    expect(safeLocalStorage.removeItem('key')).toBe(true);
+    expect(safeLocalStorage.getItem('key')).toBeNull();
+    expect(safeLocalStorage.isAvailable()).toBe(true);
+  });
+
+  it('does not throw when accessing window.localStorage itself throws', async () => {
+    makeStorageAccessThrow('localStorage');
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    expect(() => safeLocalStorage.getItem('key')).not.toThrow();
+    expect(safeLocalStorage.getItem('key')).toBeNull();
+    expect(safeLocalStorage.setItem('key', 'value')).toBe(false);
+    expect(safeLocalStorage.removeItem('key')).toBe(false);
+    expect(safeLocalStorage.clear()).toBe(false);
+    expect(safeLocalStorage.isAvailable()).toBe(false);
+    expect(safeLocalStorage.getJSON('key', { fallback: true })).toEqual({ fallback: true });
+    expect(safeLocalStorage.setJSON('key', { a: 1 })).toBe(false);
+  });
+
+  it('does not throw when storage methods throw SecurityError', async () => {
+    const throwing = {
+      getItem: () => {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+      setItem: () => {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+      removeItem: () => {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+      clear: () => {
+        throw new DOMException('The operation is insecure.', 'SecurityError');
+      },
+      key: () => null,
+      length: 0,
+    };
+    installStorage('localStorage', throwing);
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    expect(safeLocalStorage.getItem('key')).toBeNull();
+    expect(safeLocalStorage.setItem('key', 'value')).toBe(false);
+    expect(safeLocalStorage.removeItem('key')).toBe(false);
+    expect(safeLocalStorage.clear()).toBe(false);
+  });
+
+  it('warns at most once per storage area', async () => {
+    makeStorageAccessThrow('localStorage');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    safeLocalStorage.getItem('a');
+    safeLocalStorage.getItem('b');
+    safeLocalStorage.setItem('c', 'd');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back when the stored JSON is malformed', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem('key', '{not json');
+    installStorage('localStorage', storage);
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    expect(safeLocalStorage.getJSON('key', 'fallback')).toBe('fallback');
+  });
+
+  it('round-trips JSON values', async () => {
+    installStorage('localStorage', createMemoryStorage());
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    expect(safeLocalStorage.setJSON('key', { a: 1, b: [2, 3] })).toBe(true);
+    expect(safeLocalStorage.getJSON('key', null)).toEqual({ a: 1, b: [2, 3] });
+  });
+
+  it('reports write failure when the quota is exceeded', async () => {
+    const storage = createMemoryStorage();
+    vi.spyOn(storage, 'setItem').mockImplementation(() => {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    });
+    installStorage('localStorage', storage);
+    const { safeLocalStorage } = await loadStorageUtils();
+
+    expect(safeLocalStorage.setItem('key', 'value')).toBe(false);
+  });
+});
+
+describe('safeSessionStorage', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalSession) {
+      Object.defineProperty(window, 'sessionStorage', originalSession);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('does not throw when sessionStorage is blocked', async () => {
+    makeStorageAccessThrow('sessionStorage');
+    const { safeSessionStorage } = await loadStorageUtils();
+
+    expect(() => safeSessionStorage.clear()).not.toThrow();
+    expect(safeSessionStorage.clear()).toBe(false);
+    expect(safeSessionStorage.getItem('key')).toBeNull();
+  });
+});
+
+describe('UUID helpers with blocked storage', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (originalLocal) {
+      Object.defineProperty(window, 'localStorage', originalLocal);
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('returns null / false instead of throwing', async () => {
+    makeStorageAccessThrow('localStorage');
+    const { getUUIDFromLocalStorage, setUUIDInLocalStorage, removeFromLocalStorage, isLocalStorageAvailable } =
+      await loadStorageUtils();
+
+    const uuid = '3f1b9c2e-6a5d-4f8b-9c1e-2a7d5b3e4f60';
+    expect(getUUIDFromLocalStorage('key')).toBeNull();
+    expect(setUUIDInLocalStorage('key', uuid)).toBe(false);
+    expect(() => removeFromLocalStorage('key')).not.toThrow();
+    expect(isLocalStorageAvailable()).toBe(false);
+  });
+
+  it('rejects invalid UUIDs and clears them', async () => {
+    const storage = createMemoryStorage();
+    storage.setItem('key', 'not-a-uuid');
+    installStorage('localStorage', storage);
+    const { getUUIDFromLocalStorage, setUUIDInLocalStorage } = await loadStorageUtils();
+
+    expect(getUUIDFromLocalStorage('key')).toBeNull();
+    expect(storage.getItem('key')).toBeNull();
+    expect(setUUIDInLocalStorage('key', 'not-a-uuid')).toBe(false);
+  });
+
+  it('returns a valid stored UUID', async () => {
+    const uuid = '3f1b9c2e-6a5d-4f8b-9c1e-2a7d5b3e4f60';
+    const storage = createMemoryStorage();
+    installStorage('localStorage', storage);
+    const { getUUIDFromLocalStorage, setUUIDInLocalStorage } = await loadStorageUtils();
+
+    expect(setUUIDInLocalStorage('key', uuid)).toBe(true);
+    expect(getUUIDFromLocalStorage('key')).toBe(uuid);
+  });
+});


### PR DESCRIPTION
Fixes Sentry `PLUGGEDIN-CM` — `SecurityError: The operation is insecure.` (unhandled rejection, Mobile Safari 26.5 / iOS 18.7, transaction `/`).

## Root cause

Mobile Safari with storage blocked (Lockdown Mode, "Block All Cookies", private browsing) throws `SecurityError` for Web Storage — and critically, it throws on **reading the `window.localStorage` property itself**, not just on `getItem`/`setItem`. Guards shaped like `if (typeof window !== 'undefined') { localStorage.getItem(...) }` do not help.

The Sentry breadcrumbs show the already-guarded call sites degrading correctly (`ProjectsContext` via `useLocalStorageState`, the theme provider). The unhandled rejection came from a site that was **not** guarded: `components/providers/i18n-provider.tsx`, which is mounted in the root layout — matching the `layout-*.js` frames at the top of the stack. Its `useEffect` calls an async `loadLanguage()` whose bare `localStorage.getItem('pluggedin_language')` throws, rejecting a promise nothing awaits → `onunhandledrejection`.

## Changes

**`lib/storage-utils.ts`** — new `safeLocalStorage` / `safeSessionStorage` wrappers that:
- resolve the storage area *inside* the try block, so a throwing property access is handled
- never throw; return `null` / `false` when storage is unavailable
- warn at most once per storage area (the previous per-call warnings are what filled the breadcrumb trail with noise)
- expose `getJSON` / `setJSON` that also tolerate malformed stored values

The existing UUID helpers (`getUUIDFromLocalStorage`, `setUUIDInLocalStorage`, …) now build on these.

**All storage call sites routed through the wrappers.** Besides the i18n provider, several others would have thrown the same way on that browser:

| File | Why it mattered |
| --- | --- |
| `components/providers/i18n-provider.tsx` | the reported crash; unguarded read inside an async effect |
| `components/auth/sso-tracker.tsx` | unguarded write that would break SSO sign-in entirely |
| `mcp-playground/hooks/usePlayground.ts` | `removeItem` inside a `catch` of an async fn — a throw there escapes as another unhandled rejection |
| `components/sidebar-layout.tsx` | unguarded read in a `useState` initializer, throws during render |
| settings form, appearance section, claim-server dialog, playground page, `lib/font-utils.ts`, `hooks/use-language.ts`, `hooks/use-local-storage-state.ts`, theme provider | consolidated onto the shared wrappers |

Also attached a `.catch()` to `loadLanguage()` so any future failure in language detection degrades to a warning instead of a global error.

Behaviour when storage works is unchanged; when it is blocked, preferences simply do not persist for that session.

## Testing

- New `tests/lib/storage-utils.test.ts` — 11 tests covering throwing property access, throwing storage methods, `QuotaExceededError`, malformed JSON, warn-once behaviour, and the UUID helpers. All pass.
- `tsc --noEmit` — zero errors in non-test files. (The repo has pre-existing type errors under `tests/`; untouched here.)
- `vitest run tests/components tests/lib tests/smart-server-wizard tests/security/server-action-auth.test.ts` — identical failure set before and after: 10 files / 56 tests fail on `main` as well, and the only delta is the 11 new passing tests. Those failures are pre-existing and unrelated to this change.
- `eslint` clean on the changed files apart from pre-existing warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AqiYCvGSeqMTpFTmtwArjU


---
_Generated by [Claude Code](https://claude.ai/code/session_01AqiYCvGSeqMTpFTmtwArjU)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788898250&installation_model_id=430597&pr_number=192&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F192&signature=f4b52ee4a9395eb15d5cc33f473030cf708d86219084368a7c528ebf9f624da6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Introduce safe Web Storage wrappers and route all local/session storage usage through them to prevent crashes when storage is blocked.

New Features:
- Add safeLocalStorage and safeSessionStorage helpers that provide non-throwing read/write, JSON utilities, and availability checks for Web Storage.

Bug Fixes:
- Prevent Mobile Safari SecurityError crashes by handling exceptions on accessing window.localStorage/sessionStorage and degrading to non-persistent preferences.
- Ensure language detection in the i18n provider no longer surfaces as an unhandled rejection when storage or other errors occur.
- Avoid unhandled rejections and broken SSO/session flows by guarding playground, sidebar, claim-server dialog, font, theme, and SSO state persistence with safe storage helpers.

Enhancements:
- Standardize UUID-related localStorage helpers and local-storage-based hooks/components on the shared safe storage utilities.
- Reduce console and Sentry noise by warning at most once per storage area when storage is unavailable or quota is exceeded.

Tests:
- Add comprehensive unit tests for storage-utils covering blocked property access, throwing methods, quota exceeded, JSON handling, warn-once behaviour, and UUID helpers.