### PR TITLE
feat(mcp): task tools, and a second scoping axis to reach them safely

### DIFF
--- a/docs/ops/hosted-connector-deploy-checks.md
+++ b/docs/ops/hosted-connector-deploy-checks.md
@@ -301,10 +301,21 @@ make discovery unavailable — the flow cannot start without it.
 
 ## 8. Known gaps, so they are not mistaken for faults
 
-- **The tool surface is partial.** Hub selection ships — `pluggedin_list_hubs`
-  and `pluggedin_open_hub`. Library, clipboard, tasks and memory are Phase C, so
-  a connection that authorizes and shows only the two Hub tools is the expected
-  state, not a bug.
+- **The tool surface is partial.** Eight tools ship today:
+
+  | Group | Tools |
+  |---|---|
+  | Hubs | `list_hubs`, `open_hub` |
+  | Library | `list_documents`, `get_document`, `ask_knowledge_base` |
+  | Tasks | `list_notifications`, `mark_notification_done`, `delete_notification` |
+
+  Clipboard and memory are not wired yet, and neither are `search_documents` or
+  `update_document` — those two have no action underneath to call. A connection
+  showing eight tools is the expected state, not a truncated list.
+
+  Tools are also filtered by the scopes the token holds, so a connection
+  authorized for fewer scopes will legitimately show fewer tools. Check the
+  granted scopes before treating a short list as a fault.
 - **204 test failures exist on `main`** and are unrelated to this work — they
   predate both branches and are untouched by them. Compare against `main` before
   attributing a failure to the connector.

--- a/lib/mcp/connector/dispatch.ts
+++ b/lib/mcp/connector/dispatch.ts
@@ -17,6 +17,7 @@ import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
 import { listHubs, openHub } from './handlers/hubs';
 import { askKnowledge, getDocument, listDocuments } from './handlers/library';
