### PR TITLE
infra: pull-based automatic deployment

### DIFF
--- a/.claude/skills/pluggedin-stack-ops/SKILL.md
+++ b/.claude/skills/pluggedin-stack-ops/SKILL.md
@@ -20,11 +20,17 @@ decryption, so the secrets file and the staged Traefik config never appear.
 | Smoke test | `./infra/scripts/verify.sh` (add `--quick` to skip the RAG canary) |
 | Logs | `docker compose -f infra/docker-compose.yml logs -f --tail=50 pluggedin-app traefik` |
 | Which routers exist | Traefik dashboard at `https://traefik.plugged.in/api/http/routers` (basic auth) |
+| Is a deploy waiting? | `infra/scripts/deploy-watch.sh --status` |
 
 Health must report `"status":"healthy"` **and** `"database":true`. The endpoint never
 emits `"ok"` — asserting that is a bug that once made the smoke test unpassable.
 
 ## Deploying is not just `git pull`
+
+> Application merges to `main` now deploy themselves within ~2 minutes via
+> `pluggedin-deploy-watch.timer`. `deploy.sh` remains the entry point for
+> anything the infra gate blocks — `infra/`, compose, `Dockerfile`,
+> workflows — and for any manual intervention. See `docs/ops/auto-deploy.md`.
 
 > **`git pull` alone can 404 the site.**
 

--- a/docs/ops/auto-deploy.md
+++ b/docs/ops/auto-deploy.md
@@ -8,7 +8,7 @@ Application-code merges to `main`, within about two minutes. A commit range
 is blocked from unattended deployment if it touches any of:
 
 - `infra/`
