### PR TITLE
security: keep .env and the deepsec workspace out of the public repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,9 @@ LICENSE
 # TypeDoc
 typedoc.json
 docs/api/
+
+# Secrets: never let a local build bake .env into an image layer.
+# CI checkouts have no .env, so this only changes local `docker build`.
+.env
+.env.*
+!.env.example

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,8 @@ z_reports/
 CLAUDE.md
 # Sentry Config File
 .env.sentry-build-plugin
+
+# deepsec scanning workspace. Its own .gitignore excludes reports/runs, but
+# deliberately tracks INFO.md — a threat model naming this app's weak spots.
+# That is fine in a private repo; this one is public. Ignore the lot.
+.deepsec/


### PR DESCRIPTION
Two changes, same class of problem: files that must never reach the public repo or a pushed image.

## 1. `.env` was entering the Docker build context

[`Dockerfile:62`](../blob/main/Dockerfile#L62) runs `COPY . .` in the builder stage. `.dockerignore` excluded `node_modules`, `.git` and `.next` — but not `.env`.

CI images were never affected: a fresh checkout has no `.env` (gitignored, never committed — verified with a pickaxe scan over all 1500 commits). The exposure was **local builds on the prod host**, which is also the self-hosted Actions runner:

1. `COPY . .` pulls the live `.env` into the builder.
2. `next build` copies it to `.next/standalone/.env` (confirmed on this host).
3. The runner stage lands standalone at `/app` via `COPY --from=builder /app/.next/standalone ./`.

So a local `docker build` baked live provider credentials into an image layer — one config slip away from `docker push` to ghcr.

**Verified after the fix** by building a throwaway image with `COPY . /ctx` against the real context:

```
--- env files in build context ---
.env.example
```

Only `.env.example`. CI behaviour is unchanged, since its checkout never had one.

## 2. The deepsec workspace tracks a threat model

We now run [deepsec](https://github.com/vercel-labs/deepsec) against this codebase. It writes `.deepsec/` next to the code. Its own nested `.gitignore` excludes `data/*/reports/` and `data/*/runs/`, but **deliberately keeps `INFO.md` tracked** so teammates inherit project context.

`INFO.md` is a threat model that names where this codebase is weakest. That is a sensible default for a private repo and the wrong one here, so `.deepsec/` is ignored wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Keep local environment credentials and deepsec security-analysis artifacts out of Docker builds and version control.

Bug Fixes:
- Prevent .env files from entering Docker build contexts and potentially being embedded in production images.
- Prevent the deepsec workspace and its threat-model data from being included in the public repository.

Build:
- Harden Docker build-context exclusions for sensitive environment files.

Chores:
- Update repository ignore rules to keep sensitive local security-analysis artifacts private.