+import { completeTask, listTasks, removeTask } from './handlers/tasks';
 import type { ToolResult } from './tool-result';
 import {
   buildDiscoverResult,
@@ -51,6 +52,9 @@ const TOOL_HANDLERS: Record<
   pluggedin_list_documents: (identity, params) => listDocuments(identity, params),
   pluggedin_get_document: (identity, params) => getDocument(identity, params),
   pluggedin_ask_knowledge_base: (identity, params) => askKnowledge(identity, params),
+  pluggedin_list_notifications: (identity, params) => listTasks(identity, params),
+  pluggedin_mark_notification_done: (identity, params) => completeTask(identity, params),
+  pluggedin_delete_notification: (identity, params) => removeTask(identity, params),
 };
 
 export async function dispatchAuthenticated(

--- a/lib/mcp/connector/handlers/tasks.ts
+++ b/lib/mcp/connector/handlers/tasks.ts
@@ -65,7 +65,7 @@ export async function completeTask(
   params: Record<string, unknown>
 ): Promise<ToolResult> {
   const id = typeof params.id === 'string' ? params.id.trim() : '';
-  if (!id) return failure('id is required: pass a task id from pluggedin_list_tasks');
+  if (!id) return failure('id is required: pass a task id from pluggedin_list_notifications');
 
   const resolved = await requireHubProfile(identity, params.hub);
   if (!resolved.ok) return failure(resolved.message);
@@ -84,7 +84,7 @@ export async function removeTask(
   params: Record<string, unknown>
 ): Promise<ToolResult> {
   const id = typeof params.id === 'string' ? params.id.trim() : '';
-  if (!id) return failure('id is required: pass a task id from pluggedin_list_tasks');
+  if (!id) return failure('id is required: pass a task id from pluggedin_list_notifications');
 
   const resolved = await requireHubProfile(identity, params.hub);
   if (!resolved.ok) return failure(resolved.message);

--- a/lib/mcp/connector/handlers/tasks.ts
+++ b/lib/mcp/connector/handlers/tasks.ts
@@ -1,0 +1,96 @@
+/**
+ * Task tools, over what the app stores as notifications.
+ *
+ * The user's word for these is "tasks", and the scope is `tasks:*`, but the
+ * table and the actions underneath are called notifications. Kept the internal
+ * names as they are rather than renaming a live table for vocabulary — the
+ * mapping is stated here once so the next reader is not left wondering whether
+ * two systems exist.
+ *
+ * These hang off a *profile*, not a project, so they go through
+ * requireHubProfile: a Hub proven granted, then that Hub's profile. A profile
+ * uuid obtained any other way has not been through the Hub check, and the
+ * branded types keep the two from being swapped.
+ */
+
+import {
+  deleteNotification,
+  getNotifications,
+  markNotificationAsRead,
+  toggleNotificationCompleted,
+} from '@/app/actions/notifications';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+import { requireHubProfile } from '../hub-scope';
+import { toolFailure as failure, toolText as text, type ToolResult } from '../tool-result';
+
+/** What a model is told about a task. Narrower than the row. */
+function summarise(row: {
+  id: string;
+  title: string;
+  message?: string | null;
+  severity?: string | null;
+  completed?: boolean | null;
+  read?: boolean | null;
+  created_at?: Date | string;
+}) {
+  return {
+    id: row.id,
+    title: row.title,
+    detail: row.message ?? undefined,
+    severity: row.severity ?? undefined,
+    done: row.completed ?? false,
+    read: row.read ?? false,
+    createdAt: row.created_at,
+  };
+}
+
+export async function listTasks(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const resolved = await requireHubProfile(identity, params.hub);
+  if (!resolved.ok) return failure(resolved.message);
+
+  const onlyOpen = params.onlyOpen === true;
+  const result = await getNotifications(resolved.profile, onlyOpen);
+  if (!result.success) return failure(result.error ?? 'Could not list tasks.');
+
+  const tasks = (result.notifications ?? []).map(summarise);
+  return text({ hub: resolved.name, count: tasks.length, tasks });
+}
+
+export async function completeTask(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const id = typeof params.id === 'string' ? params.id.trim() : '';
+  if (!id) return failure('id is required: pass a task id from pluggedin_list_tasks');
+
+  const resolved = await requireHubProfile(identity, params.hub);
+  if (!resolved.ok) return failure(resolved.message);
+
+  // Both calls carry the profile, so a task belonging to another Hub cannot be
+  // reached by id alone — the action filters on it rather than trusting the id.
+  const result = await toggleNotificationCompleted(id, resolved.profile);
+  if (!result.success) return failure(result.error ?? 'Could not complete the task.');
+
+  await markNotificationAsRead(id, resolved.profile);
+  return text({ hub: resolved.name, id, done: true });
+}
+
+export async function removeTask(
+  identity: ConnectorIdentity,
+  params: Record<string, unknown>
+): Promise<ToolResult> {
+  const id = typeof params.id === 'string' ? params.id.trim() : '';
+  if (!id) return failure('id is required: pass a task id from pluggedin_list_tasks');
+
+  const resolved = await requireHubProfile(identity, params.hub);
+  if (!resolved.ok) return failure(resolved.message);
+
+  const result = await deleteNotification(id, resolved.profile);
+  if (!result.success) return failure(result.error ?? 'Could not delete the task.');
+
+  return text({ hub: resolved.name, id, deleted: true });
+}

--- a/lib/mcp/connector/hub-scope.ts
+++ b/lib/mcp/connector/hub-scope.ts
@@ -27,7 +27,7 @@
  * like it worked.
  */
 
-import { eq, inArray } from 'drizzle-orm';
+import { and, eq, inArray } from 'drizzle-orm';
 
 import { db } from '@/db';
 import { profilesTable, projectsTable } from '@/db/schema';
@@ -148,6 +148,34 @@ export async function requireHubProfile(
   const resolved = await requireGrantedHub(identity, argument);
   if (!resolved.ok) return resolved;
 
+  // The project records which profile is active, and the web UI reads exactly
+  // that (app/actions/profiles.ts). Taking the oldest instead would point the
+  // connector at a different profile than the browser, so the same user would
+  // see one set of tasks in the UI and another through Claude — with nothing
+  // to indicate why.
+  //
+  // Still validated against the Hub: active_profile_uuid is a plain column with
+  // no guarantee it still points inside this project.
+  const project = await db
+    .select({ active: projectsTable.active_profile_uuid })
+    .from(projectsTable)
+    .where(eq(projectsTable.uuid, resolved.hub))
+    .limit(1);
+
+  const active = project[0]?.active;
+  if (active) {
+    const confirmed = await db
+      .select({ uuid: profilesTable.uuid })
+      .from(profilesTable)
+      .where(and(eq(profilesTable.uuid, active), eq(profilesTable.project_uuid, resolved.hub)))
+      .limit(1);
+    if (confirmed.length > 0) {
+      return { ...resolved, profile: confirmed[0].uuid as HubProfile };
+    }
+  }
+
+  // No active profile recorded, or it has moved out of this Hub. Oldest first
+  // is then the stable choice — the same one the app creates by default.
   const rows = await db
     .select({ uuid: profilesTable.uuid })
     .from(profilesTable)

--- a/lib/mcp/connector/hub-scope.ts
+++ b/lib/mcp/connector/hub-scope.ts
@@ -27,18 +27,30 @@
  * like it worked.
  */
 
-import { inArray } from 'drizzle-orm';
+import { eq, inArray } from 'drizzle-orm';
 
 import { db } from '@/db';
-import { projectsTable } from '@/db/schema';
+import { profilesTable, projectsTable } from '@/db/schema';
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
 import { readHubHandle } from './handles';
 
 declare const grantedHubBrand: unique symbol;
+declare const hubProfileBrand: unique symbol;
 
 /** A project uuid proven to be in this token's granted set. */
 export type GrantedHub = string & { readonly [grantedHubBrand]: 'GrantedHub' };
+
+/**
+ * A profile uuid reached *through* a granted Hub.
+ *
+ * Some tables hang off profiles rather than projects — notifications and
+ * clipboard entries do — and a Hub can hold several profiles. Branding the
+ * result separately keeps the two uuids from being used interchangeably: a
+ * GrantedHub is not a profile, and a profile obtained any other way has not
+ * been through the Hub check.
+ */
+export type HubProfile = string & { readonly [hubProfileBrand]: 'HubProfile' };
 
 export type HubResolution =
   | { ok: true; hub: GrantedHub; name: string }
@@ -117,4 +129,37 @@ export async function requireGrantedHub(
     message:
       'Several Hubs are available and none is open. Call pluggedin_open_hub first, or pass one as the `hub` argument.',
   };
+}
+
+/**
+ * The active profile of a granted Hub.
+ *
+ * Kept behind requireGrantedHub rather than taking a project uuid directly, so
+ * there is no way to reach a profile without having proved the Hub first. The
+ * lookup is scoped to the Hub, so a profile belonging to another project cannot
+ * be returned even if one were named.
+ */
+export async function requireHubProfile(
+  identity: ConnectorIdentity,
+  argument?: unknown
+): Promise<
+  { ok: true; hub: GrantedHub; name: string; profile: HubProfile } | { ok: false; message: string }
+> {
+  const resolved = await requireGrantedHub(identity, argument);
+  if (!resolved.ok) return resolved;
+
+  const rows = await db
+    .select({ uuid: profilesTable.uuid })
+    .from(profilesTable)
+    .where(eq(profilesTable.project_uuid, resolved.hub))
+    .orderBy(profilesTable.created_at)
+    .limit(1);
+
+  if (rows.length === 0) {
+    // A Hub with no profile cannot hold notifications or clipboard entries, so
+    // saying which Hub is empty is more use than a generic failure.
+    return { ok: false, message: `Hub "${resolved.name}" has no profile to read from.` };
+  }
+
+  return { ...resolved, profile: rows[0].uuid as HubProfile };
 }

--- a/lib/mcp/connector/tools.ts
+++ b/lib/mcp/connector/tools.ts
@@ -115,6 +115,69 @@ export const TOOLS: readonly ToolDefinition[] = Object.freeze([
     },
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false },
   },
+  {
+    name: 'pluggedin_list_notifications',
+    title: 'List tasks and notifications',
+    description:
+      'List the tasks and notifications in a Plugged.in Hub. Set onlyOpen to see just the ones still needing attention. Returns each with an id for the other task tools.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        onlyOpen: { type: 'boolean', description: 'Only those not yet read.' },
+        hub: {
+          type: 'string',
+          description:
+            'Optional. Hub name or handle from pluggedin_list_hubs. Defaults to the open Hub, or the only Hub if there is one.',
+        },
+      },
+      additionalProperties: false,
+    },
+    annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: true },
+  },
+  {
+    name: 'pluggedin_mark_notification_done',
+    title: 'Mark a task done',
+    description:
+      'Mark one task in a Plugged.in Hub as completed, by the id from pluggedin_list_notifications.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Task id.' },
+        hub: {
+          type: 'string',
+          description:
+            'Optional. Hub name or handle from pluggedin_list_hubs. Defaults to the open Hub, or the only Hub if there is one.',
+        },
+      },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    // Changes state but loses nothing. Not idempotent: the underlying action
+    // toggles, so calling it twice puts the task back.
+    annotations: { readOnlyHint: false, destructiveHint: false, idempotentHint: false },
+  },
+  {
+    name: 'pluggedin_delete_notification',
+    title: 'Delete a task',
+    description: 'Permanently delete one task from a Plugged.in Hub. This cannot be undone.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string', description: 'Task id.' },
+        hub: {
+          type: 'string',
+          description:
+            'Optional. Hub name or handle from pluggedin_list_hubs. Defaults to the open Hub, or the only Hub if there is one.',
+        },
+      },
+      required: ['id'],
+      additionalProperties: false,
+    },
+    // The only destructive tool in the surface so far, and marked as such:
+    // Anthropic's directory rules require the hint, and a model treats a
+    // destructive tool differently.
+    annotations: { readOnlyHint: false, destructiveHint: true, idempotentHint: true },
+  },
 ]);
 
 /** Tools whose required scope the caller holds. */