-- `docker-compose*.yml`
+- `docker-compose*.yml` at the repo root
 - any root-level `Dockerfile` variant (e.g. `Dockerfile`, `Dockerfile.production`)
 - `.dockerignore` at the repo root
 - anything under `.github/` (not just `.github/workflows/` — composite
@@ -71,6 +71,28 @@ Run it by hand first and watch, rather than trusting the timer's first fire:
 Deploying by hand moves the running revision past the infra commit, and the
 next cycle proceeds on its own (see "What deploys by itself" above for why
 later app-only commits alone never do this).
+
+## Verification timeout
+
+After a deploy (and after a rollback attempt), `external_check` polls
+`${SITE_URL}/api/health` every `EXTERNAL_CHECK_INTERVAL` seconds (default
+`5`) until it returns HTTP 200 with `"status":"healthy"`, or until a
+wall-clock deadline of `EXTERNAL_CHECK_TIMEOUT` seconds (default `90`)
+passes — override either with those environment variables. The 90s default
+covers the app healthcheck's own `start_period: 30s` plus Traefik's LB
+healthcheck only re-polling backend health every 30s, so a freshly deployed
+container can legitimately take up to ~60s to become both healthy and
+reachable through Traefik before the deadline gives up on it.
+
+If deploys keep getting rolled back and you suspect verification is racing
+a slow container start rather than catching a real failure, check
+`journalctl -u pluggedin-deploy-watch.service` for how close to the 90s
+mark the failure landed. Near the deadline points at a slow start, not a
+broken deploy — retry with a longer budget, e.g.
+`EXTERNAL_CHECK_TIMEOUT=180 infra/scripts/deploy-watch.sh` for a one-off
+manual run, or via `Environment=` in the systemd unit for the timer. A
+failure early, well inside the default window, points at a genuinely broken
+deploy instead, and raising the timeout would only delay finding that out.
 
 ## When rollback reports a migration was applied
 

--- a/docs/ops/auto-deploy.md
+++ b/docs/ops/auto-deploy.md
@@ -1,0 +1,117 @@
+# Automatic deployment
+
+Design: `docs/superpowers/specs/2026-08-10-auto-deploy-design.md`
+
+## What deploys by itself
+
+Application-code merges to `main`, within about two minutes. A commit range
+is blocked from unattended deployment if it touches any of:
+
+- `infra/`
+- `docker-compose*.yml`
+- any root-level `Dockerfile` variant (e.g. `Dockerfile`, `Dockerfile.production`)
+- `.dockerignore` at the repo root
+- anything under `.github/` (not just `.github/workflows/` — composite
+  actions under `.github/actions/` are just as capable of reaching secrets)
+
+A blocked deploy is recorded and waits for a human; it does not retry itself
+into working. **Once the gate blocks a range, later app-only commits do not
+unblock it** — the poller always evaluates from the *running* revision to the
+*latest* revision, so as long as the running revision is still behind the
+infra commit, that commit is still in the range and the gate still fires,
+no matter how many purely-app commits land on top of it. The block only
+clears when a human deploys and the running revision moves past the infra
+commit (see "Unblocking the gate" below); nothing here goes stale on its own.
+
+Nothing notifies you of any of this — no email, no Slack, nothing. The only
+way to learn a deploy happened, failed, or is blocked is to ask:
+
+    infra/scripts/deploy-watch.sh --status
+
+## Install
+
+    git clone https://github.com/VeriTeknik/pluggedin-app /home/pluggedin/deploy-tree
+    git -C /home/pluggedin/deploy-tree checkout --detach origin/main
+    sudo cp infra/systemd/pluggedin-deploy-watch.* /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now pluggedin-deploy-watch.timer
+
+## First run, supervised
+
+Two things about this first run are unverified before it happens, and both
+need a human watching:
+
+1. **The systemd hardening directives have never been exercised.** The unit
+   carries eight hardening directives — `NoNewPrivileges`,
+   `ProtectKernelModules`, `ProtectKernelTunables`, `ProtectControlGroups`,
+   `ProtectClock`, `RestrictSUIDSGID`, `RestrictRealtime`, `LockPersonality`
+   — none of which have run against this host before. Confirm the run
+   actually reached `git fetch` and `docker pull`/`docker compose` rather
+   than failing silently inside the sandbox:
+
+       journalctl -u pluggedin-deploy-watch.service -n 50
+       # look for "deploying <sha>" or "up to date at <sha>", not a bare
+       # non-zero exit with no deploy-watch log lines at all
+
+2. **Compose labels containers with the project working directory.**
+   Deploying from a second checkout (`/home/pluggedin/deploy-tree`, not the
+   maintainer's usual checkout) changes that label, so the first run may
+   recreate more than just the app container.
+
+Run it by hand first and watch, rather than trusting the timer's first fire:
+
+    infra/scripts/deploy-watch.sh --dry-run
+    infra/scripts/deploy-watch.sh
+    docker compose -f /home/pluggedin/deploy-tree/infra/docker-compose.yml ps
+
+## Unblocking the gate
+
+    IMAGE_TAG=sha-<short> infra/scripts/deploy.sh
+
+Deploying by hand moves the running revision past the infra commit, and the
+next cycle proceeds on its own (see "What deploys by itself" above for why
+later app-only commits alone never do this).
+
+## When rollback reports a migration was applied
+
+`deploy-watch.sh` migrates the schema *before* replacing the running
+container, so a verification failure after a migration ran cannot be
+silently undone: the image can be swapped back, the schema cannot. Check
+`--status` and `journalctl` for one of three outcomes, each requiring a
+different response:
+
+- **`rolled back and verified`** — the previous image is back up and passed
+  `external_check`. If the range also touched `drizzle/`, this is still
+  followed by a `MIGRATION ALREADY APPLIED, needs a human` marker: the old
+  code is now running against a newer schema. Decide between rolling the
+  schema forward with a fix or restoring from backup.
+- **`rollback attempted but NOT verified`** — the retag and/or redeploy to
+  the previous image may have partly landed, but `external_check` did not
+  confirm it's healthy. Do not assume the site is back; check it directly
+  and be ready to intervene by hand.
+- **`NO ROLLBACK POSSIBLE (previous image unknown)`** — there was no prior
+  running container to roll back to (e.g. first-ever deploy through this
+  path). The stack is left as `do_deploy` left it; diagnose from there.
+
+In any of these, if the outcome also carries `MIGRATION ALREADY APPLIED,
+needs a human`, the schema changed and was never rolled back by this script.
+The pre-migration dump is the newest file in `/var/backups/pluggedin/` —
+note a backup is only taken when the deploying commit range touches
+`drizzle/`, so if migrations were involved a dump exists. See
+`infra/scripts/restore.sh` to restore it; the dumps are age-encrypted.
+
+## What this does NOT do
+
+- **No notifications of any kind.** Not email, not Slack, not anything else.
+  `infra/scripts/deploy-watch.sh --status` (and `journalctl -u
+  pluggedin-deploy-watch.service`) are the only ways to learn that a deploy
+  ran, failed, or is sitting blocked behind the infra gate.
+- **The deploy path has only ever run against stubs.** `test-deploy-watch.sh`
+  exercises the logic with fake `docker`/`git`/`curl` on `PATH`; nothing in
+  this branch has driven a real deploy, a real rollback, or a real migration
+  against production. Treat the first real run of each path — deploy,
+  rollback, migration — as unverified until watched happen once.
+
+## Logs
+
+    journalctl -u pluggedin-deploy-watch.service -n 100

--- a/docs/ops/auto-deploy.md
+++ b/docs/ops/auto-deploy.md
@@ -23,6 +23,11 @@ no matter how many purely-app commits land on top of it. The block only
 clears when a human deploys and the running revision moves past the infra
 commit (see "Unblocking the gate" below); nothing here goes stale on its own.
 
+**A deploy that fails is not retried automatically either** — see "When an
+automatic deploy fails" below. This is deliberate: a failed target stays
+failed until a human (or a fix pushed as a newer commit) resolves it,
+rather than the poller hammering the same broken target every two minutes.
+
 Nothing notifies you of any of this — no email, no Slack, nothing. The only
 way to learn a deploy happened, failed, or is blocked is to ask:
 
@@ -34,7 +39,34 @@ way to learn a deploy happened, failed, or is blocked is to ask:
     git -C /home/pluggedin/deploy-tree checkout --detach origin/main
     sudo cp infra/systemd/pluggedin-deploy-watch.* /etc/systemd/system/
     sudo systemctl daemon-reload
-    sudo systemctl enable --now pluggedin-deploy-watch.timer
+    sudo systemctl enable pluggedin-deploy-watch.timer
+
+`enable`, deliberately **without** `--now`. `pluggedin-deploy-watch.timer`
+has `OnBootSec=3min`: on any host that has already been up for more than 3
+minutes (i.e. every host except one that just rebooted), that fires
+immediately once the timer unit is started — a full, unsupervised deploy,
+on the spot, before the supervised first run below has ever happened. Enable
+now so the timer survives reboots; start it only at the end of "First run,
+supervised", once that run is confirmed good.
+
+### Bootstrap the state directory
+
+The service unit declares `StateDirectory=pluggedin-deploy-watch`, which
+normally makes systemd create `/var/lib/pluggedin-deploy-watch`, owned by
+`pluggedin:pluggedin`, the first time the *service* starts. But the
+supervised first run below runs the script by hand, before the service has
+ever started — and `/var/lib` itself is `root:root 0755`, so the `pluggedin`
+user cannot create a directory under it. Left alone, the hand run below dies
+on `mkdir` inside the script.
+
+Create it explicitly first, with the same ownership systemd would have used:
+
+    sudo install -d -o pluggedin -g pluggedin /var/lib/pluggedin-deploy-watch
+
+Use `install -d`, not a bare `sudo mkdir -p`, and do not run
+`deploy-watch.sh` itself under `sudo`: either one leaves the directory or
+its state file owned by `root`, and the service — which runs as
+`pluggedin`, not `root` — then cannot write to it on its next cycle.
 
 ## First run, supervised
 
@@ -58,11 +90,21 @@ need a human watching:
    maintainer's usual checkout) changes that label, so the first run may
    recreate more than just the app container.
 
-Run it by hand first and watch, rather than trusting the timer's first fire:
+Run it by hand first and watch, rather than trusting the timer's first fire.
+Run it **as the `pluggedin` user**, not as `root` and not via plain `sudo`
+(see the state-directory note above — an account mismatch here leaves a
+root-owned state file the service can never write again):
 
-    infra/scripts/deploy-watch.sh --dry-run
-    infra/scripts/deploy-watch.sh
+    sudo -u pluggedin -H infra/scripts/deploy-watch.sh --dry-run
+    sudo -u pluggedin -H infra/scripts/deploy-watch.sh
     docker compose -f /home/pluggedin/deploy-tree/infra/docker-compose.yml ps
+
+Once this is confirmed good — the container came up, `docker compose ps`
+looks right, and `infra/scripts/deploy-watch.sh --status` shows a clean `ok`
+outcome, not a `FAILED` or `BLOCKED` one — start the timer so it takes over
+future cycles:
+
+    sudo systemctl start pluggedin-deploy-watch.timer
 
 ## Unblocking the gate
 
@@ -71,6 +113,51 @@ Run it by hand first and watch, rather than trusting the timer's first fire:
 Deploying by hand moves the running revision past the infra commit, and the
 next cycle proceeds on its own (see "What deploys by itself" above for why
 later app-only commits alone never do this).
+
+## When an automatic deploy fails
+
+If `do_deploy` fails for a target — a bad migration, a health check that
+never turns green, anything in "When rollback reports a migration was
+applied" below — the watcher records that exact commit as the failed
+target and **will not attempt it again on its own**. This is deliberate,
+not a bug: a broken target does not start passing on attempt two with no
+code change in between, every attempt whose range touches `drizzle/` costs
+a full `backup.sh` run (minutes, gigabytes) before it even reaches the step
+that might fail again, and there is no notification channel to say a retry
+budget got burned overnight. One attempt, then stop, until something
+actually changes.
+
+`--status` shows it plainly:
+
+    infra/scripts/deploy-watch.sh --status
+    ...
+      DEPLOY FAILED for target <sha> — will NOT retry automatically.
+      See "last outcome" above for why. To clear this and resume automatic
+      deploys, do ONE of:
+        1. Push a fix to main — a NEWER commit deploys on its own, no
+           clearing needed, that is the whole point of the feature.
+        2. Deploy this exact target by hand, which clears the marker on the
+           next cycle once the running revision catches up to it:
+             IMAGE_TAG=sha-<short> infra/scripts/deploy.sh
+        3. Clear the marker without deploying, e.g. after fixing the
+           underlying problem out of band:
+             infra/scripts/deploy-watch.sh --clear-failed
+
+Concretely, one of three things clears the marker:
+
+- **A newer commit lands on `main`.** The watcher compares the failed
+  marker against the *exact* SHA that failed, not "anything still pending",
+  so a fix pushed as a new commit is a different target and deploys
+  normally — nothing to clear by hand.
+- **A human hand-deploys the failed commit (or something past it).** Once
+  the running revision catches up to or passes it, the next cycle notices
+  (the same staleness check the infra gate above already uses) and clears
+  the marker on its own.
+- **`infra/scripts/deploy-watch.sh --clear-failed`**, run as the
+  `pluggedin` user, if neither of the above applies yet — e.g. the
+  underlying problem (bad SOPS secret, registry outage) was fixed out of
+  band and the same commit should simply be allowed to retry on the next
+  poll.
 
 ## Verification timeout
 

--- a/docs/superpowers/plans/2026-08-11-auto-deploy.md
+++ b/docs/superpowers/plans/2026-08-11-auto-deploy.md
@@ -1,0 +1,995 @@
+# Automatic Deployment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A merge to `main` reaches production within a couple of minutes without anyone opening a terminal, while infrastructure changes still require a human.
+
+**Architecture:** A host-side poller (`infra/scripts/deploy-watch.sh`) runs as `pluggedin` under a systemd timer. It compares `origin/main` against the running container's revision label, refuses to deploy commit ranges that touch infrastructure, and otherwise runs backup → migrate → `deploy.sh` → verify, rolling back the image if verification fails. CI is never given deploy rights, because the Actions runner is deliberately isolated from the age key and the production Docker socket.
+
+**Tech Stack:** Bash 5.2, systemd timers, Docker Compose, `git`, `docker manifest inspect`, `flock`, `jq`.
+
+## Global Constraints
+
+- Deploy user is `pluggedin`. The Actions runner (`ghrunner`, rootless daemon) must gain **no** new access — no age key, no production socket.
+- GHCR short-SHA tags are **7 characters** (`sha-4cf9c6e`). Derive with `git rev-parse --short=7`.
+- The GHCR package is public and the host is logged out of `ghcr.io`. Pulls are anonymous; do not add registry credentials.
+- Image repository: `ghcr.io/veriteknik/pluggedin-app`.
+- Production compose file: `infra/docker-compose.yml`, project name `infra`.
+- App container name: `pluggedin-app`. Revision label: `org.opencontainers.image.revision`.
+- Never write to a destination with a fixed temp name; use `mktemp` (see `deploy.sh` and PR #193 for why).
+- All new shell scripts start with `set -euo pipefail`.
+- The infra gate is **fail-closed**: any condition the script cannot evaluate blocks the deploy.
+- No notification channel. Reporting is journald plus `deploy-watch.sh --status`.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `infra/scripts/deploy-watch.sh` | The poller: detect, gate, deploy, verify, roll back, report |
+| `infra/scripts/test-deploy-watch.sh` | Test harness; stubs `docker`/`git`/`curl` on `PATH` |
+| `infra/systemd/pluggedin-deploy-watch.service` | Oneshot unit that runs the poller |
+| `infra/systemd/pluggedin-deploy-watch.timer` | Every 2 minutes |
+| `infra/docker-compose.yml` | Add explicit `name: infra` |
+| `docs/ops/auto-deploy.md` | Runbook: install, first supervised run, unblocking the gate |
+| `.claude/skills/pluggedin-stack-ops/SKILL.md` | Update: deploying is no longer only manual |
+
+`deploy-watch.sh` is written so every decision function is independently callable. The bottom of the file guards its entry point:
+
+```bash
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi
+```
+
+so `test-deploy-watch.sh` can `source` it and test functions directly. The repo has no bats; `infra/scripts/test-reencrypt-idempotency.mjs` is the precedent for a standalone test script under `infra/scripts/`.
+
+---
+
+### Task 1: Pin the compose project identity
+
+Compose derives the project name from the compose file's parent directory. Deploying from a second checkout keeps the name `infra` by coincidence, not by contract. Pin it before anything deploys from a new tree.
+
+**Files:**
+- Modify: `infra/docker-compose.yml:1`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: project name `infra` is stable regardless of checkout path
+
+- [ ] **Step 1: Record the current project identity**
+
+```bash
+docker inspect pluggedin-app \
+  --format '{{index .Config.Labels "com.docker.compose.project"}}'
+```
+
+Expected: `infra`. If it prints anything else, stop — the rest of this task assumes `infra`.
+
+- [ ] **Step 2: Add the explicit name**
+
+At the very top of `infra/docker-compose.yml`, above the existing comment block:
+
+```yaml
+# Project name is pinned rather than inherited from this file's parent
+# directory. deploy-watch.sh runs compose from a second checkout
+# (/home/pluggedin/deploy-tree); without this, the project identity — and
+# therefore which containers Compose considers "ours" — would depend on the
+# directory a deploy happened to run from.
+name: infra
+```
+
+- [ ] **Step 3: Verify the rendered project name is unchanged from both paths**
+
+```bash
+docker compose -f infra/docker-compose.yml config --format json \
+  | jq -r '.name'
+```
+
+Expected: `infra`
+
+- [ ] **Step 4: Verify Compose still considers the running stack ours**
+
+```bash
+docker compose -f infra/docker-compose.yml ps --format '{{.Name}} {{.State}}'
+```
+
+Expected: the six running services listed as `running`, not an empty list. An empty list means the project name changed and Compose would orphan the stack — revert immediately.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/docker-compose.yml
+git commit -m "infra: pin compose project name so deploys are checkout-independent"
+```
+
+---
+
+### Task 2: Poller skeleton — CLI, state file, locking
+
+**Files:**
+- Create: `infra/scripts/deploy-watch.sh`
+- Create: `infra/scripts/test-deploy-watch.sh`
+
+**Interfaces:**
+- Produces:
+  - `state_set KEY VALUE` — writes/replaces a key in the state file
+  - `state_get KEY` — prints the value, empty string if unset
+  - `cmd_status()` — prints the human-readable status block
+  - Env overrides: `DEPLOY_TREE`, `STATE_DIR`, `IMAGE_REPO`, `COMPOSE_FILE`, `SITE_URL`, `APP_CONTAINER`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `infra/scripts/test-deploy-watch.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Test harness for deploy-watch.sh.
+#
+# Stubs docker/git/curl by putting fake executables first on PATH, then
+# sources deploy-watch.sh (whose main() is guarded) and calls its functions
+# directly. Run: infra/scripts/test-deploy-watch.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+is()   { # is <actual> <expected> <label>
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (got '$1', want '$2')"; fi
+}
+
+setup() {
+  TESTROOT="$(mktemp -d)"
+  export STATE_DIR="${TESTROOT}/state"
+  export DEPLOY_TREE="${TESTROOT}/tree"
+  mkdir -p "$STATE_DIR" "$DEPLOY_TREE"
+}
+teardown() { rm -rf "$TESTROOT"; }
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/deploy-watch.sh"
+
+printf '\n[test] state file\n'
+setup
+state_set last_check "2026-08-11T00:00:00Z"
+state_set running_rev "abc123"
+is "$(state_get last_check)" "2026-08-11T00:00:00Z" "state_get reads back what state_set wrote"
+is "$(state_get running_rev)" "abc123" "second key stored independently"
+state_set running_rev "def456"
+is "$(state_get running_rev)" "def456" "state_set replaces rather than appends"
+is "$(grep -c '^running_rev=' "${STATE_DIR}/deploy-watch.state")" "1" "no duplicate keys accumulate"
+is "$(state_get never_set)" "" "missing key yields empty string"
+teardown
+
+printf '\n[test] summary\n'
+printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+chmod +x infra/scripts/test-deploy-watch.sh
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: FAIL — `deploy-watch.sh: No such file or directory`
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `infra/scripts/deploy-watch.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Pull-based automatic deployment.
+#
+# Runs on the production host as `pluggedin` under a systemd timer. Compares
+# origin/main against the running container's revision label and deploys when
+# they differ — subject to the infra gate (see gate_blocked_files).
+#
+# WHY POLLING RATHER THAN CI: infra/scripts/isolate-gha-runner.sh deliberately
+# moved the Actions runner onto a rootless daemon as a separate user with no
+# access to /etc/sops/age/keys.txt, /run/sops/secrets.env, or the production
+# Docker socket. deploy.sh needs all three. A push-based deploy would mean
+# handing those back. See docs/superpowers/specs/2026-08-10-auto-deploy-design.md.
+#
+# Usage:
+#   deploy-watch.sh              # one poll cycle (what the timer runs)
+#   deploy-watch.sh --status     # report state, change nothing
+#   deploy-watch.sh --dry-run    # report what it would deploy, change nothing
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_TREE="${DEPLOY_TREE:-/home/pluggedin/deploy-tree}"
+STATE_DIR="${STATE_DIR:-/var/lib/pluggedin-deploy-watch}"
+STATE_FILE="${STATE_DIR}/deploy-watch.state"
+LOCK_FILE="${STATE_DIR}/deploy-watch.lock"
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/veriteknik/pluggedin-app}"
+APP_CONTAINER="${APP_CONTAINER:-pluggedin-app}"
+SITE_URL="${SITE_URL:-https://plugged.in}"
+COMPOSE_FILE="${COMPOSE_FILE:-${DEPLOY_TREE}/infra/docker-compose.yml}"
+
+log()  { printf '[deploy-watch %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die()  { printf '[deploy-watch] FATAL: %s\n' "$*" >&2; exit 1; }
+now()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# --- state -----------------------------------------------------------------
+# Flat key=value. Values are single-line and script-controlled, so no quoting
+# rules are needed; state_set rewrites via mktemp + rename, never in place.
+state_set() {
+  local key="$1" value="$2" tmp
+  mkdir -p "$STATE_DIR"
+  touch "$STATE_FILE"
+  tmp="$(mktemp "${STATE_FILE}.XXXXXX")"
+  { grep -v "^${key}=" "$STATE_FILE" || true; printf '%s=%s\n' "$key" "$value"; } > "$tmp"
+  mv -f "$tmp" "$STATE_FILE"
+}
+
+state_get() {
+  local key="$1"
+  [ -f "$STATE_FILE" ] || { printf ''; return 0; }
+  sed -n "s/^${key}=//p" "$STATE_FILE" | tail -1
+}
+
+cmd_status() {
+  printf 'deploy-watch status\n'
+  printf '  last check      : %s\n' "$(state_get last_check)"
+  printf '  running revision: %s\n' "$(state_get running_rev)"
+  printf '  latest revision : %s\n' "$(state_get latest_rev)"
+  printf '  last outcome    : %s\n' "$(state_get last_outcome)"
+  local blocked
+  blocked="$(state_get blocked_rev)"
+  if [ -n "$blocked" ]; then
+    printf '\n  BLOCKED by the infra gate: %s\n' "$blocked"
+    printf '  files: %s\n' "$(state_get blocked_files)"
+    printf '  This will not deploy automatically. Deploy it by hand:\n'
+    printf '    IMAGE_TAG=sha-%s infra/scripts/deploy.sh\n' "$(state_get blocked_short)"
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    --status)  cmd_status; return 0 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; return 0 ;;
+  esac
+  die "not implemented yet"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+chmod +x infra/scripts/deploy-watch.sh
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: `5 passed, 0 failed`
+
+- [ ] **Step 5: Verify `--status` runs against an empty state without erroring**
+
+```bash
+STATE_DIR=$(mktemp -d) infra/scripts/deploy-watch.sh --status
+```
+
+Expected: the block prints with empty values, exit code 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/scripts/deploy-watch.sh infra/scripts/test-deploy-watch.sh
+git commit -m "feat(deploy-watch): state file, status output, test harness"
+```
+
+---
+
+### Task 3: Revision and image resolution
+
+**Files:**
+- Modify: `infra/scripts/deploy-watch.sh`
+- Modify: `infra/scripts/test-deploy-watch.sh`
+
+**Interfaces:**
+- Consumes: `state_set`/`state_get` from Task 2
+- Produces:
+  - `running_revision()` → 40-char SHA of the running container, empty if the container is absent
+  - `short_sha REV` → 7-char abbreviation
+  - `image_exists TAG` → exit 0 if the tag resolves in the registry
+  - `fetch_tree()` → updates `$DEPLOY_TREE` and prints `origin/main`'s 40-char SHA
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `infra/scripts/test-deploy-watch.sh`, before the summary block:
+
+```bash
+printf '\n[test] revision resolution\n'
+setup
+# A real git repo, so short_sha and fetch_tree exercise real git behaviour.
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+echo one > "$DEPLOY_TREE/a.txt"
+git -C "$DEPLOY_TREE" add a.txt
+git -C "$DEPLOY_TREE" commit -qm one
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+is "$(short_sha "$REV")" "${REV:0:7}" "short_sha abbreviates to exactly 7 characters"
+is "${#REV}" "40" "test fixture revision is a full SHA"
+
+# Stub docker so image_exists is deterministic.
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+cat > "$STUBS/docker" <<'STUB'
+#!/usr/bin/env bash
+# manifest inspect <repo>:<tag> — only sha-present resolves
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ]; then
+  case "$3" in
+    *:sha-present) exit 0 ;;
+    *) echo "manifest unknown" >&2; exit 1 ;;
+  esac
+fi
+if [ "$1" = "inspect" ]; then
+  # inspect <container> --format ... — print the fixture revision
+  if [ -n "${STUB_RUNNING_REV:-}" ]; then echo "$STUB_RUNNING_REV"; exit 0; fi
+  echo "No such object" >&2; exit 1
+fi
+exit 0
+STUB
+chmod +x "$STUBS/docker"
+PATH="$STUBS:$PATH"
+
+image_exists "sha-present" && ok "image_exists true for a tag the registry resolves" \
+  || bad "image_exists true for a tag the registry resolves"
+image_exists "sha-absent" && bad "image_exists false for an absent tag" \
+  || ok "image_exists false for an absent tag"
+
+STUB_RUNNING_REV="$REV" is "$(STUB_RUNNING_REV="$REV" running_revision)" "$REV" \
+  "running_revision reads the container label"
+is "$(running_revision)" "" "running_revision is empty when the container is absent"
+teardown
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: FAIL — `short_sha: command not found`
+
+- [ ] **Step 3: Implement**
+
+Insert into `infra/scripts/deploy-watch.sh`, after `cmd_status`:
+
+```bash
+# --- revision and image resolution -----------------------------------------
+running_revision() {
+  # Empty (not an error) when the container does not exist: a first install
+  # is a legitimate state, and the caller decides what to do about it.
+  docker inspect "$APP_CONTAINER" \
+    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' \
+    2>/dev/null || printf ''
+}
+
+short_sha() { git -C "$DEPLOY_TREE" rev-parse --short=7 "$1"; }
+
+image_exists() {
+  # `docker manifest inspect` negotiates anonymous auth itself, which is what
+  # we want: the host is logged out of ghcr.io and the package is public.
+  # Same call infra/scripts/prune-build-artifacts.sh uses.
+  docker manifest inspect "${IMAGE_REPO}:$1" >/dev/null 2>&1
+}
+
+fetch_tree() {
+  [ -d "${DEPLOY_TREE}/.git" ] || die "deploy tree missing at ${DEPLOY_TREE} (see docs/ops/auto-deploy.md)"
+  git -C "$DEPLOY_TREE" fetch --quiet origin main
+  git -C "$DEPLOY_TREE" rev-parse origin/main
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: all assertions pass, `0 failed`
+
+- [ ] **Step 5: Check the real registry resolves the current tag**
+
+```bash
+IMAGE_REPO=ghcr.io/veriteknik/pluggedin-app \
+  bash -c 'source infra/scripts/deploy-watch.sh; image_exists sha-4cf9c6e && echo RESOLVES'
+```
+
+Expected: `RESOLVES`. This confirms anonymous registry access still works from the host.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/scripts/deploy-watch.sh infra/scripts/test-deploy-watch.sh
+git commit -m "feat(deploy-watch): resolve running revision, short SHA, and registry tags"
+```
+
+---
+
+### Task 4: The infra gate
+
+The security-critical task. It decides which merges may reach production unattended.
+
+**Files:**
+- Modify: `infra/scripts/deploy-watch.sh`
+- Modify: `infra/scripts/test-deploy-watch.sh`
+
+**Interfaces:**
+- Consumes: `$DEPLOY_TREE` from Task 3
+- Produces: `gate_blocked_files FROM TO` — prints matching paths, one per line; empty output means the range may deploy automatically. Exits non-zero only on an unevaluable range (fail-closed, handled by the caller).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `infra/scripts/test-deploy-watch.sh`, before the summary block:
+
+```bash
+printf '\n[test] infra gate\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+mkdir -p "$DEPLOY_TREE"/{app,infra/scripts,.github/workflows,drizzle}
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+BASE="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+commit_file() { # commit_file <path> <content> -> prints new SHA
+  mkdir -p "$(dirname "${DEPLOY_TREE}/$1")"
+  echo "$2" > "${DEPLOY_TREE}/$1"
+  git -C "$DEPLOY_TREE" add -A
+  git -C "$DEPLOY_TREE" commit -qm "touch $1"
+  git -C "$DEPLOY_TREE" rev-parse HEAD
+}
+
+APP="$(commit_file app/page.tsx changed)"
+is "$(gate_blocked_files "$BASE" "$APP")" "" "app-only change is not blocked"
+
+INFRA="$(commit_file infra/scripts/deploy.sh changed)"
+is "$(gate_blocked_files "$APP" "$INFRA")" "infra/scripts/deploy.sh" "infra/ change is blocked"
+
+COMPOSE="$(commit_file docker-compose.production.yml changed)"
+is "$(gate_blocked_files "$INFRA" "$COMPOSE")" "docker-compose.production.yml" "root compose change is blocked"
+
+DOCKERFILE="$(commit_file Dockerfile changed)"
+is "$(gate_blocked_files "$COMPOSE" "$DOCKERFILE")" "Dockerfile" "Dockerfile change is blocked"
+
+WF="$(commit_file .github/workflows/build-image.yml changed)"
+is "$(gate_blocked_files "$DOCKERFILE" "$WF")" ".github/workflows/build-image.yml" "workflow change is blocked"
+
+# Paths that merely look like the protected ones must NOT be blocked.
+DECOY="$(commit_file app/infra/helper.ts changed)"
+is "$(gate_blocked_files "$WF" "$DECOY")" "" "app/infra/ is not the protected infra/ prefix"
+DECOY2="$(commit_file app/Dockerfile.md changed)"
+is "$(gate_blocked_files "$DECOY" "$DECOY2")" "" "a nested Dockerfile.md is not the root Dockerfile"
+DECOY3="$(commit_file drizzle/0001_x.sql changed)"
+is "$(gate_blocked_files "$DECOY2" "$DECOY3")" "" "migrations are app changes, not infra"
+
+# The range, not just the tip: an infra commit buried behind an app commit
+# must still block.
+BURIED_INFRA="$(commit_file infra/docker-compose.yml changed)"
+BURIED_APP="$(commit_file app/page.tsx again)"
+is "$(gate_blocked_files "$DECOY3" "$BURIED_APP")" "infra/docker-compose.yml" \
+  "an infra commit behind a later app commit still blocks the range"
+
+# Fail-closed: an unknown starting revision cannot be evaluated.
+if gate_blocked_files "0000000000000000000000000000000000000000" "$BURIED_APP" >/dev/null 2>&1; then
+  bad "unknown revision must not evaluate as allowed"
+else
+  ok "unknown revision fails closed"
+fi
+teardown
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: FAIL — `gate_blocked_files: command not found`
+
+- [ ] **Step 3: Implement**
+
+Insert into `infra/scripts/deploy-watch.sh`, after `fetch_tree`:
+
+```bash
+# --- the infra gate --------------------------------------------------------
+# Only application-code changes deploy unattended.
+#
+# main allows merges with zero approving reviews and does not enforce branch
+# protection on admins, and the repository is public. The compensating control
+# has always been that a human runs deploy.sh; automating that removes it. A
+# commit that can rewrite compose, the Dockerfile, or a workflow is a commit
+# that can change what the host mounts and what the container can reach — on a
+# host holding the SOPS age key. Those keep the human.
+#
+# Anchored at the start of the path so `app/infra/...` and `app/Dockerfile.md`
+# are NOT caught; only the real root-level paths are.
+GATE_RE='^(infra/|docker-compose[^/]*\.yml$|Dockerfile$|\.github/workflows/)'
+
+gate_blocked_files() {
+  local from="$1" to="$2"
+  # Fail-closed. If either endpoint is unknown to this tree the range cannot
+  # be judged, and "cannot judge" must never read as "nothing to worry about".
+  git -C "$DEPLOY_TREE" cat-file -e "${from}^{commit}" 2>/dev/null || return 1
+  git -C "$DEPLOY_TREE" cat-file -e "${to}^{commit}"   2>/dev/null || return 1
+  # Every commit that would go live, not just the tip: an infra change must not
+  # ride to production hidden behind a later innocuous commit.
+  git -C "$DEPLOY_TREE" diff --name-only "$from" "$to" | grep -E "$GATE_RE" || true
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: all gate assertions pass, `0 failed`
+
+- [ ] **Step 5: Sanity-check the gate against real history**
+
+```bash
+bash -c 'source infra/scripts/deploy-watch.sh
+DEPLOY_TREE=/home/pluggedin/pluggedin-app
+echo "--- a4fbaaeb..4cf9c6e1 (the backlog just deployed) ---"
+gate_blocked_files a4fbaaeb 4cf9c6e1'
+```
+
+Expected: prints `.github/workflows/build-image.yml` and several `infra/` paths — that range contains #184, so it *should* block. This confirms the gate bites on real history rather than only on fixtures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/scripts/deploy-watch.sh infra/scripts/test-deploy-watch.sh
+git commit -m "feat(deploy-watch): fail-closed infra gate over the full commit range"
+```
+
+---
+
+### Task 5: Deploy orchestration, rollback, and dry run
+
+**Files:**
+- Modify: `infra/scripts/deploy-watch.sh`
+- Modify: `infra/scripts/test-deploy-watch.sh`
+
+**Interfaces:**
+- Consumes: everything from Tasks 2–4
+- Produces:
+  - `range_touches_migrations FROM TO` → exit 0 when `drizzle/` changed
+  - `do_deploy SHORT REV` → full sequence; returns non-zero if it rolled back
+  - `main()` → one complete poll cycle
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `infra/scripts/test-deploy-watch.sh`, before the summary block:
+
+```bash
+printf '\n[test] migration detection and dry run\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+mkdir -p "$DEPLOY_TREE"/{app,drizzle}
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+B="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+echo x > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app
+A="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+echo y > "$DEPLOY_TREE/drizzle/0002_x.sql"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm mig
+M="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+range_touches_migrations "$B" "$A" && bad "app-only range must not request a backup" \
+  || ok "app-only range does not request a backup"
+range_touches_migrations "$A" "$M" && ok "range touching drizzle/ requests a backup" \
+  || bad "range touching drizzle/ requests a backup"
+teardown
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: FAIL — `range_touches_migrations: command not found`
+
+- [ ] **Step 3: Implement the deploy sequence**
+
+Replace the placeholder `main()` in `infra/scripts/deploy-watch.sh` with:
+
+```bash
+# --- deploying -------------------------------------------------------------
+range_touches_migrations() {
+  # backup.sh dumps Postgres AND rsyncs uploads and vector data into an
+  # age-encrypted tarball — minutes and gigabytes. Far too heavy to run on
+  # every app patch, and pointless when the schema cannot change.
+  git -C "$DEPLOY_TREE" diff --name-only "$1" "$2" | grep -qE '^drizzle/'
+}
+
+external_check() {
+  local code
+  code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 "${SITE_URL}/api/health" || echo 000)"
+  [ "$code" = "200" ] || return 1
+  curl -fsS --max-time 20 "${SITE_URL}/api/health" | grep -q '"status":"healthy"'
+}
+
+do_deploy() {
+  local short="$1" rev="$2" from="$3"
+  local prev_image prev_rev
+  prev_image="$(docker inspect "$APP_CONTAINER" --format '{{.Image}}' 2>/dev/null || printf '')"
+  prev_rev="$(running_revision)"
+
+  log "deploying ${short} (${rev})"
+  git -C "$DEPLOY_TREE" checkout --quiet --detach "$rev"
+
+  if range_touches_migrations "$from" "$rev"; then
+    log "range touches drizzle/ — taking a backup first"
+    "${DEPLOY_TREE}/infra/scripts/backup.sh" || { state_set last_outcome "failed: backup"; return 1; }
+
+    # Migrate BEFORE the app is replaced. A failure here leaves the running
+    # container untouched: old code against the unmigrated schema, which is a
+    # clean failure rather than a half-deployed one.
+    log "running migrations"
+    if ! IMAGE_TAG="sha-${short}" docker compose -f "$COMPOSE_FILE" \
+           run --rm pluggedin-app node_modules/.bin/drizzle-kit migrate; then
+      state_set last_outcome "failed: migration (stack untouched)"
+      return 1
+    fi
+  fi
+
+  docker pull "${IMAGE_REPO}:sha-${short}" >/dev/null \
+    || { state_set last_outcome "failed: pull"; return 1; }
+  docker tag "${IMAGE_REPO}:sha-${short}" "${IMAGE_REPO}:live"
+
+  if IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull && external_check; then
+    state_set last_outcome "ok ${short} at $(now)"
+    state_set running_rev "$rev"
+    log "deploy ok"
+    return 0
+  fi
+
+  log "verification failed — rolling back to ${prev_rev:-previous image}"
+  if [ -n "$prev_image" ]; then
+    docker tag "$prev_image" "${IMAGE_REPO}:live"
+    IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull || true
+  fi
+  if range_touches_migrations "$from" "$rev"; then
+    # The image is back; the schema is not. Say so plainly — this is the one
+    # outcome that must never read as self-healed.
+    state_set last_outcome "ROLLED BACK ${short} at $(now) — MIGRATION ALREADY APPLIED, needs a human"
+  else
+    state_set last_outcome "rolled back ${short} at $(now)"
+  fi
+  return 1
+}
+
+main() {
+  local dry=0
+  case "${1:-}" in
+    --status)  cmd_status; return 0 ;;
+    --dry-run) dry=1 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; return 0 ;;
+    "")        ;;
+    *)         die "unknown argument: $1" ;;
+  esac
+
+  mkdir -p "$STATE_DIR"
+  # Never let two cycles overlap; the timer fires regardless of how long a
+  # deploy takes.
+  exec 9>"$LOCK_FILE"
+  flock -n 9 || { log "another cycle holds the lock — skipping"; return 0; }
+
+  local target running short
+  target="$(fetch_tree)"
+  running="$(running_revision)"
+  state_set last_check "$(now)"
+  state_set latest_rev "$target"
+  state_set running_rev "$running"
+
+  [ -n "$running" ] || die "container ${APP_CONTAINER} not running — refusing to guess a baseline"
+  if [ "$running" = "$target" ]; then
+    log "up to date at $(short_sha "$target")"
+    return 0
+  fi
+
+  short="$(short_sha "$target")"
+  if ! image_exists "sha-${short}"; then
+    log "image sha-${short} not published yet — waiting"
+    return 0
+  fi
+
+  local blocked
+  if ! blocked="$(gate_blocked_files "$running" "$target")"; then
+    state_set blocked_rev "$target"
+    state_set blocked_short "$short"
+    state_set blocked_files "unevaluable range — failing closed"
+    log "BLOCKED: cannot evaluate ${running}..${target}"
+    return 0
+  fi
+  if [ -n "$blocked" ]; then
+    state_set blocked_rev "$target"
+    state_set blocked_short "$short"
+    state_set blocked_files "$(printf '%s' "$blocked" | tr '\n' ' ')"
+    log "BLOCKED by the infra gate: $(printf '%s' "$blocked" | tr '\n' ' ')"
+    log "deploy it by hand: IMAGE_TAG=sha-${short} infra/scripts/deploy.sh"
+    return 0
+  fi
+
+  if [ "$dry" -eq 1 ]; then
+    log "DRY RUN: would deploy sha-${short} (${target}); gate clear"
+    range_touches_migrations "$running" "$target" \
+      && log "DRY RUN: range touches drizzle/ — would back up and migrate first" \
+      || log "DRY RUN: no migrations in range"
+    return 0
+  fi
+
+  state_set blocked_rev ""
+  state_set blocked_files ""
+  do_deploy "$short" "$target" "$running"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+infra/scripts/test-deploy-watch.sh
+```
+
+Expected: all assertions pass, `0 failed`
+
+- [ ] **Step 5: Verify the lock actually serialises**
+
+```bash
+STATE_DIR=$(mktemp -d)
+export STATE_DIR
+( exec 9>"${STATE_DIR}/deploy-watch.lock"; flock -n 9; sleep 5 ) &
+sleep 1
+DEPLOY_TREE=/home/pluggedin/pluggedin-app infra/scripts/deploy-watch.sh 2>&1 | tail -1
+wait
+```
+
+Expected: `another cycle holds the lock — skipping`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/scripts/deploy-watch.sh infra/scripts/test-deploy-watch.sh
+git commit -m "feat(deploy-watch): deploy sequence with conditional backup, migration, and rollback"
+```
+
+---
+
+### Task 6: systemd service and timer
+
+**Files:**
+- Create: `infra/systemd/pluggedin-deploy-watch.service`
+- Create: `infra/systemd/pluggedin-deploy-watch.timer`
+
+**Interfaces:**
+- Consumes: `infra/scripts/deploy-watch.sh` from Task 5
+- Produces: `/var/lib/pluggedin-deploy-watch` created by systemd with the right owner
+
+- [ ] **Step 1: Write the unit**
+
+Create `infra/systemd/pluggedin-deploy-watch.service`:
+
+```ini
+[Unit]
+Description=plugged.in automatic deployment poller
+Documentation=file:///home/pluggedin/pluggedin-app/docs/ops/auto-deploy.md
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=pluggedin
+Group=pluggedin
+# Runs from the deploy tree, never the maintainer's working checkout.
+WorkingDirectory=/home/pluggedin/deploy-tree
+ExecStart=/home/pluggedin/deploy-tree/infra/scripts/deploy-watch.sh
+# Creates /var/lib/pluggedin-deploy-watch owned by User, so neither the
+# script nor an operator needs sudo to read --status.
+StateDirectory=pluggedin-deploy-watch
+Environment=SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
+# A deploy including a migration and an image pull can legitimately take a
+# while; the lock means a slow run cannot pile up behind the timer.
+TimeoutStartSec=1800
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 2: Write the timer**
+
+Create `infra/systemd/pluggedin-deploy-watch.timer`:
+
+```ini
+[Unit]
+Description=Poll for new plugged.in images every 2 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=2min
+# Cycles are cheap when there is nothing to do: one git fetch and one
+# registry HEAD. Persistent=false because a missed window is meaningless —
+# the next cycle sees the same state.
+Persistent=false
+AccuracySec=15s
+Unit=pluggedin-deploy-watch.service
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 3: Validate both units parse**
+
+```bash
+systemd-analyze verify infra/systemd/pluggedin-deploy-watch.service 2>&1
+systemd-analyze verify infra/systemd/pluggedin-deploy-watch.timer 2>&1
+```
+
+Expected: no output (both valid). Warnings about the unit not being installed are fine; errors are not.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infra/systemd/
+git commit -m "feat(deploy-watch): systemd oneshot unit and 2-minute timer"
+```
+
+---
+
+### Task 7: Runbook, ops skill update, and first supervised run
+
+**Files:**
+- Create: `docs/ops/auto-deploy.md`
+- Modify: `.claude/skills/pluggedin-stack-ops/SKILL.md`
+
+**Interfaces:**
+- Consumes: everything above
+
+- [ ] **Step 1: Write the runbook**
+
+Create `docs/ops/auto-deploy.md` covering exactly these sections, with the commands inline:
+
+```markdown
+# Automatic deployment
+
+Design: `docs/superpowers/specs/2026-08-10-auto-deploy-design.md`
+
+## What deploys by itself
+
+Application-code merges to `main`, within about two minutes. Changes to
+`infra/`, `docker-compose*.yml`, `Dockerfile` or `.github/workflows/` do NOT
+— they are recorded and wait for a human. Nothing notifies you; ask:
+
+    infra/scripts/deploy-watch.sh --status
+
+## Install
+
+    git clone https://github.com/VeriTeknik/pluggedin-app /home/pluggedin/deploy-tree
+    git -C /home/pluggedin/deploy-tree checkout --detach origin/main
+    sudo cp infra/systemd/pluggedin-deploy-watch.* /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable --now pluggedin-deploy-watch.timer
+
+## First run, supervised
+
+Compose labels the containers with the project working directory. Deploying
+from a second checkout changes that label, so the first run may recreate more
+than the app container. Run it by hand and watch:
+
+    infra/scripts/deploy-watch.sh --dry-run
+    infra/scripts/deploy-watch.sh
+    docker compose -f /home/pluggedin/deploy-tree/infra/docker-compose.yml ps
+
+## Unblocking the gate
+
+    IMAGE_TAG=sha-<short> infra/scripts/deploy.sh
+
+Deploying by hand moves the running revision past the infra commit, and the
+next cycle proceeds on its own.
+
+## When rollback reports a migration was applied
+
+The image is back; the schema is not. The pre-migration dump is the newest
+file in /var/backups/pluggedin/. Decide between rolling the schema forward
+with a fix or restoring — see docs/ops/ for restore.sh, and note the dumps are
+age-encrypted.
+
+## Logs
+
+    journalctl -u pluggedin-deploy-watch.service -n 100
+```
+
+- [ ] **Step 2: Update the ops skill**
+
+In `.claude/skills/pluggedin-stack-ops/SKILL.md`, the Quick reference currently says the entry point is always `deploy.sh`. Add a row and a qualifier:
+
+```markdown
+| Is a deploy waiting? | `infra/scripts/deploy-watch.sh --status` |
+```
+
+and immediately under the "Deploying is not just `git pull`" heading, add:
+
+```markdown
+> Application merges to `main` now deploy themselves within ~2 minutes via
+> `pluggedin-deploy-watch.timer`. `deploy.sh` remains the entry point for
+> anything the infra gate blocks — `infra/`, compose, `Dockerfile`,
+> workflows — and for any manual intervention. See `docs/ops/auto-deploy.md`.
+```
+
+- [ ] **Step 3: Verify the runbook's install commands are accurate**
+
+Walk each command in `docs/ops/auto-deploy.md` against the files that now exist:
+
+```bash
+ls infra/systemd/pluggedin-deploy-watch.service infra/systemd/pluggedin-deploy-watch.timer
+infra/scripts/deploy-watch.sh --help
+```
+
+Expected: both units listed; `--help` prints the usage block.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/ops/auto-deploy.md .claude/skills/pluggedin-stack-ops/SKILL.md
+git commit -m "docs(ops): auto-deploy runbook and stack-ops skill update"
+```
+
+- [ ] **Step 5: Open the PR**
+
+```bash
+gh pr create --base main --title "infra: pull-based automatic deployment" --body "..."
+```
+
+The body must state that PR #193 should merge first — `deploy-watch.sh` calls `deploy.sh` on every cycle, and without #193 the second and every later cycle fails at the secrets write.
+
+- [ ] **Step 6: STOP — do not install on the host**
+
+Installation is a production change and is a separate, supervised step. Report that the branch is ready and hand the install decision back.
+
+---
+
+## Self-Review
+
+**Spec coverage**
+
+| Spec requirement | Task |
+|---|---|
+| Host-side poller as `pluggedin`, 2-minute cadence | 5, 6 |
+| No new runner access | 5, 6 (nothing touches `ghrunner`) |
+| Commit lockstep via a dedicated deploy tree | 5 (`checkout --detach`), 7 (clone) |
+| Infra gate over four path patterns, full range, stays shut | 4 |
+| Migration order: backup → migrate → up → verify | 5 |
+| Migration failure leaves the running container untouched | 5 |
+| Rollback restores image, reports the migration caveat loudly | 5 |
+| No notifications; journald + `--status` | 2, 5 |
+| Compose project identity pinned | 1 |
+| 7-character tags | 3 |
+| Anonymous registry access | 3 |
+| Unit test on the gate | 4 |
+| `--dry-run` | 5 |
+| Rollback rehearsal | see gap below |
+| Idempotence and lock serialisation | 5 |
+
+**Gap found and closed:** the spec calls for a rollback rehearsal; no task exercised the rollback path. Rather than add a task that deliberately breaks production verification, Task 5 Step 5 covers the lock and the rehearsal moves to the supervised first run in Task 7. Anyone executing this plan should treat an untested rollback path as a known risk and rehearse it on the first real failure — noted here rather than left silent.
+
+**Placeholders:** none. Every code step carries the actual content; the only `"..."` is the PR body in Task 7 Step 5, whose required content is specified in the sentence beneath it.
+
+**Type consistency:** `gate_blocked_files`, `range_touches_migrations`, `running_revision`, `short_sha`, `image_exists`, `fetch_tree`, `state_set`, `state_get`, `do_deploy`, `external_check`, `cmd_status` are each defined once and called with the same arity everywhere. `do_deploy` takes three arguments (`short`, `rev`, `from`) at both definition and call site.

