### PR TITLE
fix(deploy): write SOPS artefacts via temp+rename so re-deploys work

### DIFF
--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -40,6 +40,35 @@ done
 log() { printf '[deploy %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 die() { printf '[deploy] FATAL: %s\n' "$*" >&2; exit 1; }
 
+# Staging files created by this run, removed on any exit.
+#
+# Every stage-then-rename below writes a temp file, marks it read-only, then
+# renames it over the destination. Interrupt the script between those last two
+# steps and the temp file survives read-only. Under a FIXED name that is the
+# same trap the destinations themselves used to be: the next run's redirect or
+# `cp` opens an existing unwritable file and dies with "Permission denied",
+# wedging every future deploy. Verified: both `>` and `cp` fail against an
+# existing 0444 file.
+#
+# mktemp gives each run a unique name, so a leftover can never block a later
+# run — which also covers SIGKILL, where the trap does not fire and the only
+# residue is garbage on tmpfs. The trap keeps the normal cases tidy.
+# `rm` unlinks via the directory, so mode 0400/0444 does not obstruct cleanup.
+#
+# Cleanup hangs off EXIT alone. A bare `trap cleanup_tmp INT` would run the
+# handler and then RESUME the script, which would carry on with its staging
+# files already deleted — worse than not trapping at all. The signal traps
+# therefore only force an exit, and the EXIT trap does the removal once.
+TMP_FILES=()
+cleanup_tmp() {
+  if [ "${#TMP_FILES[@]}" -gt 0 ]; then
+    rm -f "${TMP_FILES[@]}"
+  fi
+}
+trap cleanup_tmp EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 # 1. Preflight
 command -v sops >/dev/null || die "sops not installed"
 command -v age >/dev/null  || die "age not installed"
@@ -71,10 +100,12 @@ chmod 0700 "$RUNTIME_DIR"
 #    mode (it needs write permission on the directory, not the file) and is
 #    atomic, so a concurrent reader never sees a half-written secrets file.
 log "decrypting secrets"
+secrets_tmp="$(mktemp "${SECRETS_DECRYPTED}.XXXXXX")"
+TMP_FILES+=("$secrets_tmp")
 sops --decrypt --input-type dotenv --output-type dotenv \
-  "$SECRETS_ENCRYPTED" > "${SECRETS_DECRYPTED}.tmp"
-chmod 0400 "${SECRETS_DECRYPTED}.tmp"
-mv -f "${SECRETS_DECRYPTED}.tmp" "$SECRETS_DECRYPTED"
+  "$SECRETS_ENCRYPTED" > "$secrets_tmp"
+chmod 0400 "$secrets_tmp"
+mv -f "$secrets_tmp" "$SECRETS_DECRYPTED"
 
 # 3a. Project specific secrets out of the env file into single-line files
 #     under /run/sops/, because Traefik and a few other services consume
@@ -92,9 +123,12 @@ extract_secret() {
   fi
   # Same temp-then-rename reason as the secrets file above: $dest is left
   # mode 0400, so redirecting onto it fails on every re-deploy.
-  printf '%s' "$value" > "${dest}.tmp"
-  chmod 0400 "${dest}.tmp"
-  mv -f "${dest}.tmp" "$dest"
+  local tmp
+  tmp="$(mktemp "${dest}.XXXXXX")"
+  TMP_FILES+=("$tmp")
+  printf '%s' "$value" > "$tmp"
+  chmod 0400 "$tmp"
+  mv -f "$tmp" "$dest"
 }
 
 extract_secret TRAEFIK_DASHBOARD_AUTH traefik-users
@@ -130,9 +164,13 @@ staged=0
 for src in "${INFRA_DIR}"/traefik/dynamic/*.yml; do
   [ -f "$src" ] || continue
   base="$(basename "$src")"
-  cp "$src" "${TRAEFIK_DYNAMIC_DIR}/.${base}.tmp"
-  chmod 0444 "${TRAEFIK_DYNAMIC_DIR}/.${base}.tmp"
-  mv -f "${TRAEFIK_DYNAMIC_DIR}/.${base}.tmp" "${TRAEFIK_DYNAMIC_DIR}/${base}"
+  # Same unique-temp reason as the secrets files: a fixed `.${base}.tmp` left
+  # behind read-only makes the next run's `cp` fail with "Permission denied".
+  dyn_tmp="$(mktemp "${TRAEFIK_DYNAMIC_DIR}/.${base}.XXXXXX")"
+  TMP_FILES+=("$dyn_tmp")
+  cp "$src" "$dyn_tmp"
+  chmod 0444 "$dyn_tmp"
+  mv -f "$dyn_tmp" "${TRAEFIK_DYNAMIC_DIR}/${base}"
   staged=$((staged + 1))
 done
 [ "$staged" -gt 0 ] || die "no dynamic config staged — Traefik would start with no middlewares"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -62,10 +62,19 @@ chmod 0700 "$RUNTIME_DIR"
 #    --input-type/--output-type are mandatory here: sops infers format from
 #    the file extension, and `.sops` is not a format it knows, so it falls
 #    back to JSON and dies on the first `#` comment in the dotenv payload.
+#
+#    Write via a temp file and rename rather than redirecting onto the
+#    destination. The destination is left mode 0400, so on every deploy after
+#    the first the redirect opens an existing read-only file and dies with
+#    "Permission denied" — the script only ever worked on a host where the
+#    file did not exist yet. rename(2) replaces the target regardless of its
+#    mode (it needs write permission on the directory, not the file) and is
+#    atomic, so a concurrent reader never sees a half-written secrets file.
 log "decrypting secrets"
 sops --decrypt --input-type dotenv --output-type dotenv \
-  "$SECRETS_ENCRYPTED" > "$SECRETS_DECRYPTED"
-chmod 0400 "$SECRETS_DECRYPTED"
+  "$SECRETS_ENCRYPTED" > "${SECRETS_DECRYPTED}.tmp"
+chmod 0400 "${SECRETS_DECRYPTED}.tmp"
+mv -f "${SECRETS_DECRYPTED}.tmp" "$SECRETS_DECRYPTED"
 
 # 3a. Project specific secrets out of the env file into single-line files
 #     under /run/sops/, because Traefik and a few other services consume
@@ -81,8 +90,11 @@ extract_secret() {
     log "WARN: ${key} missing from secrets.env (skipping ${dest})"
     return
   fi
-  printf '%s' "$value" > "$dest"
-  chmod 0400 "$dest"
+  # Same temp-then-rename reason as the secrets file above: $dest is left
+  # mode 0400, so redirecting onto it fails on every re-deploy.
+  printf '%s' "$value" > "${dest}.tmp"
+  chmod 0400 "${dest}.tmp"
+  mv -f "${dest}.tmp" "$dest"
 }
 
 extract_secret TRAEFIK_DASHBOARD_AUTH traefik-users


### PR DESCRIPTION
Found while deploying an eight-day production backlog. `deploy.sh` — the documented and only entry point — could not run a second time on a host where it had already run once.

## The bug

The script redirects onto its two SOPS outputs and leaves both mode `0400`:

```sh
sops --decrypt ... > "$SECRETS_DECRYPTED"
chmod 0400 "$SECRETS_DECRYPTED"
```

`>` opens the destination for writing. Against an existing `0400` file that fails, so the code path only ever worked on a host where the file did not exist yet — the initial cutover. Every deploy after that died immediately:

```
./infra/scripts/deploy.sh: line 66: /run/sops/secrets.env: Permission denied
```

before the pull, before compose, before verify. `extract_secret()` has the same shape and would have failed next.

The practical cost: production was serving the 2026-08-01 image with four merged app-affecting PRs undeployed — including the `sanitize-html` GHSA patch (#183) and the Mobile Safari crash fix (#192) — and re-running the documented deploy could not clear it.

## The fix

Write to a `.tmp` sibling, `chmod` that, then `mv -f` over the destination. `rename(2)` needs write permission on the *directory*, not on the target file, so `0400` stops being self-blocking; and it is atomic, so a reader never observes a half-written secrets file. This is the same temp-then-rename pattern the script already uses to stage Traefik's dynamic config, and for the same class of reason.

## Verification

Run against production, not a scratch host:

- `deploy.sh` completes end to end; `verify.sh` all green.
- `/run/sops` rewritten with `0400` preserved on `secrets.env`, `pg-password`, `traefik-users`; no stray `.tmp` files left behind.
- Externally: `https://plugged.in/` 200, `/api/health` 200 `{"status":"healthy","database":true}`, no `does not exist` middleware errors in Traefik.
- `traefik-users` goes 65 → 64 bytes. That is the pre-existing file having carried a trailing newline; the content is `ops:` plus a 60-character `$2b$` bcrypt hash = 64, and the dashboard still answers `401`.

## Note

This does not touch the reason the backlog existed in the first place — nothing consumes the images CI builds, because `build-image.yml` has no deploy step and `:live` is a hand-moved tag. That is being addressed separately; this PR only makes the manual entry point work more than once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788992489&installation_model_id=430597&pr_number=193&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F193&signature=5d2321d15e13f312ad05dd397786cf65f65b87b1b8bb8a6abf4adf0511827bd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Bug Fixes:
- Fix deploy.sh failing on subsequent runs when redirecting onto existing 0400 SOPS output files by switching to a temp-plus-rename write strategy for secrets.env and extracted secret files.