--- a/tests/mcp/connector-tasks.test.ts
+++ b/tests/mcp/connector-tasks.test.ts
@@ -48,25 +48,66 @@ function identity(overrides: Partial<ConnectorIdentity> = {}): ConnectorIdentity
 }
 
 /**
- * requireHubProfile makes two queries: the granted Hubs, then that Hub's
- * profiles. Answering them in order is what lets these tests assert the second
- * was scoped to the first.
+ * requireHubProfile queries in order: the granted Hubs, then the project's
+ * active_profile_uuid, then either a confirmation that the active profile is
+ * still inside that Hub, or the oldest profile as a fallback. Answering them in
+ * sequence is what lets these tests assert the connector lands on the same
+ * profile the web UI uses.
  */
 function hubThenProfile(
   hubs: { uuid: string; name: string }[],
-  profiles: { uuid: string }[]
+  profiles: { uuid: string }[],
+  activeProfileUuid?: string | null
 ) {
-  const profileWhere = vi.fn(() => ({
-    orderBy: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(profiles) })),
-  }));
-  let call = 0;
+  const calls: string[] = [];
+  const confirmColumns: string[] = [];
+  let n = 0;
   (db.select as ReturnType<typeof vi.fn>).mockImplementation(() => ({
     from: vi.fn(() => {
-      call += 1;
-      return call === 1 ? { where: vi.fn().mockResolvedValue(hubs) } : { where: profileWhere };
+      n += 1;
+      if (n === 1) {
+        calls.push('granted-hubs');
+        return { where: vi.fn().mockResolvedValue(hubs) };
+      }
+      if (n === 2) {
+        calls.push('active-profile');
+        return {
+          where: vi.fn(() => ({
+            limit: vi.fn().mockResolvedValue([{ active: activeProfileUuid ?? null }]),
+          })),
+        };
+      }
+      calls.push(activeProfileUuid ? 'confirm-active' : 'oldest-profile');
+      return {
+        where: vi.fn((condition: unknown) => {
+          confirmColumns.push(...columnsIn(condition));
+          return {
+            limit: vi.fn().mockResolvedValue(profiles),
+            orderBy: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(profiles) })),
+          };
+        }),
+      };
     }),
   }));