--- a/docs/superpowers/specs/2026-08-10-auto-deploy-design.md
+++ b/docs/superpowers/specs/2026-08-10-auto-deploy-design.md
@@ -1,0 +1,214 @@
+# Automatic Deployment — Design
+
+**Date:** 2026-08-10
+**Status:** Approved — ready for implementation planning
+**Repository:** `pluggedin-app`
+
+---
+
+## Goal
+
+A merge to `main` reaches production without anyone opening a terminal, so the
+maintainer can patch from a phone or from Claude Code on the web while away from
+the box.
+
+The prompting incident: PR #192 (a Mobile Safari crash fix) merged on 2026-08-09
+and was still not live the next day. Production had been serving the 2026-08-01
+image for eight days, with four merged app-affecting PRs — including a
+`sanitize-html` GHSA patch — sitting undeployed. CI built and pushed every one of
+those images successfully. Nothing consumed them.
+
+---
+
+## Why deployment is not already automatic
+
+`.github/workflows/build-image.yml` builds and pushes to GHCR. It has no deploy
+step, and production pins `IMAGE_TAG` to a hand-maintained `:live` tag that CI
+never moves. Deployment has always been a human running `infra/scripts/deploy.sh`.
+
+---
+
+## The constraint that determines the shape
+
+**CI cannot deploy this stack, by design.**
+
+`infra/scripts/isolate-gha-runner.sh` moved the self-hosted runner off the
+`pluggedin` account onto a dedicated `ghrunner` user with a *rootless* Docker
+daemon. Its header states the reasoning: membership in the `docker` group is
+root-equivalent, so a separate user in that group closes nothing —
+
+```
+docker run -v /etc/sops/age:/host:ro alpine cat /host/keys.txt
+```
+
+— and that was verified against this host before the script was written.
+
+After isolation the runner cannot read `/etc/sops/age/keys.txt`, cannot read
+`/run/sops/secrets.env`, and cannot reach the system Docker daemon that serves
+production. `deploy.sh` requires all three.
+
+So a push-based deploy from CI would mean handing the runner back the age key and
+the production socket — reverting the hardening. **Deployment must therefore be
+pull-based: triggered on the host, by a principal that already holds those
+rights.**
+
+Watchtower fails the same test more cheaply. It needs `POST` and `IMAGES` on the
+Docker API, which `docker-socket-proxy` denies deliberately — the compose comment
+records that direct socket access could read 108 environment variables off
+`pluggedin-app`, 28 of them secret-bearing, and that `POST /containers/create` is
+one bind-mount from host root. Watchtower also knows nothing about SOPS
+decryption, Traefik config staging, migrations, verification, or rollback. It was
+never installed here, and should not be.
+
+---
+
+## Architecture
+
+A `deploy-watch.sh` script runs on the host as `pluggedin` under a systemd timer,
+every 2 minutes. Given that an image build takes several minutes, a 2-minute poll
+is indistinguishable from merge-triggered in practice, and it needs no inbound
+network surface, no webhook secret, and no relaxation of the runner boundary.
+
+Each tick:
+
+1. `git fetch` the deploy tree; read `origin/main`'s HEAD commit.
+2. Resolve `ghcr.io/veriteknik/pluggedin-app:sha-<short>` for that exact commit.
+   Absent means CI has not finished — exit quietly, try again next tick.
+3. Compare against the running container's
+   `org.opencontainers.image.revision` label. Equal means nothing to do.
+4. Apply the infra gate (below). Blocked means record and exit.
+5. Deploy, verify, and roll back on failure.
+
+`flock` guarantees a single concurrent run.
+
+### Commit lockstep
+
+Deployment runs from a dedicated clean clone at `/home/pluggedin/deploy-tree`,
+checked out detached at the exact commit the image was built from — never from
+the maintainer's working tree.
+
+This fixes a live hazard. `deploy.sh` reads `infra/docker-compose.yml` and
+`infra/traefik/dynamic/*.yml` from whatever tree it is invoked in, and that tree
+is currently on branch `infra/prune-build-artifacts`, not `main`. A deploy today
+would pair `main`'s image with a feature branch's infrastructure config. Lockstep
+removes the class of bug, and frees the maintainer to switch branches in the
+working tree without any effect on production.
+
+### The infra gate
+
+Automatic deployment applies **only to application-code changes**. The range
+examined is `<currently deployed revision>..<candidate commit>` — every commit
+that would go live in this deploy, not just the newest one. If any file in that
+range matches:
+
+- `infra/**`
+- `docker-compose*.yml`
+- `Dockerfile`
+- `.github/workflows/**`
+
+the watcher does not deploy. It records the blocked commit in its state file and
+exits.
+
+Once blocked, later app-only commits do **not** unblock it: they widen the range,
+which still contains the infra change. The gate stays shut until a human deploys
+and the deployed revision moves past it. This is deliberate — the alternative
+would let an infra change ride to production behind an innocuous follow-up
+commit.
+
+The reasoning is specific to this repository. `main` has
+`required_approving_review_count: 0` and `enforce_admins: false`, so a commit can
+reach `main` with no review — commit `c1d7a27f` did, and had to be reverted by
+#182. The repository is public. Today the compensating control is that a human
+must run `deploy.sh`; automation removes it, and a merge to `main` would become
+arbitrary code execution on the production host as the user holding the SOPS age
+key, within two minutes.
+
+The gate keeps the routine case — an app patch merged from a phone — fully
+automatic, while the class of change that can alter what the host mounts, which
+services run, or what the container can reach still requires a human at a
+terminal. It is the single decision that most reduces blast radius without
+blocking the workflow this project exists to enable.
+
+### Migrations
+
+Migrations do not run at container start; `Dockerfile:122` documents them as a
+manual one-shot. Automation therefore runs them explicitly, in this order:
+
+```
+pull → pg_dump (infra/scripts/backup.sh) → drizzle-kit migrate (one-shot, new image)
+     → docker compose up -d → verify.sh → external HTTP check
+```
+
+Migrating **before** the app is replaced means a migration failure aborts the
+deploy without ever touching the running container: the old app keeps serving old
+code against the unmigrated schema. That is a clean failure.
+
+### Rollback
+
+If `verify.sh` or the external check fails, the watcher retags `:live` to the
+previous digest and brings the stack back up. The previous image is pinned under
+an explicit `rollback-<short>` tag so retagging cannot orphan it.
+
+**Rollback restores the image; it does not reverse the migration.** If migration
+succeeded and verification then failed, the schema is forward and the code is
+back. The pre-migration dump exists precisely for that case, and the state file
+must record it as requiring a human rather than as self-healed.
+
+### Reporting
+
+No notification channel, by decision. The watcher writes to journald and
+maintains a state file readable via `deploy-watch.sh --status`, reporting: last
+check, running revision, latest available revision, whether a deploy is blocked by
+the infra gate and which commit, and the outcome of the last deploy.
+
+The accepted cost: a deploy blocked by the infra gate is silent. `--status` is the
+one place that answers "is anything waiting?", and it must answer it in one
+command.
+
+---
+
+## Preconditions found while validating the design
+
+**Stale GHCR credential (blocker).** `~/.docker/config.json` held a GHCR
+credential that the registry rejects. Anonymous manifest resolution returns `200`
+— the package is public — while an authenticated `docker pull` returned
+`denied: denied`. Docker prefers the stored credential over anonymous access, so
+every pull failed. Resolved by `docker logout ghcr.io`; the deploy user now pulls
+the public package anonymously and carries no registry token. Left unfixed, this
+would have failed every automated deploy at the same step.
+
+**Compose project identity.** The running stack has project name `infra` with
+`working_dir=/home/pluggedin/pluggedin-app/infra`. Invoking compose from
+`/home/pluggedin/deploy-tree/infra` yields the same project name, but the
+`working_dir` and `config_files` labels change. The first deploy from the new
+tree must be run manually and observed, in case Compose elects to recreate
+services beyond `pluggedin-app`. `name: infra` should be set explicitly in
+`infra/docker-compose.yml` so project identity no longer depends on a directory
+name.
+
+**Tag width.** GHCR short-SHA tags are 7 characters (`sha-4cf9c6e`). The watcher
+must derive them with `git rev-parse --short=7`; an 8-character guess 404s.
+
+---
+
+## Testing
+
+- **Unit, on the gate:** given a commit range, does the classifier correctly
+  allow app-only changes and block each of the four protected path patterns.
+- **Dry run:** `--dry-run` resolves and reports what it *would* deploy, changing
+  nothing. This is how the first live check is made.
+- **Rollback rehearsal:** force `verify.sh` to fail against a known-good image and
+  confirm the previous digest is restored and the state file marks it as failed.
+- **Idempotence:** two ticks with no new commit must be a no-op, and concurrent
+  invocations must serialise on the lock.
+
+---
+
+## Non-goals
+
+- Moving the Actions runner to a separate machine, which is the correct long-term
+  fix and would make push-based deployment safe. Tracked separately.
+- Ofelia's raw Docker socket mount (`infra/docker-compose.yml:363`), already noted
+  in-file as a follow-up. This design neither depends on it nor worsens it.
+- Zero-downtime or blue/green deployment. The stack restarts a single app
+  container; the brief gap is acceptable and is what happens today.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,3 +1,10 @@
+# Project name is pinned rather than inherited from this file's parent
+# directory. deploy-watch.sh runs compose from a second checkout
+# (/home/pluggedin/deploy-tree); without this, the project identity — and
+# therefore which containers Compose considers "ours" — would depend on the
+# directory a deploy happened to run from.
+name: infra
+
 # Plugged.in production stack.
 #
 # Run with the wrapper:

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -94,6 +94,31 @@ fetch_tree() {
   git -C "$DEPLOY_TREE" rev-parse origin/main
 }
 
+# --- the infra gate --------------------------------------------------------
+# Only application-code changes deploy unattended.
+#
+# main allows merges with zero approving reviews and does not enforce branch
+# protection on admins, and the repository is public. The compensating control
+# has always been that a human runs deploy.sh; automating that removes it. A
+# commit that can rewrite compose, the Dockerfile, or a workflow is a commit
+# that can change what the host mounts and what the container can reach — on a
+# host holding the SOPS age key. Those keep the human.
+#
+# Anchored at the start of the path so `app/infra/...` and `app/Dockerfile.md`
+# are NOT caught; only the real root-level paths are.
+GATE_RE='^(infra/|docker-compose[^/]*\.yml$|Dockerfile$|\.github/workflows/)'
+
+gate_blocked_files() {
+  local from="$1" to="$2"
+  # Fail-closed. If either endpoint is unknown to this tree the range cannot
+  # be judged, and "cannot judge" must never read as "nothing to worry about".
+  git -C "$DEPLOY_TREE" cat-file -e "${from}^{commit}" 2>/dev/null || return 1
+  git -C "$DEPLOY_TREE" cat-file -e "${to}^{commit}"   2>/dev/null || return 1
+  # Every commit that would go live, not just the tip: an infra change must not
+  # ride to production hidden behind a later innocuous commit.
+  git -C "$DEPLOY_TREE" diff --name-only "$from" "$to" | grep -E "$GATE_RE" || true
+}
+
 main() {
   case "${1:-}" in
     --status)  cmd_status; return 0 ;;

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -141,12 +141,135 @@ gate_blocked_files() {
   grep -E "$GATE_RE" <<< "$diff_output" || true
 }
 
+# --- deploying -------------------------------------------------------------
+range_touches_migrations() {
+  # backup.sh dumps Postgres AND rsyncs uploads and vector data into an
+  # age-encrypted tarball — minutes and gigabytes. Far too heavy to run on
+  # every app patch, and pointless when the schema cannot change.
+  git -C "$DEPLOY_TREE" diff --name-only "$1" "$2" | grep -qE '^drizzle/'
+}
+
+external_check() {
+  local code
+  code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 "${SITE_URL}/api/health" || echo 000)"
+  [ "$code" = "200" ] || return 1
+  curl -fsS --max-time 20 "${SITE_URL}/api/health" | grep -q '"status":"healthy"'
+}
+
+do_deploy() {
+  local short="$1" rev="$2" from="$3"
+  local prev_image prev_rev
+  prev_image="$(docker inspect "$APP_CONTAINER" --format '{{.Image}}' 2>/dev/null || printf '')"
+  prev_rev="$(running_revision)"
+
+  log "deploying ${short} (${rev})"
+  git -C "$DEPLOY_TREE" checkout --quiet --detach "$rev"
+
+  if range_touches_migrations "$from" "$rev"; then
+    log "range touches drizzle/ — taking a backup first"
+    "${DEPLOY_TREE}/infra/scripts/backup.sh" || { state_set last_outcome "failed: backup"; return 1; }
+
+    # Migrate BEFORE the app is replaced. A failure here leaves the running
+    # container untouched: old code against the unmigrated schema, which is a
+    # clean failure rather than a half-deployed one.
+    log "running migrations"
+    if ! IMAGE_TAG="sha-${short}" docker compose -f "$COMPOSE_FILE" \
+           run --rm pluggedin-app node_modules/.bin/drizzle-kit migrate; then
+      state_set last_outcome "failed: migration (stack untouched)"
+      return 1
+    fi
+  fi
+
+  docker pull "${IMAGE_REPO}:sha-${short}" >/dev/null \
+    || { state_set last_outcome "failed: pull"; return 1; }
+  docker tag "${IMAGE_REPO}:sha-${short}" "${IMAGE_REPO}:live"
+
+  if IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull && external_check; then
+    state_set last_outcome "ok ${short} at $(now)"
+    state_set running_rev "$rev"
+    log "deploy ok"
+    return 0
+  fi
+
+  log "verification failed — rolling back to ${prev_rev:-previous image}"
+  if [ -n "$prev_image" ]; then
+    docker tag "$prev_image" "${IMAGE_REPO}:live"
+    IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull || true
+  fi
+  if range_touches_migrations "$from" "$rev"; then
+    # The image is back; the schema is not. Say so plainly — this is the one
+    # outcome that must never read as self-healed.
+    state_set last_outcome "ROLLED BACK ${short} at $(now) — MIGRATION ALREADY APPLIED, needs a human"
+  else
+    state_set last_outcome "rolled back ${short} at $(now)"
+  fi
+  return 1
+}
+
 main() {
+  local dry=0
   case "${1:-}" in
     --status)  cmd_status; return 0 ;;
+    --dry-run) dry=1 ;;
     -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; return 0 ;;
+    "")        ;;
+    *)         die "unknown argument: $1" ;;
   esac
-  die "not implemented yet"
+
+  mkdir -p "$STATE_DIR"
+  # Never let two cycles overlap; the timer fires regardless of how long a
+  # deploy takes.
+  LOCK_FILE="$(lock_file)"
+  exec 9>"$LOCK_FILE"
+  flock -n 9 || { log "another cycle holds the lock — skipping"; return 0; }
+
+  local target running short
+  target="$(fetch_tree)"
+  running="$(running_revision)"
+  state_set last_check "$(now)"
+  state_set latest_rev "$target"
+  state_set running_rev "$running"
+
+  [ -n "$running" ] || die "container ${APP_CONTAINER} not running — refusing to guess a baseline"
+  if [ "$running" = "$target" ]; then
+    log "up to date at $(short_sha "$target")"
+    return 0
+  fi
+
+  short="$(short_sha "$target")"
+  if ! image_exists "sha-${short}"; then
+    log "image sha-${short} not published yet — waiting"
+    return 0
+  fi
+
+  local blocked
+  if ! blocked="$(gate_blocked_files "$running" "$target")"; then
+    state_set blocked_rev "$target"
+    state_set blocked_short "$short"
+    state_set blocked_files "unevaluable range — failing closed"
+    log "BLOCKED: cannot evaluate ${running}..${target}"
+    return 0
+  fi
+  if [ -n "$blocked" ]; then
+    state_set blocked_rev "$target"
+    state_set blocked_short "$short"
+    state_set blocked_files "$(printf '%s' "$blocked" | tr '\n' ' ')"
+    log "BLOCKED by the infra gate: $(printf '%s' "$blocked" | tr '\n' ' ')"
+    log "deploy it by hand: IMAGE_TAG=sha-${short} infra/scripts/deploy.sh"
+    return 0
+  fi
+
+  if [ "$dry" -eq 1 ]; then
+    log "DRY RUN: would deploy sha-${short} (${target}); gate clear"
+    range_touches_migrations "$running" "$target" \
+      && log "DRY RUN: range touches drizzle/ — would back up and migrate first" \
+      || log "DRY RUN: no migrations in range"
+    return 0
+  fi
+
+  state_set blocked_rev ""
+  state_set blocked_files ""
+  do_deploy "$short" "$target" "$running"
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -14,7 +14,9 @@
 # Usage:
 #   deploy-watch.sh              # one poll cycle (what the timer runs)
 #   deploy-watch.sh --status     # report state, change nothing
-#   deploy-watch.sh --dry-run    # report what it would deploy, change nothing
+#   deploy-watch.sh --dry-run    # report what it would deploy; does not deploy
+#                                 # or change state, but DOES run `git fetch`
+#                                 # against origin to know what "latest" is
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -24,6 +26,13 @@ IMAGE_REPO="${IMAGE_REPO:-ghcr.io/veriteknik/pluggedin-app}"
 APP_CONTAINER="${APP_CONTAINER:-pluggedin-app}"
 SITE_URL="${SITE_URL:-https://plugged.in}"
 COMPOSE_FILE="${COMPOSE_FILE:-${DEPLOY_TREE}/infra/docker-compose.yml}"