-  return { profileWhere };
+  return { calls, confirmColumns };
+}
+
+/**
+ * drizzle nests an and() as SQL objects whose queryChunks hold further chunks,
+ * so the columns a condition names are only reachable by walking the tree.
+ * Reading them is how the test below asserts on the SQL the query states,
+ * rather than on what the mock chose to return — a mock that ignores the where
+ * clause answers the same whether or not the condition is there.
+ */
+function columnsIn(chunks: unknown, depth = 0): string[] {
+  if (depth > 6 || chunks == null) return [];
+  if (Array.isArray(chunks)) return chunks.flatMap((c) => columnsIn(c, depth + 1));
+  if (typeof chunks !== 'object') return [];
+  const node = chunks as { name?: unknown; queryChunks?: unknown };
+  return [
+    ...(typeof node.name === 'string' ? [node.name] : []),
+    ...columnsIn(node.queryChunks, depth + 1),
+  ];
 }
 
 function call(name: string, args: Record<string, unknown> = {}) {
@@ -99,11 +140,12 @@ describe('the profile is reached through the Hub', () => {
   it('scopes the profile query to the resolved Hub', async () => {
     // Without this the profile could come from any project the user owns,
     // which is what the existing clipboard helper does.
-    const { profileWhere } = hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+    const { calls } = hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
 
     await dispatchAuthenticated(call('pluggedin_list_notifications'), identity());
 
-    expect(profileWhere).toHaveBeenCalledOnce();
+    expect(calls[0]).toBe('granted-hubs');
+    expect(calls).toContain('oldest-profile');
   });
 
   it('never reaches an action when the Hub cannot be resolved', async () => {
@@ -187,5 +229,64 @@ describe('annotations', () => {
       readOnlyHint: false,
       destructiveHint: false,
     });
+  });
+});
+
+describe('which profile the connector lands on', () => {
+  it("uses the project's active profile, not the oldest", async () => {
+    // The web UI reads active_profile_uuid. Taking the oldest instead would
+    // point the connector at a different profile than the browser, so the same
+    // user would see one set of tasks in the UI and another through Claude,
+    // with nothing to indicate why.
+    const OTHER = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: OTHER }], OTHER);
+
+    await dispatchAuthenticated(call('pluggedin_list_notifications'), identity());
+
+    expect(actions.getNotifications).toHaveBeenCalledWith(OTHER, false);
+  });
+
+  it('confirms the active profile still belongs to the Hub', async () => {
+    // active_profile_uuid is a plain column with no guarantee it still points
+    // inside this project, so it is confirmed before being used.
+    //
+    // Asserted on the SQL rather than the result: the mock answers the same
+    // whether or not the project_uuid condition is present, so checking the
+    // returned rows would pass with the condition deleted.
+    const { confirmColumns } = hubThenProfile(
+      [{ uuid: HUB_A, name: 'Acme' }],
+      [{ uuid: PROFILE_A }],
+      PROFILE_A
+    );
+
+    await dispatchAuthenticated(call('pluggedin_list_notifications'), identity());
+
+    expect(confirmColumns).toContain('uuid');
+    expect(confirmColumns).toContain('project_uuid');
+  });
+
+  it('falls back when the active profile is not in the Hub', async () => {
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [], 'a-profile-somewhere-else');
+
+    const result = payloadOf(
+      await dispatchAuthenticated(call('pluggedin_list_notifications'), identity())
+    );
+
+    expect(result.isError).toBe(true);
+    expect(actions.getNotifications).not.toHaveBeenCalled();
+  });
+
+  it('names no non-existent tool in its failures', async () => {
+    // The error strings said pluggedin_list_tasks, which is not a tool —
+    // TOOL_SCOPES fails closed, so a caller following that advice would be
+    // told the tool is unknown.
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(call('pluggedin_mark_notification_done', {}), identity())
+    );
+
+    expect(result.text).toContain('pluggedin_list_notifications');
+    expect(result.text).not.toContain('pluggedin_list_tasks');
   });
 });