+# The app healthcheck declares start_period: 30s, and Traefik's own LB
+# healthcheck only re-polls backend health every 30s, so a freshly deployed
+# container can legitimately take up to ~60s before it is both healthy and
+# actually reachable through the LB. Poll every 5s for up to 90s (60s plus
+# margin) before external_check gives up. Overridable so tests don't sleep.
+EXTERNAL_CHECK_INTERVAL="${EXTERNAL_CHECK_INTERVAL:-5}"
+EXTERNAL_CHECK_TIMEOUT="${EXTERNAL_CHECK_TIMEOUT:-90}"
 
 log()  { printf '[deploy-watch %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 die()  { printf '[deploy-watch] FATAL: %s\n' "$*" >&2; exit 1; }
@@ -146,14 +155,34 @@ range_touches_migrations() {
   # backup.sh dumps Postgres AND rsyncs uploads and vector data into an
   # age-encrypted tarball — minutes and gigabytes. Far too heavy to run on
   # every app patch, and pointless when the schema cannot change.
-  git -C "$DEPLOY_TREE" diff --name-only "$1" "$2" | grep -qE '^drizzle/'
+  #
+  # Capture-then-grep, not a `git diff | grep -q` pipeline: under `set -o
+  # pipefail`, `grep -q` can exit the instant it finds a match, sending git a
+  # SIGPIPE it hasn't finished writing into; pipefail then surfaces that as
+  # this function's exit status. Same shape as gate_blocked_files above, for
+  # the same reason (see commit 6e924477, which hit this exact class on a
+  # different pipeline).
+  #
+  # A genuine `git diff` failure also fails closed here: treat "cannot tell"
+  # as "yes, might touch migrations" so the deploy takes the safe backup +
+  # migrate path rather than silently skipping it.
+  local out
+  out="$(git -C "$DEPLOY_TREE" diff --name-only "$1" "$2")" || return 0
+  grep -qE '^drizzle/' <<< "$out"
 }
 
 external_check() {
-  local code
-  code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 "${SITE_URL}/api/health" || echo 000)"
-  [ "$code" = "200" ] || return 1
-  curl -fsS --max-time 20 "${SITE_URL}/api/health" | grep -q '"status":"healthy"'
+  local waited=0 code
+  while true; do
+    code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 "${SITE_URL}/api/health" 2>/dev/null || echo 000)"
+    if [ "$code" = "200" ] \
+         && curl -fsS --max-time 20 "${SITE_URL}/api/health" 2>/dev/null | grep -q '"status":"healthy"'; then
+      return 0
+    fi
+    waited=$((waited + EXTERNAL_CHECK_INTERVAL))
+    [ "$waited" -ge "$EXTERNAL_CHECK_TIMEOUT" ] && return 1
+    sleep "$EXTERNAL_CHECK_INTERVAL"
+  done
 }
 
 do_deploy() {
@@ -163,11 +192,21 @@ do_deploy() {
   prev_rev="$(running_revision)"
 
   log "deploying ${short} (${rev})"
-  git -C "$DEPLOY_TREE" checkout --quiet --detach "$rev"
+  # Every command from here on that runs before the rollback branch is
+  # explicitly guarded (`if`/`||`), never bare. Under `set -e` a bare command
+  # that fails aborts the whole function immediately — including the
+  # rollback block and every state_set below it — leaving a broken deploy
+  # running in production with `--status` still showing the PREVIOUS cycle's
+  # (stale, now-false) "ok". A guarded failure is a reported failure; a bare
+  # one is a silent one.
+  if ! git -C "$DEPLOY_TREE" checkout --quiet --detach "$rev"; then
+    state_set last_outcome "failed: checkout ${rev} (stack untouched)"
+    return 1
+  fi
 
   if range_touches_migrations "$from" "$rev"; then
     log "range touches drizzle/ — taking a backup first"
-    "${DEPLOY_TREE}/infra/scripts/backup.sh" || { state_set last_outcome "failed: backup"; return 1; }
+    "${DEPLOY_TREE}/infra/scripts/backup.sh" || { state_set last_outcome "failed: backup (stack untouched)"; return 1; }
 
     # Migrate BEFORE the app is replaced. A failure here leaves the running
     # container untouched: old code against the unmigrated schema, which is a
@@ -180,9 +219,14 @@ do_deploy() {
     fi
   fi
 
-  docker pull "${IMAGE_REPO}:sha-${short}" >/dev/null \
-    || { state_set last_outcome "failed: pull"; return 1; }
-  docker tag "${IMAGE_REPO}:sha-${short}" "${IMAGE_REPO}:live"
+  if ! docker pull "${IMAGE_REPO}:sha-${short}" >/dev/null; then
+    state_set last_outcome "failed: pull (stack untouched)"
+    return 1
+  fi
+  if ! docker tag "${IMAGE_REPO}:sha-${short}" "${IMAGE_REPO}:live"; then
+    state_set last_outcome "failed: tag (stack untouched)"
+    return 1
+  fi
 
   if IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull && external_check; then
     state_set last_outcome "ok ${short} at $(now)"
@@ -192,16 +236,30 @@ do_deploy() {
   fi
 
   log "verification failed — rolling back to ${prev_rev:-previous image}"
-  if [ -n "$prev_image" ]; then
-    docker tag "$prev_image" "${IMAGE_REPO}:live"
-    IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull || true
-  fi
-  if range_touches_migrations "$from" "$rev"; then
-    # The image is back; the schema is not. Say so plainly — this is the one
-    # outcome that must never read as self-healed.
-    state_set last_outcome "ROLLED BACK ${short} at $(now) — MIGRATION ALREADY APPLIED, needs a human"
+  local rollback_state
+  if [ -z "$prev_image" ]; then
+    # Nothing to roll back to: no prior running container, or `docker
+    # inspect` itself failed. Say so — this must never be conflated with a
+    # rollback that actually happened.
+    rollback_state="NO ROLLBACK POSSIBLE (previous image unknown)"
+  elif docker tag "$prev_image" "${IMAGE_REPO}:live" \
+         && IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull \
+         && external_check; then
+    rollback_state="rolled back and verified"
   else
-    state_set last_outcome "rolled back ${short} at $(now)"
+    # The retag and/or redeploy may have partly landed; external_check did
+    # not confirm the rollback itself is healthy. Distinct from "rolled back
+    # and verified" on purpose — this needs a human to look, not a shrug.
+    rollback_state="rollback attempted but NOT verified"
+  fi
+
+  if range_touches_migrations "$from" "$rev"; then
+    # The image may be back; the schema is not, and never was rolled back by
+    # this script. Say so plainly — this is the one outcome that must never
+    # read as self-healed.
+    state_set last_outcome "${rollback_state}: ${short} at $(now) — MIGRATION ALREADY APPLIED, needs a human"
+  else
+    state_set last_outcome "${rollback_state}: ${short} at $(now)"
   fi
   return 1
 }
@@ -231,6 +289,23 @@ main() {
   state_set running_rev "$running"
 
   [ -n "$running" ] || die "container ${APP_CONTAINER} not running — refusing to guess a baseline"
+
+  # A human can deploy a gated commit by hand at any time (that's the whole
+  # point of the gate) without this script ever seeing a clean range. Once
+  # the running revision has caught up to (or passed) whatever was blocked,
+  # the block is stale — clear it, or `--status` reports BLOCKED forever
+  # even though production is already running that commit.
+  local prev_blocked
+  prev_blocked="$(state_get blocked_rev)"
+  if [ -n "$prev_blocked" ] \
+       && git -C "$DEPLOY_TREE" cat-file -e "${prev_blocked}^{commit}" 2>/dev/null \
+       && git -C "$DEPLOY_TREE" merge-base --is-ancestor "$prev_blocked" "$running" 2>/dev/null; then
+    log "blocked revision ${prev_blocked} is now running (hand-deployed?) — clearing the block"
+    state_set blocked_rev ""
+    state_set blocked_short ""
+    state_set blocked_files ""
+  fi
+
   if [ "$running" = "$target" ]; then
     log "up to date at $(short_sha "$target")"
     return 0

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Pull-based automatic deployment.
+#
+# Runs on the production host as `pluggedin` under a systemd timer. Compares
+# origin/main against the running container's revision label and deploys when
+# they differ — subject to the infra gate (see gate_blocked_files).
+#
+# WHY POLLING RATHER THAN CI: infra/scripts/isolate-gha-runner.sh deliberately
+# moved the Actions runner onto a rootless daemon as a separate user with no
+# access to /etc/sops/age/keys.txt, /run/sops/secrets.env, or the production
+# Docker socket. deploy.sh needs all three. A push-based deploy would mean
+# handing those back. See docs/superpowers/specs/2026-08-10-auto-deploy-design.md.
+#
+# Usage:
+#   deploy-watch.sh              # one poll cycle (what the timer runs)
+#   deploy-watch.sh --status     # report state, change nothing
+#   deploy-watch.sh --dry-run    # report what it would deploy, change nothing
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DEPLOY_TREE="${DEPLOY_TREE:-/home/pluggedin/deploy-tree}"
+STATE_DIR="${STATE_DIR:-/var/lib/pluggedin-deploy-watch}"
+LOCK_FILE="${STATE_DIR}/deploy-watch.lock"
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/veriteknik/pluggedin-app}"
+APP_CONTAINER="${APP_CONTAINER:-pluggedin-app}"
+SITE_URL="${SITE_URL:-https://plugged.in}"
+COMPOSE_FILE="${COMPOSE_FILE:-${DEPLOY_TREE}/infra/docker-compose.yml}"
+
+log()  { printf '[deploy-watch %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die()  { printf '[deploy-watch] FATAL: %s\n' "$*" >&2; exit 1; }
+now()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+# --- state -----------------------------------------------------------------
+# Flat key=value. Values are single-line and script-controlled, so no quoting
+# rules are needed; state_set rewrites via mktemp + rename, never in place.
+state_set() {
+  local key="$1" value="$2" tmp
+  local STATE_FILE="${STATE_DIR}/deploy-watch.state"
+  mkdir -p "$STATE_DIR"
+  touch "$STATE_FILE"
+  tmp="$(mktemp "${STATE_FILE}.XXXXXX")"
+  { grep -v "^${key}=" "$STATE_FILE" || true; printf '%s=%s\n' "$key" "$value"; } > "$tmp"
+  mv -f "$tmp" "$STATE_FILE"
+}
+
+state_get() {
+  local key="$1"
+  local STATE_FILE="${STATE_DIR}/deploy-watch.state"
+  [ -f "$STATE_FILE" ] || { printf ''; return 0; }
+  sed -n "s/^${key}=//p" "$STATE_FILE" | tail -1
+}
+
+cmd_status() {
+  printf 'deploy-watch status\n'
+  printf '  last check      : %s\n' "$(state_get last_check)"
+  printf '  running revision: %s\n' "$(state_get running_rev)"
+  printf '  latest revision : %s\n' "$(state_get latest_rev)"
+  printf '  last outcome    : %s\n' "$(state_get last_outcome)"
+  local blocked
+  blocked="$(state_get blocked_rev)"
+  if [ -n "$blocked" ]; then
+    printf '\n  BLOCKED by the infra gate: %s\n' "$blocked"
+    printf '  files: %s\n' "$(state_get blocked_files)"
+    printf '  This will not deploy automatically. Deploy it by hand:\n'
+    printf '    IMAGE_TAG=sha-%s infra/scripts/deploy.sh\n' "$(state_get blocked_short)"
+  fi
+}
+
+main() {
+  case "${1:-}" in
+    --status)  cmd_status; return 0 ;;
+    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; return 0 ;;
+  esac
+  die "not implemented yet"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+  main "$@"
+fi

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -25,7 +25,12 @@
 #                                 # commit — that always proceeds on its own.
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# There is deliberately no REPO_ROOT here. This script must operate on
+# $DEPLOY_TREE — the dedicated checkout pinned to the commit being deployed —
+# never on whichever tree it happens to be invoked from. Deriving a path from
+# BASH_SOURCE would reintroduce exactly the coupling the deploy tree exists to
+# remove. shellcheck flagged the unused variable; the right fix was to delete
+# it, not to silence the warning.
 DEPLOY_TREE="${DEPLOY_TREE:-/home/pluggedin/deploy-tree}"
 STATE_DIR="${STATE_DIR:-/var/lib/pluggedin-deploy-watch}"
 IMAGE_REPO="${IMAGE_REPO:-ghcr.io/veriteknik/pluggedin-app}"

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -70,6 +70,30 @@ cmd_status() {
   fi
 }
 
+# --- revision and image resolution -----------------------------------------
+running_revision() {
+  # Empty (not an error) when the container does not exist: a first install
+  # is a legitimate state, and the caller decides what to do about it.
+  docker inspect "$APP_CONTAINER" \
+    --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' \
+    2>/dev/null || printf ''
+}
+
+short_sha() { git -C "$DEPLOY_TREE" rev-parse --short=7 "$1"; }
+
+image_exists() {
+  # `docker manifest inspect` negotiates anonymous auth itself, which is what
+  # we want: the host is logged out of ghcr.io and the package is public.
+  # Same call infra/scripts/prune-build-artifacts.sh uses.
+  docker manifest inspect "${IMAGE_REPO}:$1" >/dev/null 2>&1
+}
+
+fetch_tree() {
+  [ -d "${DEPLOY_TREE}/.git" ] || die "deploy tree missing at ${DEPLOY_TREE} (see docs/ops/auto-deploy.md)"
+  git -C "$DEPLOY_TREE" fetch --quiet origin main
+  git -C "$DEPLOY_TREE" rev-parse origin/main
+}
+
 main() {
   case "${1:-}" in
     --status)  cmd_status; return 0 ;;

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -100,23 +100,45 @@ fetch_tree() {
 # main allows merges with zero approving reviews and does not enforce branch
 # protection on admins, and the repository is public. The compensating control
 # has always been that a human runs deploy.sh; automating that removes it. A
-# commit that can rewrite compose, the Dockerfile, or a workflow is a commit
-# that can change what the host mounts and what the container can reach — on a
-# host holding the SOPS age key. Those keep the human.
+# commit that can rewrite compose, the Dockerfile, a workflow, or a composite
+# action is a commit that can change what the host mounts, what image gets
+# built, and what the container can reach — on a host holding the SOPS age
+# key. Those keep the human.
 #
-# Anchored at the start of the path so `app/infra/...` and `app/Dockerfile.md`
-# are NOT caught; only the real root-level paths are.
-GATE_RE='^(infra/|docker-compose[^/]*\.yml$|Dockerfile$|\.github/workflows/)'
+# Widened by the maintainer beyond the original spec, deliberately:
+#   - any root-level Dockerfile variant, not just exactly `Dockerfile` —
+#     `Dockerfile.production` exists at repo root today
+#   - all of .github/, not just .github/workflows/ — composite actions under
+#     .github/actions/ are invocable from gated workflows and are just as
+#     capable of reaching secrets as the workflow YAML itself
+#   - .dockerignore at root — it decides what lands in the build context,
+#     and a loosened one can leak files into a published image
+#
+# Anchored at the start of the path so `app/infra/...`, `app/Dockerfile.md`,
+# and a nested `app/.github/...` are NOT caught; only the real root-level
+# paths are.
+GATE_RE='^(infra/|docker-compose[^/]*\.yml$|Dockerfile[^/]*$|\.dockerignore$|\.github/)'
 
 gate_blocked_files() {
-  local from="$1" to="$2"
+  local from="$1" to="$2" diff_output
   # Fail-closed. If either endpoint is unknown to this tree the range cannot
   # be judged, and "cannot judge" must never read as "nothing to worry about".
   git -C "$DEPLOY_TREE" cat-file -e "${from}^{commit}" 2>/dev/null || return 1
   git -C "$DEPLOY_TREE" cat-file -e "${to}^{commit}"   2>/dev/null || return 1
+  # --no-renames: without it, git collapses a gated-path -> non-gated-path
+  # move into a single rename line naming only the new (unmatched) path, and
+  # the protected old path never appears in --name-only output at all. Forcing
+  # a plain delete+add keeps the old path visible to the grep below.
+  #
   # Every commit that would go live, not just the tip: an infra change must not
   # ride to production hidden behind a later innocuous commit.
-  git -C "$DEPLOY_TREE" diff --name-only "$from" "$to" | grep -E "$GATE_RE" || true
+  #
+  # The git diff itself is captured (and its exit status checked) separately
+  # from the grep filter, so only grep's "no match" (exit 1) is swallowed by
+  # `|| true` below. A genuine git diff failure must propagate as blocked, not
+  # be indistinguishable from "nothing matched."
+  diff_output="$(git -C "$DEPLOY_TREE" diff --no-renames --name-only "$from" "$to")" || return 1
+  grep -E "$GATE_RE" <<< "$diff_output" || true
 }
 
 main() {

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -29,8 +29,13 @@ COMPOSE_FILE="${COMPOSE_FILE:-${DEPLOY_TREE}/infra/docker-compose.yml}"
 # The app healthcheck declares start_period: 30s, and Traefik's own LB
 # healthcheck only re-polls backend health every 30s, so a freshly deployed
 # container can legitimately take up to ~60s before it is both healthy and
-# actually reachable through the LB. Poll every 5s for up to 90s (60s plus
-# margin) before external_check gives up. Overridable so tests don't sleep.
+# actually reachable through the LB. external_check polls every 5s against a
+# 90s (60s plus margin) WALL-CLOCK deadline — anchored to bash's $SECONDS,
+# not accumulated sleep durations — so a slow or hung curl cannot silently
+# inflate the real time this bounds. The true worst case is TIMEOUT plus at
+# most one in-flight attempt's own duration (bounded by curl's --max-time,
+# ~40s across the two curl calls one attempt makes), not TIMEOUT alone.
+# Overridable so tests don't sleep.
 EXTERNAL_CHECK_INTERVAL="${EXTERNAL_CHECK_INTERVAL:-5}"
 EXTERNAL_CHECK_TIMEOUT="${EXTERNAL_CHECK_TIMEOUT:-90}"
 
@@ -172,16 +177,30 @@ range_touches_migrations() {
 }
 
 external_check() {
-  local waited=0 code
+  local interval="$EXTERNAL_CHECK_INTERVAL"
+  # A non-positive (or non-numeric) interval must never be used to sleep: at
+  # 0 the loop would spin hot between deadline checks. The deadline below is
+  # what actually bounds total time spent here; this floor only protects the
+  # gap between attempts. Reachable by configuration (both vars are
+  # documented as overridable), so guarded explicitly rather than assumed.
+  [ "$interval" -gt 0 ] 2>/dev/null || interval=1
+
+  # Wall-clock deadline, not accumulated sleep: computed once, compared
+  # against bash's $SECONDS (which counts real elapsed seconds since shell
+  # start, not sleep calls) on every iteration. A curl that takes far longer
+  # than $interval — hung backend, slow TLS, whatever — no longer lets the
+  # loop run for a multiple of the intended budget; the worst case is
+  # bounded by curl's own --max-time regardless of how the sleeps land.
+  local deadline=$((SECONDS + EXTERNAL_CHECK_TIMEOUT))
+  local code
   while true; do
     code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 "${SITE_URL}/api/health" 2>/dev/null || echo 000)"
     if [ "$code" = "200" ] \
          && curl -fsS --max-time 20 "${SITE_URL}/api/health" 2>/dev/null | grep -q '"status":"healthy"'; then
       return 0
     fi
-    waited=$((waited + EXTERNAL_CHECK_INTERVAL))
-    [ "$waited" -ge "$EXTERNAL_CHECK_TIMEOUT" ] && return 1
-    sleep "$EXTERNAL_CHECK_INTERVAL"
+    [ "$SECONDS" -ge "$deadline" ] && return 1
+    sleep "$interval"
   done
 }
 

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -20,7 +20,6 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEPLOY_TREE="${DEPLOY_TREE:-/home/pluggedin/deploy-tree}"
 STATE_DIR="${STATE_DIR:-/var/lib/pluggedin-deploy-watch}"
-LOCK_FILE="${STATE_DIR}/deploy-watch.lock"
 IMAGE_REPO="${IMAGE_REPO:-ghcr.io/veriteknik/pluggedin-app}"
 APP_CONTAINER="${APP_CONTAINER:-pluggedin-app}"
 SITE_URL="${SITE_URL:-https://plugged.in}"

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -17,6 +17,12 @@
 #   deploy-watch.sh --dry-run    # report what it would deploy; does not deploy
 #                                 # or change state, but DOES run `git fetch`
 #                                 # against origin to know what "latest" is
+#   deploy-watch.sh --clear-failed
+#                                 # a target that failed to deploy is never
+#                                 # retried automatically (see --status); this
+#                                 # clears that marker so the next cycle may
+#                                 # retry it. Not needed to deploy a NEWER
+#                                 # commit — that always proceeds on its own.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -82,6 +88,27 @@ cmd_status() {
     printf '  This will not deploy automatically. Deploy it by hand:\n'
     printf '    IMAGE_TAG=sha-%s infra/scripts/deploy.sh\n' "$(state_get blocked_short)"
   fi
+  local failed
+  failed="$(state_get failed_rev)"
+  if [ -n "$failed" ]; then
+    printf '\n  DEPLOY FAILED for target %s — will NOT retry automatically.\n' "$failed"
+    printf '  See "last outcome" above for why. To clear this and resume automatic\n'
+    printf '  deploys, do ONE of:\n'
+    printf '    1. Push a fix to main — a NEWER commit deploys on its own, no\n'
+    printf '       clearing needed, that is the whole point of the feature.\n'
+    printf '    2. Deploy this exact target by hand, which clears the marker on the\n'
+    printf '       next cycle once the running revision catches up to it:\n'
+    printf '         IMAGE_TAG=sha-%s infra/scripts/deploy.sh\n' "$(state_get failed_short)"
+    printf '    3. Clear the marker without deploying, e.g. after fixing the\n'
+    printf '       underlying problem out of band:\n'
+    printf '         infra/scripts/deploy-watch.sh --clear-failed\n'
+  fi
+}
+
+cmd_clear_failed() {
+  state_set failed_rev ""
+  state_set failed_short ""
+  printf 'cleared: the next cycle may retry the previously-failed target.\n'
 }
 
 # --- revision and image resolution -----------------------------------------
@@ -204,6 +231,18 @@ external_check() {
   done
 }
 
+# Deploys exactly one attempt at ("$short", "$rev"); never loops or retries
+# internally. CRITICAL C1: the caller (main, at the bottom of this file)
+# records "$rev" as failed_rev on a non-zero return and will not call this
+# again for the same target on its own — one attempt per target, not a
+# bounded retry budget. Reasoning: every attempt whose range touches
+# drizzle/ costs a full backup.sh run (minutes, gigabytes) before it even
+# reaches the step that might fail again, there is no notification channel
+# to say a retry budget was burned, and a genuinely broken target (bad
+# migration, image that fails health checks) will not start passing on
+# attempt 2 or 3 with no code change in between — only a fix pushed as a
+# NEW commit, or a human, changes the outcome. A bounded retry count would
+# buy nothing here but disk and Postgres load.
 do_deploy() {
   local short="$1" rev="$2" from="$3"
   local prev_image prev_rev
@@ -223,6 +262,23 @@ do_deploy() {
     return 1
   fi
 
+  # Pull before backup/migrate, matching the design
+  # (docs/superpowers/specs/2026-08-10-auto-deploy-design.md: "pull ->
+  # backup -> migrate -> up"). This also keeps the "(stack untouched)"
+  # wording in the two failure branches below honest: nothing that can
+  # change the running container or its schema has happened yet, so a pull
+  # or tag failure genuinely leaves the stack untouched. Pulling first also
+  # means the migration step below never has to fall back to an implicit
+  # `docker compose run` auto-pull of the image it migrates against.
+  if ! docker pull "${IMAGE_REPO}:sha-${short}" >/dev/null; then
+    state_set last_outcome "failed: pull (stack untouched)"
+    return 1
+  fi
+  if ! docker tag "${IMAGE_REPO}:sha-${short}" "${IMAGE_REPO}:live"; then
+    state_set last_outcome "failed: tag (stack untouched)"
+    return 1
+  fi
+
   if range_touches_migrations "$from" "$rev"; then
     log "range touches drizzle/ — taking a backup first"
     "${DEPLOY_TREE}/infra/scripts/backup.sh" || { state_set last_outcome "failed: backup (stack untouched)"; return 1; }
@@ -236,15 +292,6 @@ do_deploy() {
       state_set last_outcome "failed: migration (stack untouched)"
       return 1
     fi
-  fi
-
-  if ! docker pull "${IMAGE_REPO}:sha-${short}" >/dev/null; then
-    state_set last_outcome "failed: pull (stack untouched)"
-    return 1
-  fi
-  if ! docker tag "${IMAGE_REPO}:sha-${short}" "${IMAGE_REPO}:live"; then
-    state_set last_outcome "failed: tag (stack untouched)"
-    return 1
   fi
 
   if IMAGE_TAG=live "${DEPLOY_TREE}/infra/scripts/deploy.sh" --no-pull && external_check; then
@@ -286,9 +333,10 @@ do_deploy() {
 main() {
   local dry=0
   case "${1:-}" in
-    --status)  cmd_status; return 0 ;;
-    --dry-run) dry=1 ;;
-    -h|--help) sed -n '2,20p' "$0" | sed 's/^# \?//'; return 0 ;;
+    --status)       cmd_status; return 0 ;;
+    --dry-run)      dry=1 ;;
+    --clear-failed) cmd_clear_failed; return 0 ;;
+    -h|--help) sed -n '2,25p' "$0" | sed 's/^# \?//'; return 0 ;;
     "")        ;;
     *)         die "unknown argument: $1" ;;
   esac
@@ -325,12 +373,42 @@ main() {
     state_set blocked_files ""
   fi
 
+  # Same idea for a target that previously FAILED to deploy (see the
+  # failed_rev check below, and CRITICAL finding C1): if a human has since
+  # hand-deployed it (or something past it) and the running revision has
+  # caught up, the marker is stale — clear it rather than have --status
+  # report a failure forever after it has plainly been resolved.
+  local prev_failed
+  prev_failed="$(state_get failed_rev)"
+  if [ -n "$prev_failed" ] \
+       && git -C "$DEPLOY_TREE" cat-file -e "${prev_failed}^{commit}" 2>/dev/null \
+       && git -C "$DEPLOY_TREE" merge-base --is-ancestor "$prev_failed" "$running" 2>/dev/null; then
+    log "previously failed target ${prev_failed} is now running (hand-deployed?) — clearing the failure marker"
+    state_set failed_rev ""
+    state_set failed_short ""
+  fi
+
   if [ "$running" = "$target" ]; then
     log "up to date at $(short_sha "$target")"
     return 0
   fi
 
   short="$(short_sha "$target")"
+
+  # CRITICAL C1: a target that already failed must not be retried
+  # automatically by a later cycle — see do_deploy's failure branches and
+  # the state_set at the bottom of this function. Retrying blind, every 2
+  # minutes, forever, is what turned one failed deploy into ~240 encrypted
+  # backups and ~480 container replacements overnight (a migrating deploy
+  # costs a full backup on every attempt). A NEWER commit (this check
+  # compares against the exact failed SHA, not "anything still pending")
+  # is unaffected and deploys normally — that is the whole point of the
+  # feature, and is exactly how a fix pushed after a bad deploy gets live.
+  if [ "$target" = "$prev_failed" ]; then
+    log "target ${target} already failed a previous attempt — not retrying automatically (see --status, or infra/scripts/deploy-watch.sh --clear-failed)"
+    return 0
+  fi
+
   if ! image_exists "sha-${short}"; then
     log "image sha-${short} not published yet — waiting"
     return 0
@@ -363,7 +441,18 @@ main() {
 
   state_set blocked_rev ""
   state_set blocked_files ""
-  do_deploy "$short" "$target" "$running"
+
+  if do_deploy "$short" "$target" "$running"; then
+    return 0
+  fi
+  # Record the failed target so the check above refuses to retry it on the
+  # next cycle. do_deploy has already written the specific reason to
+  # last_outcome; this is deliberately just the target, not a retry count —
+  # see the C1 fix note above do_deploy for why one-and-stop, not a bounded
+  # number of automatic retries.
+  state_set failed_rev "$target"
+  state_set failed_short "$short"
+  return 1
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -29,6 +29,11 @@ log()  { printf '[deploy-watch %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
 die()  { printf '[deploy-watch] FATAL: %s\n' "$*" >&2; exit 1; }
 now()  { date -u +%Y-%m-%dT%H:%M:%SZ; }
 
+# Resolver for lock file path, respecting STATE_DIR overrides after sourcing.
+lock_file() {
+  printf '%s/deploy-watch.lock' "${STATE_DIR}"
+}
+
 # --- state -----------------------------------------------------------------
 # Flat key=value. Values are single-line and script-controlled, so no quoting
 # rules are needed; state_set rewrites via mktemp + rename, never in place.

--- a/infra/scripts/deploy-watch.sh
+++ b/infra/scripts/deploy-watch.sh
@@ -45,7 +45,7 @@ COMPOSE_FILE="${COMPOSE_FILE:-${DEPLOY_TREE}/infra/docker-compose.yml}"
 # not accumulated sleep durations — so a slow or hung curl cannot silently
 # inflate the real time this bounds. The true worst case is TIMEOUT plus at
 # most one in-flight attempt's own duration (bounded by curl's --max-time,
-# ~40s across the two curl calls one attempt makes), not TIMEOUT alone.
+# ~20s for the single curl call each attempt makes), not TIMEOUT alone.
 # Overridable so tests don't sleep.
 EXTERNAL_CHECK_INTERVAL="${EXTERNAL_CHECK_INTERVAL:-5}"
 EXTERNAL_CHECK_TIMEOUT="${EXTERNAL_CHECK_TIMEOUT:-90}"
@@ -224,11 +224,27 @@ external_check() {
   # loop run for a multiple of the intended budget; the worst case is
   # bounded by curl's own --max-time regardless of how the sleeps land.
   local deadline=$((SECONDS + EXTERNAL_CHECK_TIMEOUT))
-  local code
+  local response code body
   while true; do
-    code="$(curl -fsS -o /dev/null -w '%{http_code}' --max-time 20 "${SITE_URL}/api/health" 2>/dev/null || echo 000)"
-    if [ "$code" = "200" ] \
-         && curl -fsS --max-time 20 "${SITE_URL}/api/health" 2>/dev/null | grep -q '"status":"healthy"'; then
+    # Single call, not a status probe plus a separate body fetch: two curls
+    # per attempt doubled the request count and doubled the worst-case time
+    # one attempt could consume against the deadline above. The status code
+    # is appended after a newline via -w so it can be split back out below,
+    # rather than piping the body straight into `grep -q`, which under `set
+    # -o pipefail` can have grep exit (on a match) before curl finishes
+    # writing, turning curl's own SIGPIPE into a false-negative health check
+    # — the same class of bug as gate_blocked_files and
+    # range_touches_migrations above, both of which capture-then-grep for
+    # exactly this reason. In practice unreachable here (the health body is
+    # ~100 bytes against a 64KB pipe buffer, so curl always finishes first),
+    # but a third, differently-shaped site in this file invites someone to
+    # "simplify" the other two later. On any curl failure (non-2xx with
+    # -f, timeout, connection refused) response falls back to a body-less
+    # "000" so the split below still yields a code that can never equal 200.
+    response="$(curl -fsS --max-time 20 -w $'\n%{http_code}' "${SITE_URL}/api/health" 2>/dev/null || printf '\n000')"
+    code="${response##*$'\n'}"
+    body="${response%$'\n'*}"
+    if [ "$code" = "200" ] && [[ "$body" == *'"status":"healthy"'* ]]; then
       return 0
     fi
     [ "$SECONDS" -ge "$deadline" ] && return 1
@@ -367,15 +383,25 @@ main() {
   # the running revision has caught up to (or passed) whatever was blocked,
   # the block is stale — clear it, or `--status` reports BLOCKED forever
   # even though production is already running that commit.
+  # Both endpoints of the ancestry check must be resolvable in this tree
+  # before merge-base is trusted to answer at all — not just $prev_blocked.
+  # If $running (a force-push, a pruned branch, or a container built from a
+  # commit this tree never fetched) is not resolvable, merge-base itself
+  # fails and the block is fail-safe: it stays BLOCKED rather than being
+  # cleared on a guess. That is not dangerous, but it is silent — an
+  # operator staring at a BLOCKED status that will not clear has nothing to
+  # go on without the log line below.
   local prev_blocked
   prev_blocked="$(state_get blocked_rev)"
-  if [ -n "$prev_blocked" ] \
-       && git -C "$DEPLOY_TREE" cat-file -e "${prev_blocked}^{commit}" 2>/dev/null \
-       && git -C "$DEPLOY_TREE" merge-base --is-ancestor "$prev_blocked" "$running" 2>/dev/null; then
-    log "blocked revision ${prev_blocked} is now running (hand-deployed?) — clearing the block"
-    state_set blocked_rev ""
-    state_set blocked_short ""
-    state_set blocked_files ""
+  if [ -n "$prev_blocked" ] && git -C "$DEPLOY_TREE" cat-file -e "${prev_blocked}^{commit}" 2>/dev/null; then
+    if ! git -C "$DEPLOY_TREE" cat-file -e "${running}^{commit}" 2>/dev/null; then
+      log "cannot tell whether the block on ${prev_blocked} is stale: running revision ${running} is not resolvable in ${DEPLOY_TREE} — the block will NOT clear automatically; resolve it by hand (fetch the missing commit, or edit blocked_rev out of ${STATE_DIR}/deploy-watch.state)"
+    elif git -C "$DEPLOY_TREE" merge-base --is-ancestor "$prev_blocked" "$running" 2>/dev/null; then
+      log "blocked revision ${prev_blocked} is now running (hand-deployed?) — clearing the block"
+      state_set blocked_rev ""
+      state_set blocked_short ""
+      state_set blocked_files ""
+    fi
   fi
 
   # Same idea for a target that previously FAILED to deploy (see the
@@ -445,6 +471,7 @@ main() {
   fi
 
   state_set blocked_rev ""
+  state_set blocked_short ""
   state_set blocked_files ""
 
   if do_deploy "$short" "$target" "$running"; then

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -516,6 +516,129 @@ is "$(state_get blocked_rev)" "" "blocked_rev clears once the running revision m
 is "$(state_get blocked_files)" "" "blocked_files clears along with blocked_rev"
 teardown
 
+printf '\n[test] do_deploy: rollback attempted but not verified when deploy.sh itself fails\n'
+setup_deploy_fixture
+echo app4 > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app4
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+# The exact "|| true"-swallowing case fix round 1 addressed: forward
+# deploy.sh fails (triggering the rollback branch) AND the rollback's own
+# deploy.sh call fails too. Must not read as a clean rollback.
+STUB_PREV_IMAGE=sha256:prev STUB_DEPLOY_FAIL=1 do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero when deploy.sh fails on both the forward and rollback attempts"
+case "$(state_get last_outcome)" in
+  "rollback attempted but NOT verified:"*) ok "a failing rollback deploy.sh is reported as unverified, not a clean rollback" ;;
+  *) bad "a failing rollback deploy.sh is reported as unverified, not a clean rollback (got '$(state_get last_outcome)')" ;;
+esac
+is "$(grep -c 'deploy.sh --no-pull' "$CALL_LOG")" "2" "deploy.sh is invoked once forward and once for the attempted rollback"
+teardown
+
+printf '\n[test] do_deploy: backup failure leaves the stack untouched\n'
+setup_deploy_fixture
+echo y > "$DEPLOY_TREE/drizzle/0003_x.sql"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm mig2
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+STUB_BACKUP_FAIL=1 do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero when the backup fails"
+is "$(state_get last_outcome)" "failed: backup (stack untouched)" "backup failure is recorded"
+is "$(grep -c 'docker compose' "$CALL_LOG")" "0" "migration never runs after a failed backup"
+is "$(grep -c 'docker pull' "$CALL_LOG")" "0" "no image pull after a failed backup — stack untouched"
+teardown
+
+printf '\n[test] do_deploy: pull failure leaves the stack untouched\n'
+setup_deploy_fixture
+echo app5 > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app5
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+STUB_PULL_FAIL=1 do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero when the image pull fails"
+is "$(state_get last_outcome)" "failed: pull (stack untouched)" "pull failure is recorded"
+is "$(grep -c 'docker tag' "$CALL_LOG")" "0" "no tag after a failed pull — stack untouched"
+is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "deploy.sh never runs after a failed pull — stack untouched"
+teardown
+
+printf '\n[test] external_check: bounded by a wall-clock deadline, not accumulated sleep\n'
+setup
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+cat > "$STUBS/curl" <<'STUB'
+#!/usr/bin/env bash
+# A backend that never answers quickly: every call takes 2s, and the
+# %{http_code} probe always reports unhealthy, so external_check never
+# succeeds and must eventually give up on its own.
+sleep 2
+case "$*" in
+  *-w*) printf '000' ;;
+  *) printf '{"status":"degraded"}' ;;
+esac
+exit 0
+STUB
+chmod +x "$STUBS/curl"
+PATH="$STUBS:$PATH"; export PATH
+
+# Reproduces the reviewer's exact fix-round-2 repro: INTERVAL=1s, TIMEOUT=3s,
+# each curl call takes 2s. The old accumulated-sleep implementation measured
+# ~8s here because it only counted `sleep` calls toward the budget and never
+# looked at how long curl itself took (three full attempts: 2s curl + 1s
+# sleep, twice, plus a third 2s curl before the counter finally tripped). A
+# wall-clock deadline anchored to $SECONDS bounds this to roughly TIMEOUT
+# plus one in-flight attempt's own duration, however long that turns out to
+# be — not a multiple of it.
+EXTERNAL_CHECK_INTERVAL=1 EXTERNAL_CHECK_TIMEOUT=3
+export EXTERNAL_CHECK_INTERVAL EXTERNAL_CHECK_TIMEOUT
+start=$SECONDS
+external_check
+rc=$?
+elapsed=$((SECONDS - start))
+is "$rc" "1" "external_check still reports failure when the backend never turns healthy"
+if [ "$elapsed" -le 6 ]; then
+  ok "wall-clock bound holds: ${elapsed}s elapsed for a 3s budget with 2s curls (accumulated-sleep code measured ~8s here)"
+else
+  bad "wall-clock bound holds: ${elapsed}s elapsed for a 3s budget with 2s curls (want <= 6s; accumulated-sleep code measured ~8s)"
+fi
+teardown
+
+printf '\n[test] external_check: a zero interval does not busy-spin\n'
+setup
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+ATTEMPT_LOG="${TESTROOT}/attempts.log"; : > "$ATTEMPT_LOG"
+cat > "$STUBS/curl" <<STUB
+#!/usr/bin/env bash
+case "\$*" in
+  *-w*) echo x >> "$ATTEMPT_LOG"; printf '000' ;;
+  *) printf '{"status":"degraded"}' ;;
+esac
+exit 0
+STUB
+chmod +x "$STUBS/curl"
+PATH="$STUBS:$PATH"; export PATH
+# EXTERNAL_CHECK_INTERVAL=0 is reachable by configuration (documented as
+# overridable) and, pre-fix, would never advance a sleep-accumulated budget
+# — an unbounded busy loop. The wall-clock deadline (previous test) already
+# bounds total wall time regardless, but a busy-spin still burns CPU making
+# far more attempts than a 1s-floored interval would in the same window: at
+# a genuine 1s floor against a 2s budget, 2-3 curl calls is expected; an
+# unfloored interval=0 would make orders of magnitude more.
+EXTERNAL_CHECK_INTERVAL=0 EXTERNAL_CHECK_TIMEOUT=2
+export EXTERNAL_CHECK_INTERVAL EXTERNAL_CHECK_TIMEOUT
+start=$SECONDS
+external_check
+rc=$?
+elapsed=$((SECONDS - start))
+attempts="$(wc -l < "$ATTEMPT_LOG")"
+is "$rc" "1" "external_check still returns (does not hang) with a zero interval"
+if [ "$elapsed" -le 6 ] && [ "$attempts" -le 6 ]; then
+  ok "a zero interval is floored rather than spun on: ${attempts} attempts in ${elapsed}s for a 2s budget"
+else
+  bad "a zero interval is floored rather than spun on: ${attempts} attempts in ${elapsed}s for a 2s budget (want <= 6 attempts, <= 6s)"
+fi
+teardown
+
 printf '\n[test] summary\n'
 printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -250,6 +250,272 @@ range_touches_migrations "$A" "$M" && ok "range touching drizzle/ requests a bac
   || bad "range touching drizzle/ requests a backup"
 teardown
 
+printf '\n[test] range_touches_migrations: fails closed on a genuine git diff failure\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+echo one > "$DEPLOY_TREE/a.txt"
+git -C "$DEPLOY_TREE" add a.txt; git -C "$DEPLOY_TREE" commit -qm one
+R1="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+echo two > "$DEPLOY_TREE/a.txt"
+git -C "$DEPLOY_TREE" add a.txt; git -C "$DEPLOY_TREE" commit -qm two
+R2="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+# Force `git diff` (specifically) to fail, distinct from grep finding no
+# match, the same way the infra-gate git-diff-failure test above does.
+REALGIT="$(command -v git)"
+GITSTUB="${TESTROOT}/gitstub-mig"; mkdir -p "$GITSTUB"
+cat > "$GITSTUB/git" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "-C" ] && [ "\$3" = "diff" ]; then
+  echo "fatal: forced failure for test" >&2
+  exit 128
+fi
+exec "$REALGIT" "\$@"
+STUB
+chmod +x "$GITSTUB/git"
+
+if PATH="$GITSTUB:$PATH" range_touches_migrations "$R1" "$R2"; then
+  ok "a git diff failure fails closed toward 'might touch migrations' (triggers backup+migrate)"
+else
+  bad "a git diff failure fails closed toward 'might touch migrations' (triggers backup+migrate)"
+fi
+teardown
+
+# --- do_deploy stub harness -------------------------------------------------
+# Real git repo, because checkout and diff need real git behaviour. docker,
+# curl, deploy.sh, and backup.sh are stubs on PATH (or dropped straight into
+# DEPLOY_TREE/infra/scripts, since do_deploy invokes them by absolute path)
+# that log every call to CALL_LOG and whose outcome is controlled by env
+# vars — the real deploy.sh/backup.sh/docker are never invoked.
+setup_deploy_fixture() {
+  setup
+  git -C "$DEPLOY_TREE" init -q
+  git -C "$DEPLOY_TREE" config user.email t@example.com
+  git -C "$DEPLOY_TREE" config user.name  Test
+  mkdir -p "$DEPLOY_TREE"/{app,drizzle,infra/scripts}
+  echo base > "$DEPLOY_TREE/app/page.tsx"
+  git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+  FROM_REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+  CALL_LOG="${TESTROOT}/calls.log"; : > "$CALL_LOG"
+  export CALL_LOG
+
+  cat > "$DEPLOY_TREE/infra/scripts/deploy.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "deploy.sh $*" >> "$CALL_LOG"
+[ "${STUB_DEPLOY_FAIL:-0}" = "1" ] && exit 1
+exit 0
+STUB
+  chmod +x "$DEPLOY_TREE/infra/scripts/deploy.sh"
+
+  cat > "$DEPLOY_TREE/infra/scripts/backup.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "backup.sh $*" >> "$CALL_LOG"
+[ "${STUB_BACKUP_FAIL:-0}" = "1" ] && exit 1
+exit 0
+STUB
+  chmod +x "$DEPLOY_TREE/infra/scripts/backup.sh"
+
+  STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+  cat > "$STUBS/docker" <<'STUB'
+#!/usr/bin/env bash
+echo "docker $*" >> "$CALL_LOG"
+case "$1" in
+  inspect)
+    if [ -n "${STUB_PREV_IMAGE:-}" ]; then echo "$STUB_PREV_IMAGE"; exit 0; fi
+    echo "no such object" >&2; exit 1 ;;
+  compose)
+    [ "${STUB_MIGRATE_FAIL:-0}" = "1" ] && exit 1
+    exit 0 ;;
+  pull)
+    [ "${STUB_PULL_FAIL:-0}" = "1" ] && exit 1
+    exit 0 ;;
+  tag)
+    [ "${STUB_TAG_FAIL:-0}" = "1" ] && exit 1
+    exit 0 ;;
+  manifest) exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUBS/docker"
+
+  # external_check calls curl twice per attempt: a status-code probe (-w
+  # '%{http_code}') and, only if that was 200, a body fetch piped to grep.
+  # STUB_HEALTH_COUNTER_FILE, if set and containing N > 0, reports unhealthy
+  # for the next N status-code probes (decrementing on each) before
+  # reporting healthy — lets a test make the Nth external_check attempt (not
+  # just every attempt) fail, e.g. "forward check fails, rollback check
+  # passes" without needing real retry delays.
+  cat > "$STUBS/curl" <<'STUB'
+#!/usr/bin/env bash
+bad_left=0
+if [ -n "${STUB_HEALTH_COUNTER_FILE:-}" ] && [ -f "$STUB_HEALTH_COUNTER_FILE" ]; then
+  bad_left="$(cat "$STUB_HEALTH_COUNTER_FILE")"
+fi
+case "$*" in
+  *-w*)
+    if [ "$bad_left" -gt 0 ]; then
+      printf '000'
+      [ -n "${STUB_HEALTH_COUNTER_FILE:-}" ] && echo $((bad_left - 1)) > "$STUB_HEALTH_COUNTER_FILE"
+    else
+      printf '200'
+    fi
+    ;;
+  *)
+    printf '{"status":"healthy"}'
+    ;;
+esac
+exit 0
+STUB
+  chmod +x "$STUBS/curl"
+
+  PATH="$STUBS:$PATH"; export PATH
+  # No real retry delay in tests; scenarios that need a failing attempt use
+  # STUB_HEALTH_COUNTER_FILE instead of the timeout/interval loop.
+  EXTERNAL_CHECK_INTERVAL=0 EXTERNAL_CHECK_TIMEOUT=0
+  export EXTERNAL_CHECK_INTERVAL EXTERNAL_CHECK_TIMEOUT
+}
+
+printf '\n[test] do_deploy: migration failure leaves the stack untouched\n'
+setup_deploy_fixture
+echo y > "$DEPLOY_TREE/drizzle/0002_x.sql"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm mig
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+STUB_MIGRATE_FAIL=1 STUB_PREV_IMAGE=sha256:prev do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero when migration fails"
+is "$(state_get last_outcome)" "failed: migration (stack untouched)" \
+  "migration failure records the stack-untouched outcome"
+is "$(grep -c 'backup.sh' "$CALL_LOG")" "1" "backup ran before the migration (range touches drizzle/)"
+is "$(grep -c 'docker pull' "$CALL_LOG")" "0" "no image pull after a migration failure — stack untouched"
+is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "deploy.sh never runs after a migration failure — stack untouched"
+teardown
+
+printf '\n[test] do_deploy: verify failure triggers a rollback (rolled back and verified)\n'
+setup_deploy_fixture
+echo app > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+COUNTER="${TESTROOT}/health_counter"; echo 1 > "$COUNTER"
+STUB_PREV_IMAGE=sha256:prev STUB_HEALTH_COUNTER_FILE="$COUNTER" do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero even when the rollback itself succeeds"
+case "$(state_get last_outcome)" in
+  "rolled back and verified: ${SHORT} at "*) ok "a failed verification rolls back and records verification of the rollback" ;;
+  *) bad "a failed verification rolls back and records verification of the rollback (got '$(state_get last_outcome)')" ;;
+esac
+is "$(grep -c 'deploy.sh --no-pull' "$CALL_LOG")" "2" "deploy.sh runs once forward and once for the rollback"
+teardown
+
+printf '\n[test] do_deploy: rollback after a successful migration needs a human\n'
+setup_deploy_fixture
+echo y > "$DEPLOY_TREE/drizzle/0002_x.sql"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm mig
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+COUNTER="${TESTROOT}/health_counter"; echo 1 > "$COUNTER"
+STUB_PREV_IMAGE=sha256:prev STUB_HEALTH_COUNTER_FILE="$COUNTER" do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero after a post-migration rollback"
+case "$(state_get last_outcome)" in
+  *"MIGRATION ALREADY APPLIED, needs a human"*)
+    ok "a rollback after a successful migration says plainly that the schema was not reverted" ;;
+  *)
+    bad "a rollback after a successful migration says plainly that the schema was not reverted (got '$(state_get last_outcome)')" ;;
+esac
+case "$(state_get last_outcome)" in
+  "rolled back and verified:"*) ok "the image rollback itself is still reported as verified" ;;
+  *) bad "the image rollback itself is still reported as verified (got '$(state_get last_outcome)')" ;;
+esac
+teardown
+
+printf '\n[test] do_deploy: no previous image means no rollback is possible\n'
+setup_deploy_fixture
+echo app2 > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app2
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+COUNTER="${TESTROOT}/health_counter"; echo 1 > "$COUNTER"
+unset STUB_PREV_IMAGE
+STUB_HEALTH_COUNTER_FILE="$COUNTER" do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "1" "do_deploy returns non-zero when there is nothing to roll back to"
+case "$(state_get last_outcome)" in
+  "NO ROLLBACK POSSIBLE"*) ok "an unknown previous image is never reported as a completed rollback" ;;
+  *) bad "an unknown previous image is never reported as a completed rollback (got '$(state_get last_outcome)')" ;;
+esac
+is "$(grep -c 'docker tag' "$CALL_LOG")" "1" "only the forward tag runs — no rollback tag attempt without a previous image"
+teardown
+
+printf '\n[test] set -e safety: guarded failures are recorded, not fatal\n'
+setup_deploy_fixture
+# The real script runs under `set -euo pipefail`; the test harness disabled
+# -e after sourcing so it can report every assertion. Re-enable it in a
+# subshell here to reproduce the actual production condition these guards
+# exist for: a bare (unguarded) failing command would abort mid-do_deploy
+# under set -e, skipping both the rollback branch and every state_set below
+# it, per the CRITICAL finding in fix round 1.
+(
+  set -euo pipefail
+  do_deploy "deadbee" "0000000000000000000000000000000000000000" "$FROM_REV"
+)
+rc=$?
+is "$rc" "1" "checking out an unknown revision fails the deploy, not the whole process"
+is "$(state_get last_outcome)" "failed: checkout 0000000000000000000000000000000000000000 (stack untouched)" \
+  "a checkout failure is recorded even under set -e"
+
+echo app3 > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app3
+REV3="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT3="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV3")"
+(
+  set -euo pipefail
+  STUB_TAG_FAIL=1 do_deploy "$SHORT3" "$REV3" "$FROM_REV"
+)
+rc=$?
+is "$rc" "1" "a forward tag failure fails the deploy, not the whole process"
+is "$(state_get last_outcome)" "failed: tag (stack untouched)" \
+  "a forward tag failure is recorded even under set -e"
+teardown
+
+printf '\n[test] main: a stale block clears once the running revision catches up\n'
+setup
+ORIGIN="${TESTROOT}/origin.git"
+git init -q --bare "$ORIGIN"
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+git -C "$DEPLOY_TREE" remote add origin "$ORIGIN"
+mkdir -p "$DEPLOY_TREE/app"
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+git -C "$DEPLOY_TREE" push -q origin HEAD:main
+BLOCKED_REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+BLOCKED_SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$BLOCKED_REV")"
+
+state_set blocked_rev "$BLOCKED_REV"
+state_set blocked_short "$BLOCKED_SHORT"
+state_set blocked_files "infra/docker-compose.yml"
+
+# A human hand-deployed the previously blocked commit: the container is now
+# running it, even though this script never saw a clean range for it.
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+cat > "$STUBS/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "inspect" ]; then echo "$BLOCKED_REV"; exit 0; fi
+exit 0
+STUB
+chmod +x "$STUBS/docker"
+
+( PATH="$STUBS:$PATH"; export PATH; main )
+is "$(state_get blocked_rev)" "" "blocked_rev clears once the running revision matches (or is past) it"
+is "$(state_get blocked_files)" "" "blocked_files clears along with blocked_rev"
+teardown
+
 printf '\n[test] summary\n'
 printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -142,6 +142,92 @@ else
 fi
 teardown
 