--- a/tests/mcp/connector-tasks.test.ts
+++ b/tests/mcp/connector-tasks.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Task tools, and the second scoping axis they introduced.
+ *
+ * Documents hang off a project; notifications hang off a *profile*. So the Hub
+ * check alone is not enough here — a profile has to be reached through a
+ * granted Hub, never looked up on its own. The pre-existing app code shows why
+ * that matters: clipboard's helper resolves a profile by taking the user's
+ * first project with `LIMIT 1` and no ordering, which ignores the granted set
+ * entirely. Reaching a profile any other way reintroduces exactly that.
+ */
+
+const { mockDb, actions } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn(), update: vi.fn() },
+  actions: {
+    getNotifications: vi.fn(),
+    toggleNotificationCompleted: vi.fn(),
+    markNotificationAsRead: vi.fn(),
+    deleteNotification: vi.fn(),
+  },
+}));
+
+vi.mock('@/db', () => ({ db: mockDb }));
+vi.mock('@/app/actions/notifications', () => actions);
+
+process.env.NEXTAUTH_SECRET = 'connector-tasks-test-secret';
+process.env.NEXTAUTH_URL = 'https://plugged.in';
+
+import { db } from '@/db';
+import { dispatchAuthenticated } from '@/lib/mcp/connector/dispatch';
+import { findTool } from '@/lib/mcp/connector/tools';
+import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
+
+const HUB_A = '11111111-1111-1111-1111-111111111111';
+const PROFILE_A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const TOKEN = '33333333-3333-3333-3333-333333333333';
+
+function identity(overrides: Partial<ConnectorIdentity> = {}): ConnectorIdentity {
+  return {
+    userId: 'user-1',
+    grantedProjectUuids: [HUB_A],
+    defaultProjectUuid: HUB_A,
+    scopes: ['tasks:read', 'tasks:write'],
+    tokenUuid: TOKEN,
+    ...overrides,
+  };
+}
+
+/**
+ * requireHubProfile makes two queries: the granted Hubs, then that Hub's
+ * profiles. Answering them in order is what lets these tests assert the second
+ * was scoped to the first.
+ */
+function hubThenProfile(
+  hubs: { uuid: string; name: string }[],
+  profiles: { uuid: string }[]
+) {
+  const profileWhere = vi.fn(() => ({
+    orderBy: vi.fn(() => ({ limit: vi.fn().mockResolvedValue(profiles) })),
+  }));
+  let call = 0;
+  (db.select as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+    from: vi.fn(() => {
+      call += 1;
+      return call === 1 ? { where: vi.fn().mockResolvedValue(hubs) } : { where: profileWhere };
+    }),
+  }));
+  return { profileWhere };
+}
+
+function call(name: string, args: Record<string, unknown> = {}) {
+  return { jsonrpc: '2.0' as const, id: 1, method: 'tools/call', params: { name, arguments: args } };
+}
+
+function payloadOf(outcome: Awaited<ReturnType<typeof dispatchAuthenticated>>) {
+  if (outcome.kind !== 'result') throw new Error('expected a result');
+  const result = outcome.result as { isError?: boolean; content: { text: string }[] };
+  return { isError: result.isError, text: result.content[0].text };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  actions.getNotifications.mockResolvedValue({ success: true, notifications: [] });
+  actions.toggleNotificationCompleted.mockResolvedValue({ success: true });
+  actions.markNotificationAsRead.mockResolvedValue({ success: true });
+  actions.deleteNotification.mockResolvedValue({ success: true });
+});
+
+describe('the profile is reached through the Hub', () => {
+  it('passes the Hub profile to getNotifications', async () => {
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+
+    await dispatchAuthenticated(call('pluggedin_list_notifications'), identity());
+
+    expect(actions.getNotifications).toHaveBeenCalledWith(PROFILE_A, false);
+  });
+
+  it('scopes the profile query to the resolved Hub', async () => {
+    // Without this the profile could come from any project the user owns,
+    // which is what the existing clipboard helper does.
+    const { profileWhere } = hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+
+    await dispatchAuthenticated(call('pluggedin_list_notifications'), identity());
+
+    expect(profileWhere).toHaveBeenCalledOnce();
+  });
+
+  it('never reaches an action when the Hub cannot be resolved', async () => {
+    hubThenProfile([], []);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(
+        call('pluggedin_list_notifications'),
+        identity({ grantedProjectUuids: [], defaultProjectUuid: null })
+      )
+    );
+
+    expect(result.isError).toBe(true);
+    expect(actions.getNotifications).not.toHaveBeenCalled();
+  });
+
+  it('says which Hub is empty when it holds no profile', async () => {
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], []);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(call('pluggedin_list_notifications'), identity())
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('Acme');
+    expect(actions.getNotifications).not.toHaveBeenCalled();
+  });
+});
+
+describe('writes carry the profile too', () => {
+  it('completes a task against the Hub profile, not by id alone', async () => {
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+
+    await dispatchAuthenticated(
+      call('pluggedin_mark_notification_done', { id: 'task-1' }),
+      identity()
+    );
+
+    // The action filters on the profile, so a task in another Hub cannot be
+    // reached by guessing its id.
+    expect(actions.toggleNotificationCompleted).toHaveBeenCalledWith('task-1', PROFILE_A);
+  });
+
+  it('deletes against the Hub profile', async () => {
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+
+    await dispatchAuthenticated(call('pluggedin_delete_notification', { id: 'task-1' }), identity());
+
+    expect(actions.deleteNotification).toHaveBeenCalledWith('task-1', PROFILE_A);
+  });
+
+  it('refuses a write when the token holds only tasks:read', async () => {
+    hubThenProfile([{ uuid: HUB_A, name: 'Acme' }], [{ uuid: PROFILE_A }]);
+
+    const result = payloadOf(
+      await dispatchAuthenticated(
+        call('pluggedin_delete_notification', { id: 'task-1' }),
+        identity({ scopes: ['tasks:read'] })
+      )
+    );
+
+    expect(result.isError).toBe(true);
+    expect(actions.deleteNotification).not.toHaveBeenCalled();
+  });
+});
+
+describe('annotations', () => {
+  it('marks deletion destructive and listing read-only', () => {
+    // Anthropic's directory rules require these, and a model treats a
+    // destructive tool differently. Getting it wrong is caught at submission,
+    // long after it would have mattered.
+    expect(findTool('pluggedin_delete_notification')?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: true,
+    });
+    expect(findTool('pluggedin_list_notifications')?.annotations).toMatchObject({
+      readOnlyHint: true,
+      destructiveHint: false,
+    });
+    expect(findTool('pluggedin_mark_notification_done')?.annotations).toMatchObject({
+      readOnlyHint: false,
+      destructiveHint: false,
+    });
+  });
+});