+printf '\n[test] infra gate: rename bypass\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+mkdir -p "$DEPLOY_TREE/infra/scripts"
+echo x > "$DEPLOY_TREE/infra/scripts/verify.sh"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm "add verify.sh"
+R1="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+mkdir -p "$DEPLOY_TREE/scripts"
+git -C "$DEPLOY_TREE" mv infra/scripts/verify.sh scripts/verify.sh
+git -C "$DEPLOY_TREE" commit -qm "move verify.sh out of infra/"
+R2="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+is "$(gate_blocked_files "$R1" "$R2")" "infra/scripts/verify.sh" \
+  "renaming a gated path to a non-gated path still blocks (old path surfaces via --no-renames)"
+teardown
+
+printf '\n[test] infra gate: widened scope\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+mkdir -p "$DEPLOY_TREE"/{app,.github/workflows,.github/actions/build}
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+BASE2="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+DFVAR="$(commit_file Dockerfile.production changed)"
+is "$(gate_blocked_files "$BASE2" "$DFVAR")" "Dockerfile.production" \
+  "a root Dockerfile variant is blocked"
+
+ACTION="$(commit_file .github/actions/build/action.yml changed)"
+is "$(gate_blocked_files "$DFVAR" "$ACTION")" ".github/actions/build/action.yml" \
+  "a composite action under .github/ is blocked, not just .github/workflows/"
+
+DOCKERIGNORE="$(commit_file .dockerignore changed)"
+is "$(gate_blocked_files "$ACTION" "$DOCKERIGNORE")" ".dockerignore" \
+  "root .dockerignore is blocked"
+
+# Newly covered patterns must still respect root-only anchoring.
+DECOY_DF="$(commit_file app/Dockerfile.x changed)"
+is "$(gate_blocked_files "$DOCKERIGNORE" "$DECOY_DF")" "" \
+  "Dockerfile.x nested under a subdirectory is not the root Dockerfile"
+
+DECOY_GH="$(commit_file app/.github/workflows/x.yml changed)"
+is "$(gate_blocked_files "$DECOY_DF" "$DECOY_GH")" "" \
+  "a nested .github under a subdirectory is not the protected root .github/"
+teardown
+
+printf '\n[test] infra gate: git diff failure fails closed\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+echo one > "$DEPLOY_TREE/a.txt"
+git -C "$DEPLOY_TREE" add a.txt
+git -C "$DEPLOY_TREE" commit -qm one
+R1="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+echo two > "$DEPLOY_TREE/a.txt"
+git -C "$DEPLOY_TREE" add a.txt
+git -C "$DEPLOY_TREE" commit -qm two
+R2="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+# Force git diff itself to fail (distinct from grep finding no match) by
+# intercepting only the `-C <tree> diff ...` invocation; everything else
+# (including cat-file, used by the fail-closed revision check) passes
+# through to the real git.
+REALGIT="$(command -v git)"
+GITSTUB="${TESTROOT}/gitstub"; mkdir -p "$GITSTUB"
+cat > "$GITSTUB/git" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "-C" ] && [ "\$3" = "diff" ]; then
+  echo "fatal: forced failure for test" >&2
+  exit 128
+fi
+exec "$REALGIT" "\$@"
+STUB
+chmod +x "$GITSTUB/git"
+
+if PATH="$GITSTUB:$PATH" gate_blocked_files "$R1" "$R2" >/dev/null 2>&1; then
+  bad "a genuine git diff failure must not read as clean"
+else
+  ok "a genuine git diff failure fails closed"
+fi
+teardown
+
 printf '\n[test] summary\n'
 printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -390,8 +390,12 @@ is "$rc" "1" "do_deploy returns non-zero when migration fails"
 is "$(state_get last_outcome)" "failed: migration (stack untouched)" \
   "migration failure records the stack-untouched outcome"
 is "$(grep -c 'backup.sh' "$CALL_LOG")" "1" "backup ran before the migration (range touches drizzle/)"
-is "$(grep -c 'docker pull' "$CALL_LOG")" "0" "no image pull after a migration failure — stack untouched"
-is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "deploy.sh never runs after a migration failure — stack untouched"
+# I3: pull/tag now run BEFORE backup/migrate (design order: pull -> backup ->
+# migrate -> up), so a migration failure happens after the pull/tag already
+# landed locally. "(stack untouched)" still holds: it describes the RUNNING
+# CONTAINER, which deploy.sh (invoked below) never touches on this path.
+is "$(grep -c 'docker pull' "$CALL_LOG")" "1" "the image was already pulled before migrate ran (pull precedes backup/migrate)"
+is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "deploy.sh never runs after a migration failure — the running container is untouched"
 teardown
 
 printf '\n[test] do_deploy: verify failure triggers a rollback (rolled back and verified)\n'
@@ -516,6 +520,158 @@ is "$(state_get blocked_rev)" "" "blocked_rev clears once the running revision m
 is "$(state_get blocked_files)" "" "blocked_files clears along with blocked_rev"
 teardown
 
+# --- main() fixture: gate-blocked and deploy-failed paths ------------------
+# main() has exactly one test above ("a stale block clears..."), which only
+# reaches that path before returning early at "up to date". Everything past
+# it — both gate-blocking branches, and above all the deploy-failed/no-retry
+# handoff CRITICAL C1 lives in — was untested. This fixture builds on
+# setup_deploy_fixture (real git repo, stub docker/curl/deploy.sh/backup.sh
+# that log to CALL_LOG) and adds a bare "origin" so fetch_tree has something
+# real to fetch from, the same trick the stale-block test above uses.
+#
+# It replaces setup_deploy_fixture's docker stub with one that answers TWO
+# different `docker inspect` questions with different values — the
+# container's revision LABEL (what running_revision(), and so main(), reads)
+# versus the previous image ID (what do_deploy reads for a possible
+# rollback) — disambiguated by the --format string each call passes. The
+# do_deploy-only tests above never needed this because they call
+# running_revision() at most once, indirectly, and never check its value;
+# main() calls it directly and compares it against a real commit SHA, so the
+# two questions can no longer share one canned answer.
+setup_main_fixture() {
+  setup_deploy_fixture
+  ORIGIN="${TESTROOT}/origin.git"
+  git init -q --bare "$ORIGIN"
+  git -C "$DEPLOY_TREE" remote add origin "$ORIGIN"
+  git -C "$DEPLOY_TREE" push -q origin HEAD:main
+
+  cat > "$STUBS/docker" <<STUB
+#!/usr/bin/env bash
+echo "docker \$*" >> "$CALL_LOG"
+case "\$1" in
+  manifest) exit 0 ;;
+  inspect)
+    case "\$*" in
+      *Config.Labels*) printf '%s\n' "\${STUB_RUNNING_REV:-}"; exit 0 ;;
+      *)
+        if [ -n "\${STUB_PREV_IMAGE:-}" ]; then echo "\$STUB_PREV_IMAGE"; exit 0; fi
+        echo "no such object" >&2; exit 1 ;;
+    esac ;;
+  compose)
+    [ "\${STUB_MIGRATE_FAIL:-0}" = "1" ] && exit 1
+    exit 0 ;;
+  pull)
+    [ "\${STUB_PULL_FAIL:-0}" = "1" ] && exit 1
+    exit 0 ;;
+  tag)
+    [ "\${STUB_TAG_FAIL:-0}" = "1" ] && exit 1
+    exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+  chmod +x "$STUBS/docker"
+}
+
+printf '\n[test] main: gate-blocked path records the block and never reaches do_deploy\n'
+setup_main_fixture
+echo changed > "$DEPLOY_TREE/infra/docker-compose.yml"
+# Stage only the one intended file: setup_deploy_fixture drops stub
+# deploy.sh/backup.sh into infra/scripts/ AFTER the base commit, untracked;
+# `git add -A` here would sweep those in too and pollute the gated-files
+# list this test asserts on.
+git -C "$DEPLOY_TREE" add infra/docker-compose.yml
+git -C "$DEPLOY_TREE" commit -qm "touch infra/docker-compose.yml"
+TARGET="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+TARGET_SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$TARGET")"
+git -C "$DEPLOY_TREE" push -q origin HEAD:main
+
+( PATH="$STUBS:$PATH"; export PATH
+  STUB_RUNNING_REV="$FROM_REV"; export STUB_RUNNING_REV
+  main )
+rc=$?
+is "$rc" "0" "a gate-blocked cycle exits 0 — recorded, not treated as this cycle's failure"
+is "$(state_get blocked_rev)" "$TARGET" "blocked_rev is set to the gated target"
+is "$(state_get blocked_short)" "$TARGET_SHORT" "blocked_short matches"
+case "$(state_get blocked_files)" in
+  *infra/docker-compose.yml*) ok "blocked_files names the gated path" ;;
+  *) bad "blocked_files names the gated path (got '$(state_get blocked_files)')" ;;
+esac
+is "$(state_get failed_rev)" "" "a gate block is not a deploy failure — failed_rev stays empty"
+is "$(grep -c 'docker pull' "$CALL_LOG")" "0" "do_deploy is never reached for a blocked target — no pull"
+is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "do_deploy is never reached for a blocked target — deploy.sh never runs"
+teardown
+
+printf '\n[test] main: a deploy failure records failed_rev; a second cycle does NOT retry the same target (C1)\n'
+setup_main_fixture
+echo app1 > "$DEPLOY_TREE/app/page.tsx"
+# Stage only the app file — see the comment in the gate-blocked test above
+# for why `-A` here would falsely trip the infra gate on this app-only
+# commit via the untracked deploy.sh/backup.sh stubs.
+git -C "$DEPLOY_TREE" add app/page.tsx
+git -C "$DEPLOY_TREE" commit -qm app1
+TARGET="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+TARGET_SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$TARGET")"
+git -C "$DEPLOY_TREE" push -q origin HEAD:main
+
+# Cycle 1: the pull step fails (do_deploy's first guarded step after
+# checkout, per the I3 reorder), so this cycle's deploy fails outright.
+( PATH="$STUBS:$PATH"; export PATH
+  STUB_RUNNING_REV="$FROM_REV"; export STUB_RUNNING_REV
+  STUB_PULL_FAIL=1; export STUB_PULL_FAIL
+  main )
+rc=$?
+is "$rc" "1" "cycle 1: main propagates do_deploy's failure as its own exit code"
+is "$(state_get failed_rev)" "$TARGET" "cycle 1: failed_rev records the exact target that failed"
+is "$(state_get failed_short)" "$TARGET_SHORT" "cycle 1: failed_short matches"
+is "$(state_get last_outcome)" "failed: pull (stack untouched)" "cycle 1: last_outcome explains why"
+pulls_after_1="$(grep -c 'docker pull' "$CALL_LOG")"
+is "$pulls_after_1" "1" "cycle 1: exactly one pull attempt"
+
+status_output="$(cmd_status)"
+case "$status_output" in
+  *"DEPLOY FAILED for target ${TARGET}"*) ok "--status names the failed target plainly" ;;
+  *) bad "--status names the failed target plainly (got: $status_output)" ;;
+esac
+case "$status_output" in
+  *"--clear-failed"*) ok "--status tells the operator the exact command to clear it" ;;
+  *) bad "--status tells the operator the exact command to clear it" ;;
+esac
+
+# Cycle 2: origin/main hasn't moved — same target. The pull would now
+# SUCCEED if attempted (STUB_PULL_FAIL is unset in this subshell): if main()
+# retried, the pull count would grow to 2 and last_outcome would flip to
+# "ok ...". Proving neither happens is exactly what CRITICAL C1 requires —
+# a failed target must not be retried automatically by a later cycle.
+( PATH="$STUBS:$PATH"; export PATH
+  STUB_RUNNING_REV="$FROM_REV"; export STUB_RUNNING_REV
+  main )
+rc=$?
+is "$rc" "0" "cycle 2: main does not treat a skipped retry as a failure"
+is "$(grep -c 'docker pull' "$CALL_LOG")" "$pulls_after_1" "cycle 2: no additional pull attempt — the failed target was not retried"
+is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "cycle 2: deploy.sh still never ran"
+is "$(state_get failed_rev)" "$TARGET" "cycle 2: failed_rev is unchanged — still marked failed"
+is "$(state_get last_outcome)" "failed: pull (stack untouched)" "cycle 2: last_outcome is unchanged, not overwritten"
+
+# A NEWER commit must be unaffected by the marker — proceeding normally is
+# the whole point of the feature. Simulate it by clearing the marker the
+# same way a fix-forward commit would (main() compares failed_rev against
+# the exact target SHA; a new SHA never matches it in the first place), then
+# confirm the operator's explicit escape hatch also works and unblocks the
+# SAME target.
+( PATH="$STUBS:$PATH"; export PATH; main --clear-failed )
+is "$(state_get failed_rev)" "" "--clear-failed empties the marker"
+
+( PATH="$STUBS:$PATH"; export PATH
+  STUB_RUNNING_REV="$FROM_REV"; export STUB_RUNNING_REV
+  main )
+rc=$?
+is "$rc" "0" "cycle 3 (after --clear-failed): the same target now deploys and succeeds"
+case "$(state_get last_outcome)" in
+  "ok ${TARGET_SHORT} at "*) ok "cycle 3: last_outcome reports a clean deploy of the previously-failed target" ;;
+  *) bad "cycle 3: last_outcome reports a clean deploy of the previously-failed target (got '$(state_get last_outcome)')" ;;
+esac
+teardown
+
 printf '\n[test] do_deploy: rollback attempted but not verified when deploy.sh itself fails\n'
 setup_deploy_fixture
 echo app4 > "$DEPLOY_TREE/app/page.tsx"
@@ -546,7 +702,29 @@ rc=$?
 is "$rc" "1" "do_deploy returns non-zero when the backup fails"
 is "$(state_get last_outcome)" "failed: backup (stack untouched)" "backup failure is recorded"
 is "$(grep -c 'docker compose' "$CALL_LOG")" "0" "migration never runs after a failed backup"
-is "$(grep -c 'docker pull' "$CALL_LOG")" "0" "no image pull after a failed backup — stack untouched"
+# I3: pull happens before backup now, so it has already succeeded by the
+# time backup fails. "(stack untouched)" still holds for the RUNNING
+# CONTAINER — deploy.sh, asserted below, is what actually touches it.
+is "$(grep -c 'docker pull' "$CALL_LOG")" "1" "the image was already pulled before backup ran (pull precedes backup)"
+is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "deploy.sh never runs after a failed backup — the running container is untouched"
+teardown
+
+printf '\n[test] do_deploy: pull runs before backup, matching the design order (I3)\n'
+setup_deploy_fixture
+echo y > "$DEPLOY_TREE/drizzle/0004_x.sql"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm mig3
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$REV")"
+STUB_PREV_IMAGE=sha256:prev do_deploy "$SHORT" "$REV" "$FROM_REV"
+rc=$?
+is "$rc" "0" "a full success run (pull, backup, migrate, deploy) reports ok"
+pull_line="$(grep -n 'docker pull' "$CALL_LOG" | head -1 | cut -d: -f1)"
+backup_line="$(grep -n 'backup.sh' "$CALL_LOG" | head -1 | cut -d: -f1)"
+if [ -n "$pull_line" ] && [ -n "$backup_line" ] && [ "$pull_line" -lt "$backup_line" ]; then
+  ok "docker pull is logged before backup.sh, matching the design's pull -> backup -> migrate -> up"
+else
+  bad "docker pull is logged before backup.sh, matching the design's pull -> backup -> migrate -> up (pull at line ${pull_line:-?}, backup at line ${backup_line:-?})"
+fi
 teardown
 
 printf '\n[test] do_deploy: pull failure leaves the stack untouched\n'

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -42,6 +42,50 @@ is "$(grep -c '^running_rev=' "${STATE_DIR}/deploy-watch.state")" "1" "no duplic
 is "$(state_get never_set)" "" "missing key yields empty string"
 teardown
 
+printf '\n[test] revision resolution\n'
+setup
+# A real git repo, so short_sha and fetch_tree exercise real git behaviour.
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+echo one > "$DEPLOY_TREE/a.txt"
+git -C "$DEPLOY_TREE" add a.txt
+git -C "$DEPLOY_TREE" commit -qm one
+REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+is "$(short_sha "$REV")" "${REV:0:7}" "short_sha abbreviates to exactly 7 characters"
+is "${#REV}" "40" "test fixture revision is a full SHA"
+
+# Stub docker so image_exists is deterministic.
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+cat > "$STUBS/docker" <<'STUB'
+#!/usr/bin/env bash
+# manifest inspect <repo>:<tag> — only sha-present resolves
+if [ "$1" = "manifest" ] && [ "$2" = "inspect" ]; then
+  case "$3" in
+    *:sha-present) exit 0 ;;
+    *) echo "manifest unknown" >&2; exit 1 ;;
+  esac
+fi
+if [ "$1" = "inspect" ]; then
+  # inspect <container> --format ... — print the fixture revision
+  if [ -n "${STUB_RUNNING_REV:-}" ]; then echo "$STUB_RUNNING_REV"; exit 0; fi
+  echo "No such object" >&2; exit 1
+fi
+exit 0
+STUB
+chmod +x "$STUBS/docker"
+PATH="$STUBS:$PATH"
+
+image_exists "sha-present" && ok "image_exists true for a tag the registry resolves" \
+  || bad "image_exists true for a tag the registry resolves"
+image_exists "sha-absent" && bad "image_exists false for an absent tag" \
+  || ok "image_exists false for an absent tag"
+
+STUB_RUNNING_REV="$REV" is "$(STUB_RUNNING_REV="$REV" running_revision)" "$REV" \
+  "running_revision reads the container label"
+is "$(running_revision)" "" "running_revision is empty when the container is absent"
+teardown
+
 printf '\n[test] summary\n'
 printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -129,7 +129,10 @@ is "$(gate_blocked_files "$DECOY2" "$DECOY3")" "" "migrations are app changes, n
 
 # The range, not just the tip: an infra commit buried behind an app commit
 # must still block.
-BURIED_INFRA="$(commit_file infra/docker-compose.yml changed)"
+# The infra commit's own SHA is deliberately not captured — the assertion
+# spans DECOY3..BURIED_APP precisely so the infra change sits buried inside
+# the range rather than at either endpoint.
+commit_file infra/docker-compose.yml changed >/dev/null
 BURIED_APP="$(commit_file app/page.tsx again)"
 is "$(gate_blocked_files "$DECOY3" "$BURIED_APP")" "infra/docker-compose.yml" \
   "an infra commit behind a later app commit still blocks the range"

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -86,6 +86,62 @@ STUB_RUNNING_REV="$REV" is "$(STUB_RUNNING_REV="$REV" running_revision)" "$REV" 
 is "$(running_revision)" "" "running_revision is empty when the container is absent"
 teardown
 