### PR DESCRIPTION
Documents hang off a project; notifications hang off a **profile**. The Hub check alone doesn't reach these — a profile has to come *through* a granted Hub, never be looked up on its own.

### Why that matters, from the existing code

`app/actions/clipboard.ts` resolves a profile like this:

```ts
const project = await db.select(...).from(projectsTable)
  .where(eq(projectsTable.user_id, userId))
  .limit(1);          // the user's first project, no ordering
```

with a comment saying *"they can have one project in the simplified model"*. The whole Hub feature is built on users having several. That helper picks an arbitrary project and ignores the granted set entirely.

`requireHubProfile` therefore sits behind `requireGrantedHub` and returns a branded `HubProfile`, so a profile uuid and a project uuid can't be swapped, and neither can be obtained without the Hub check.

### Three tools

Under the names already in `TOOL_SCOPES` rather than a second vocabulary — that map is the authorization decision and **fails closed**, so inventing `pluggedin_list_tasks` would have produced a tool nothing could call. Delete carries `destructiveHint`; it's the first such tool here and a model treats one differently.

### Clipboard is deliberately not in this change

Its actions take **no profile argument at all**: they call `requireAuthUserId()`, which reads a NextAuth session the connector doesn't have, then the arbitrary-project helper above. Wrapping them would either throw or cross the Hub boundary.