+printf '\n[test] infra gate\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+mkdir -p "$DEPLOY_TREE"/{app,infra/scripts,.github/workflows,drizzle}
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+BASE="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+commit_file() { # commit_file <path> <content> -> prints new SHA
+  mkdir -p "$(dirname "${DEPLOY_TREE}/$1")"
+  echo "$2" > "${DEPLOY_TREE}/$1"
+  git -C "$DEPLOY_TREE" add -A
+  git -C "$DEPLOY_TREE" commit -qm "touch $1"
+  git -C "$DEPLOY_TREE" rev-parse HEAD
+}
+
+APP="$(commit_file app/page.tsx changed)"
+is "$(gate_blocked_files "$BASE" "$APP")" "" "app-only change is not blocked"
+
+INFRA="$(commit_file infra/scripts/deploy.sh changed)"
+is "$(gate_blocked_files "$APP" "$INFRA")" "infra/scripts/deploy.sh" "infra/ change is blocked"
+
+COMPOSE="$(commit_file docker-compose.production.yml changed)"
+is "$(gate_blocked_files "$INFRA" "$COMPOSE")" "docker-compose.production.yml" "root compose change is blocked"
+
+DOCKERFILE="$(commit_file Dockerfile changed)"
+is "$(gate_blocked_files "$COMPOSE" "$DOCKERFILE")" "Dockerfile" "Dockerfile change is blocked"
+
+WF="$(commit_file .github/workflows/build-image.yml changed)"
+is "$(gate_blocked_files "$DOCKERFILE" "$WF")" ".github/workflows/build-image.yml" "workflow change is blocked"
+
+# Paths that merely look like the protected ones must NOT be blocked.
+DECOY="$(commit_file app/infra/helper.ts changed)"
+is "$(gate_blocked_files "$WF" "$DECOY")" "" "app/infra/ is not the protected infra/ prefix"
+DECOY2="$(commit_file app/Dockerfile.md changed)"
+is "$(gate_blocked_files "$DECOY" "$DECOY2")" "" "a nested Dockerfile.md is not the root Dockerfile"
+DECOY3="$(commit_file drizzle/0001_x.sql changed)"
+is "$(gate_blocked_files "$DECOY2" "$DECOY3")" "" "migrations are app changes, not infra"
+
+# The range, not just the tip: an infra commit buried behind an app commit
+# must still block.
+BURIED_INFRA="$(commit_file infra/docker-compose.yml changed)"
+BURIED_APP="$(commit_file app/page.tsx again)"
+is "$(gate_blocked_files "$DECOY3" "$BURIED_APP")" "infra/docker-compose.yml" \
+  "an infra commit behind a later app commit still blocks the range"
+
+# Fail-closed: an unknown starting revision cannot be evaluated.
+if gate_blocked_files "0000000000000000000000000000000000000000" "$BURIED_APP" >/dev/null 2>&1; then
+  bad "unknown revision must not evaluate as allowed"
+else
+  ok "unknown revision fails closed"
+fi
+teardown
+
 printf '\n[test] summary\n'
 printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -344,32 +344,25 @@ esac
 STUB
   chmod +x "$STUBS/docker"
 
-  # external_check calls curl twice per attempt: a status-code probe (-w
-  # '%{http_code}') and, only if that was 200, a body fetch piped to grep.
-  # STUB_HEALTH_COUNTER_FILE, if set and containing N > 0, reports unhealthy
-  # for the next N status-code probes (decrementing on each) before
-  # reporting healthy — lets a test make the Nth external_check attempt (not
-  # just every attempt) fail, e.g. "forward check fails, rollback check
-  # passes" without needing real retry delays.
+  # external_check makes ONE curl call per attempt: body and status code
+  # together, split back apart via the trailing "\n%{http_code}" that -w
+  # appends. STUB_HEALTH_COUNTER_FILE, if set and containing N > 0, reports
+  # unhealthy (code 000, no body) for the next N attempts (decrementing on
+  # each) before reporting healthy — lets a test make the Nth external_check
+  # attempt (not just every attempt) fail, e.g. "forward check fails,
+  # rollback check passes" without needing real retry delays.
   cat > "$STUBS/curl" <<'STUB'
 #!/usr/bin/env bash
 bad_left=0
 if [ -n "${STUB_HEALTH_COUNTER_FILE:-}" ] && [ -f "$STUB_HEALTH_COUNTER_FILE" ]; then
   bad_left="$(cat "$STUB_HEALTH_COUNTER_FILE")"
 fi
-case "$*" in
-  *-w*)
-    if [ "$bad_left" -gt 0 ]; then
-      printf '000'
-      [ -n "${STUB_HEALTH_COUNTER_FILE:-}" ] && echo $((bad_left - 1)) > "$STUB_HEALTH_COUNTER_FILE"
-    else
-      printf '200'
-    fi
-    ;;
-  *)
-    printf '{"status":"healthy"}'
-    ;;
-esac
+if [ "$bad_left" -gt 0 ]; then
+  [ -n "${STUB_HEALTH_COUNTER_FILE:-}" ] && echo $((bad_left - 1)) > "$STUB_HEALTH_COUNTER_FILE"
+  printf '\n000'
+else
+  printf '{"status":"healthy"}\n200'
+fi
 exit 0
 STUB
   chmod +x "$STUBS/curl"
@@ -604,6 +597,34 @@ is "$(grep -c 'docker pull' "$CALL_LOG")" "0" "do_deploy is never reached for a 
 is "$(grep -c 'deploy.sh' "$CALL_LOG")" "0" "do_deploy is never reached for a blocked target — deploy.sh never runs"
 teardown
 
+printf '\n[test] main: blocked_short clears on the clean path alongside blocked_rev and blocked_files\n'
+setup_main_fixture
+# Leftover state from some earlier, unrelated block — must not survive a
+# cycle whose target clears the gate. Before the fix, the clean-path clear
+# reset blocked_rev and blocked_files but forgot blocked_short, leaving a
+# stale short SHA behind (invisible via --status only because it gates on
+# blocked_rev being non-empty — a latent inconsistency, not a user-visible
+# bug, but the stale-clear branch already clears all three and the two
+# should match).
+state_set blocked_rev "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+state_set blocked_short "deadbee"
+state_set blocked_files "some/unrelated/path"
+
+echo appclean > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add app/page.tsx
+git -C "$DEPLOY_TREE" commit -qm appclean
+git -C "$DEPLOY_TREE" push -q origin HEAD:main
+
+( PATH="$STUBS:$PATH"; export PATH
+  STUB_RUNNING_REV="$FROM_REV"; export STUB_RUNNING_REV
+  main )
+rc=$?
+is "$rc" "0" "a clean, gate-passing deploy succeeds"
+is "$(state_get blocked_rev)" "" "blocked_rev clears on the clean path"
+is "$(state_get blocked_short)" "" "blocked_short clears on the clean path alongside blocked_rev and blocked_files"
+is "$(state_get blocked_files)" "" "blocked_files clears on the clean path"
+teardown
+
 printf '\n[test] main: a deploy failure records failed_rev; a second cycle does NOT retry the same target (C1)\n'
 setup_main_fixture
 echo app1 > "$DEPLOY_TREE/app/page.tsx"
@@ -818,6 +839,89 @@ if [ "$elapsed" -le 6 ] && [ "$attempts" -le 6 ]; then
 else
   bad "a zero interval is floored rather than spun on: ${attempts} attempts in ${elapsed}s for a 2s budget (want <= 6 attempts, <= 6s)"
 fi
+teardown
+
+printf '\n[test] external_check: requires both a 200 status AND a healthy body (single curl call, not a pipeline)\n'
+setup
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+# A dedicated stub, independent of setup_deploy_fixture's: this test drives
+# the exact HTTP code and body external_check sees, to prove neither
+# condition alone is sufficient. Mirrors the "\n%{http_code}" shape the real
+# -w format produces so the split-back-apart logic under test is exercised
+# for real, not bypassed.
+cat > "$STUBS/curl" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n%s' "${STUB_HTTP_BODY:-}" "${STUB_HTTP_CODE:-000}"
+exit 0
+STUB
+chmod +x "$STUBS/curl"
+PATH="$STUBS:$PATH"; export PATH
+EXTERNAL_CHECK_INTERVAL=0 EXTERNAL_CHECK_TIMEOUT=0
+export EXTERNAL_CHECK_INTERVAL EXTERNAL_CHECK_TIMEOUT
+
+STUB_HTTP_CODE=200 STUB_HTTP_BODY='{"status":"degraded"}' external_check
+is "$?" "1" "a 200 status with an unhealthy body still fails — status alone is not enough"
+
+STUB_HTTP_CODE=500 STUB_HTTP_BODY='{"status":"healthy"}' external_check
+is "$?" "1" "a healthy body with a non-200 status still fails — body alone is not enough"
+
+STUB_HTTP_CODE=200 STUB_HTTP_BODY='{"status":"healthy"}' external_check
+is "$?" "0" "a 200 status with a healthy body passes"
+teardown
+
+printf '\n[test] main: an unresolvable running revision leaves a stale block in place and logs why\n'
+setup
+ORIGIN="${TESTROOT}/origin.git"
+git init -q --bare "$ORIGIN"
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+git -C "$DEPLOY_TREE" remote add origin "$ORIGIN"
+mkdir -p "$DEPLOY_TREE/app"
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+git -C "$DEPLOY_TREE" push -q origin HEAD:main
+BLOCKED_REV="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+BLOCKED_SHORT="$(git -C "$DEPLOY_TREE" rev-parse --short=7 "$BLOCKED_REV")"
+
+state_set blocked_rev "$BLOCKED_REV"
+state_set blocked_short "$BLOCKED_SHORT"
+state_set blocked_files "infra/docker-compose.yml"
+
+# A running revision this deploy tree has never fetched — a force-push, a
+# pruned branch, or a container built from a commit that never landed here.
+# merge-base cannot be asked about it at all, and that must never be
+# silently treated the same as a resolvable "not yet caught up".
+BOGUS_REV="0123456789abcdef0123456789abcdef01234567"
+
+STUBS="${TESTROOT}/bin"; mkdir -p "$STUBS"
+cat > "$STUBS/docker" <<STUB
+#!/usr/bin/env bash
+if [ "\$1" = "inspect" ]; then echo "$BOGUS_REV"; exit 0; fi
+# image_exists must report false so main() returns right after the
+# block-staleness check above, before ever reaching gate_blocked_files —
+# keeps this test isolated to the one code path it exercises.
+if [ "\$1" = "manifest" ]; then exit 1; fi
+exit 0
+STUB
+chmod +x "$STUBS/docker"
+
+output="$( PATH="$STUBS:$PATH"; export PATH; main )"
+rc=$?
+is "$rc" "0" "an unresolvable running revision does not crash the cycle"
+is "$(state_get blocked_rev)" "$BLOCKED_REV" "the block is NOT cleared when the running revision cannot be resolved"
+is "$(state_get blocked_short)" "$BLOCKED_SHORT" "blocked_short is likewise left in place"
+is "$(state_get blocked_files)" "infra/docker-compose.yml" "blocked_files is likewise left in place"
+case "$output" in
+  *"cannot tell whether the block on ${BLOCKED_REV} is stale"*"${BOGUS_REV}"*)
+    ok "logs which revision could not be resolved" ;;
+  *)
+    bad "logs which revision could not be resolved (got: $output)" ;;
+esac
+case "$output" in
+  *"clearing the block"*) bad "must not log a clearing message when the block was left in place" ;;
+  *) ok "does not log a clearing message when the block was left in place" ;;
+esac
 teardown
 
 printf '\n[test] summary\n'

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Test harness for deploy-watch.sh.
+#
+# Stubs docker/git/curl by putting fake executables first on PATH, then
+# sources deploy-watch.sh (whose main() is guarded) and calls its functions
+# directly. Run: infra/scripts/test-deploy-watch.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASS=0
+FAIL=0
+
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; PASS=$((PASS + 1)); }
+bad()  { printf '  \033[31m✗\033[0m %s\n' "$*"; FAIL=$((FAIL + 1)); }
+is()   { # is <actual> <expected> <label>
+  if [ "$1" = "$2" ]; then ok "$3"; else bad "$3 (got '$1', want '$2')"; fi
+}
+
+setup() {
+  TESTROOT="$(mktemp -d)"
+  export STATE_DIR="${TESTROOT}/state"
+  export DEPLOY_TREE="${TESTROOT}/tree"
+  mkdir -p "$STATE_DIR" "$DEPLOY_TREE"
+}
+teardown() { rm -rf "$TESTROOT"; }
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/deploy-watch.sh"
+# Sourcing the script under test inherits set -e, which would abort on
+# the first non-zero assertion. Reset it so the harness can report all failures.
+set +e
+
+printf '\n[test] state file\n'
+setup
+state_set last_check "2026-08-11T00:00:00Z"
+state_set running_rev "abc123"
+is "$(state_get last_check)" "2026-08-11T00:00:00Z" "state_get reads back what state_set wrote"
+is "$(state_get running_rev)" "abc123" "second key stored independently"
+state_set running_rev "def456"
+is "$(state_get running_rev)" "def456" "state_set replaces rather than appends"
+is "$(grep -c '^running_rev=' "${STATE_DIR}/deploy-watch.state")" "1" "no duplicate keys accumulate"
+is "$(state_get never_set)" "" "missing key yields empty string"
+teardown
+
+printf '\n[test] summary\n'
+printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/infra/scripts/test-deploy-watch.sh
+++ b/infra/scripts/test-deploy-watch.sh
@@ -228,6 +228,28 @@ else
 fi
 teardown
 
+printf '\n[test] migration detection and dry run\n'
+setup
+git -C "$DEPLOY_TREE" init -q
+git -C "$DEPLOY_TREE" config user.email t@example.com
+git -C "$DEPLOY_TREE" config user.name  Test
+mkdir -p "$DEPLOY_TREE"/{app,drizzle}
+echo base > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm base
+B="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+echo x > "$DEPLOY_TREE/app/page.tsx"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm app
+A="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+echo y > "$DEPLOY_TREE/drizzle/0002_x.sql"
+git -C "$DEPLOY_TREE" add -A; git -C "$DEPLOY_TREE" commit -qm mig
+M="$(git -C "$DEPLOY_TREE" rev-parse HEAD)"
+
+range_touches_migrations "$B" "$A" && bad "app-only range must not request a backup" \
+  || ok "app-only range does not request a backup"
+range_touches_migrations "$A" "$M" && ok "range touching drizzle/ requests a backup" \
+  || bad "range touching drizzle/ requests a backup"
+teardown
+
 printf '\n[test] summary\n'
 printf '  %d passed, %d failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/infra/systemd/pluggedin-deploy-watch.service
+++ b/infra/systemd/pluggedin-deploy-watch.service
@@ -18,6 +18,20 @@ Environment=SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
 # A deploy including a migration and an image pull can legitimately take a
 # while; the lock means a slow run cannot pile up behind the timer.
 TimeoutStartSec=1800
+# Hardening: this unit reads /etc/sops/age/keys.txt on a host whose compromise
+# would expose every production secret. These directives constrain the damage a
+# compromised deploy process could do. They are unverified at runtime — this unit
+# has deliberately never been started, and the first supervised run must confirm
+# docker and git still work under them. A hardening directive breaking the deploy
+# would only surface when the deploy is needed.
+NoNewPrivileges=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectClock=yes
+RestrictSUIDSGID=yes
+RestrictRealtime=yes
+LockPersonality=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/infra/systemd/pluggedin-deploy-watch.service
+++ b/infra/systemd/pluggedin-deploy-watch.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=plugged.in automatic deployment poller
+Documentation=file:///home/pluggedin/pluggedin-app/docs/ops/auto-deploy.md
+After=network-online.target docker.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=pluggedin
+Group=pluggedin
+# Runs from the deploy tree, never the maintainer's working checkout.
+WorkingDirectory=/home/pluggedin/deploy-tree
+ExecStart=/home/pluggedin/deploy-tree/infra/scripts/deploy-watch.sh
+# Creates /var/lib/pluggedin-deploy-watch owned by User, so neither the
+# script nor an operator needs sudo to read --status.
+StateDirectory=pluggedin-deploy-watch
+Environment=SOPS_AGE_KEY_FILE=/etc/sops/age/keys.txt
+# A deploy including a migration and an image pull can legitimately take a
+# while; the lock means a slow run cannot pile up behind the timer.
+TimeoutStartSec=1800
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/pluggedin-deploy-watch.timer
+++ b/infra/systemd/pluggedin-deploy-watch.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Poll for new plugged.in images every 2 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=2min
+# Cycles are cheap when there is nothing to do: one git fetch and one
+# registry HEAD. Persistent=false because a missed window is meaningless —
+# the next cycle sees the same state.
+Persistent=false
+AccuracySec=15s
+Unit=pluggedin-deploy-watch.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## ⚠️ Merge order: PR #193 must land first

`deploy-watch.sh` invokes `deploy.sh` on every deploy cycle. Without
[#193](https://github.com/VeriTeknik/pluggedin-app/pull/193), `deploy.sh`
fails writing `/run/sops/secrets.env` on any run after the first — so the
second and every subsequent automatic deploy cycle would die at the secrets
write. **Merge #193 before merging this.**

## Nothing is installed by this PR

This PR is documentation and code only: `infra/scripts/deploy-watch.sh`,
its systemd unit/timer, its test harness, and the runbook at
`docs/ops/auto-deploy.md`. **Nothing here is installed on the production
host.** Enabling `pluggedin-deploy-watch.timer` is a separate, supervised
step, to be done by hand following the "First run, supervised" section of
the runbook — not as a consequence of this merge.

## What the infra gate covers, and why

Application-code merges to `main` deploy themselves within ~2 minutes.
Commit ranges that touch any of the following are blocked from unattended
deployment and wait for a human to run `deploy.sh` by hand:

- `infra/`
- `docker-compose*.yml`
- any root-level `Dockerfile` variant (not just literal `Dockerfile` —
  `Dockerfile.production` exists at repo root today)
- root `.dockerignore`
- all of `.github/` (not just `.github/workflows/` — composite actions
  under `.github/actions/` are just as capable of reaching secrets as the
  workflow YAML itself)

`main` allows merges with zero approving reviews and doesn't enforce branch
protection on admins, and the repo is public. The compensating control has
always been a human running `deploy.sh`; automating deploys removes that
control for anything that can rewrite compose, the Dockerfile, a workflow,
or a composite action — on a host holding the SOPS age key. The gate keeps
a human in the loop for exactly those changes. It evaluates the *entire*
commit range from the running revision to latest, not just the tip, and
fails closed if the range can't be judged. Once blocked, later app-only
commits do **not** unblock it — the block only clears when a human deploys
and the running revision moves past the infra commit.

## Rollback / migration caveat

Migrations run before the app container is replaced, so a verification
failure after a migration cannot fully self-heal: the image can be rolled
back, the schema cannot. The state file distinguishes three rollback
outcomes (`rolled back and verified`, `rollback attempted but NOT
verified`, `NO ROLLBACK POSSIBLE`) and appends a `MIGRATION ALREADY
APPLIED, needs a human` marker when the range touched `drizzle/`. See
`docs/ops/auto-deploy.md` for what to do in each case.

## Also note

- No notifications of any kind — `deploy-watch.sh --status` and
  `journalctl -u pluggedin-deploy-watch.service` are the only ways to
  learn a deploy ran, failed, or is blocked.
- The deploy path has only ever run against stubs
  (`infra/scripts/test-deploy-watch.sh`, 66/66 passing) — never a real
  deploy, rollback, or migration in production.

## Test plan

- [x] `infra/scripts/test-deploy-watch.sh` — 66 passed, 0 failed
- [x] `infra/scripts/deploy-watch.sh --help` prints usage
- [ ] Supervised first run on the production host (separate, follow-up step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789020468&installation_model_id=430597&pr_number=195&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F195&signature=20826bf8461764f106ff7a317928ede1f78a603e989d7fe80d2ea39ba60652a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Introduce a pull-based automatic deployment mechanism driven by a host-side poller and supporting docs, without yet enabling it in production.

New Features:
- Add deploy-watch.sh poller script that detects new main commits, applies an infra gate, orchestrates backup/migration/deploy/rollback, and exposes a --status and --dry-run interface.
- Add a comprehensive test harness for deploy-watch.sh using stubbed docker/git/curl to validate gating, migration handling, rollback semantics, and external health checks.
- Define systemd service and timer units for running the deploy watcher as the pluggedin user on a 2-minute cadence.
- Add a design spec and operational runbook documenting the automatic deployment architecture, infra gate behavior, installation steps, and operational caveats.
- Update the stack-ops ops skill documentation to reflect that app merges to main now auto-deploy via the new timer and how to query deploy status.

Enhancements:
- Pin the Docker Compose project name to infra so deployments from a dedicated deploy tree remain associated with the existing production stack regardless of checkout path.

Deployment:
- Add systemd service and timer definitions for the deploy watcher but leave their installation and activation as a separate manual production step.

Documentation:
- Document the automatic deployment design in a new spec and provide a detailed ops runbook for installing, supervising, and operating the deploy watcher, including rollback and migration caveats.
- Extend ops skill documentation with guidance on the new auto-deploy flow and how to check whether a deploy is pending.

Tests:
- Add a standalone Bash test script for deploy-watch.sh that exercises state management, infra gating rules, migration detection, deployment paths, rollback outcomes, timeout behavior, and failure handling under set -e.