Making them usable means changing shared app code the web UI depends on. That's a decision worth making explicitly rather than smuggling into a connector PR — **flagging it for a call rather than doing it here.**

### Verification

| Mutation | Result |
|---|---|
| profile query not scoped to the Hub | 5 fail |
| completion not carrying the profile | 1 fail |
| profile-less Hub branch removed | 1 fail |
| `destructiveHint` dropped on delete | 1 fail |

Full suite **1327 passing** vs **1297** on main, same 204 pre-existing failures. Build clean.

§8 of the deploy doc updated: it still described the surface as two Hub tools, and now names all eight — plus the fact that scope filtering can legitimately shorten the list, so a short list isn't automatically a fault.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789016821&installation_model_id=430597&pr_number=194&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F194&signature=ff2c5d7a51f292818b411c4c55f2f7a6f766351aca324383f5bd687765a00349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Add task tools to the MCP connector and ensure they operate over profiles that are reached via granted Hubs, with updated documentation and tests for the expanded tool surface and scoping model.

New Features:
- Expose tools to list tasks/notifications, mark them done, and delete them within a Plugged.in Hub.
- Add a handler module for task operations that integrates with existing notification actions and MCP dispatch.

Enhancements:
- Introduce HubProfile branding and a helper to resolve profiles through a granted Hub, preventing cross-Hub access by profile id.
- Wire task tools into the MCP connector dispatch table and enforce scope-based access for read vs write operations.
- Update deployment documentation to describe the full set of available Hub, library, and task tools and scope-based filtering.

Tests:
- Add connector task tests covering Hub-profile scoping, error handling for missing or unresolved Hubs, scope checks on writes, and tool annotation correctness.