### PR TITLE
security: stop social server actions trusting caller-supplied identity

### DIFF
--- a/app/actions/mcp-servers.ts
+++ b/app/actions/mcp-servers.ts
@@ -19,6 +19,7 @@ import { decryptServerData, encryptServerData } from '@/lib/encryption';
 import { mcpServerOperations } from '@/lib/mcp/metrics';
 import { validateCommand, validateCommandArgs, validateHeaders, validateMcpUrl } from '@/lib/security/validators';
 import { formatRateLimitError,rateLimitServerAction, ServerActionRateLimits } from '@/lib/server-action-rate-limiter';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 import { McpServerSlugService } from '@/lib/services/mcp-server-slug-service';
 import { 
   createMcpServerSchema, 
@@ -881,20 +882,23 @@ export async function importSharedServer(
  *
  * The connection fields - command, args, env, url, transport and
  * streamableHTTPOptions - are encrypted at rest because they carry the server's
- * credentials. They are left out entirely by default so that publishing a share
- * can never republish them. The share wizard asks for them explicitly via
- * `includeOwnerSecrets` so the owner can review and redact before publishing;
- * that path re-reads the server under an ownership check rather than decrypting
- * whatever ciphertext the caller passed in, since this is a public server action.
+ * credentials. They are left out entirely by default. The share wizard asks for
+ * them via `includeConnectionFields` so the owner can review the install recipe
+ * before publishing; that path re-reads the server under an ownership check
+ * rather than decrypting whatever ciphertext the caller passed in, since this is
+ * a public server action.
+ *
+ * Either way the result goes through `sanitizeServerTemplate`, so what comes
+ * back is structure - command, args, env keys - with the values redacted.
  *
  * @param server The original MCP server
- * @param options.includeOwnerSecrets Include the owner's decrypted connection
- *   fields. Requires an authenticated session that owns `server.uuid`.
+ * @param options.includeConnectionFields Include the connection structure.
+ *   Requires an authenticated session that owns `server.uuid`.
  * @returns A sanitized version for sharing
  */
 export async function createShareableTemplate(
   server: McpServer,
-  options: { includeOwnerSecrets?: boolean } = {}
+  options: { includeConnectionFields?: boolean } = {}
 ): Promise<any> {
   // Create template with basic server information (non-sensitive fields)
   const template: any = {
@@ -908,7 +912,7 @@ export async function createShareableTemplate(
     updated_at: (server as any).updated_at,
   };
 
-  if (options.includeOwnerSecrets) {
+  if (options.includeConnectionFields) {
     const storedServer = await withServerAuth(
       server.uuid,
       async (_session, ownedServer) => ownedServer
@@ -952,44 +956,6 @@ export async function createShareableTemplate(
     // If there's an error, continue without the sharedBy information
   }
   
-  // Sanitize the database URL if present in command or args
-  if (template.command) {
-    template.command = sanitizeDatabaseUrl(template.command);
-  }
-  
-  if (template.args && Array.isArray(template.args)) {
-    template.args = template.args.map((arg: string) => sanitizeDatabaseUrl(arg));
-  }
-
-  // Replace sensitive env variables with placeholders
-  const sanitizedEnv: Record<string, string> = {};
-  if (template.env && typeof template.env === 'object') {
-    Object.keys(template.env).forEach(key => {
-      // Assume environment variables are sensitive and replace with placeholders
-      if (key.toLowerCase().includes('key') || 
-          key.toLowerCase().includes('token') || 
-          key.toLowerCase().includes('secret') || 
-          key.toLowerCase().includes('password') || 
-          key.toLowerCase().includes('auth')) {
-        sanitizedEnv[key] = '<YOUR_SECRET_HERE>';
-      } else {
-        // For non-sensitive keys, check if the value looks like a URL with credentials
-        const value = template.env[key];
-        if (typeof value === 'string') {
-          sanitizedEnv[key] = sanitizeDatabaseUrl(value);
-        } else {
-          sanitizedEnv[key] = value;
-        }
-      }
-    });
-    template.env = sanitizedEnv;
-  }
-  
-  // Clear any API keys or tokens in the URL
-  if (template.url) {
-    template.url = sanitizeDatabaseUrl(template.url);
-  }
-  
   // Fetch and include custom instructions if they exist
   try {
     const customInstructions = await db.query.customInstructionsTable.findFirst({
@@ -1004,48 +970,7 @@ export async function createShareableTemplate(
     // Continue without custom instructions if there's an error
   }
   
-  return template;
+  // Structure survives; the values in it do not.
+  return sanitizeServerTemplate(template);
 }
 
-/**
- * Sanitize a database URL or any URL with credentials
- * Replaces usernames, passwords, API keys, etc. with placeholders
- * 
- * @param text The text that might contain sensitive URLs
- * @returns Sanitized text with credentials replaced by placeholders
- */
-function sanitizeDatabaseUrl(text: string): string {
-  if (!text) return text;
-  
-  // Replace postgres connections: postgresql://username:password@host:port/database
-  text = text.replace(
-    /(postgresql:\/\/[^:]+):([^@]+)@([^\/]+\/[^\s]+)/gi, 
-    '$1:<YOUR_PASSWORD>@$3'
-  );
-  
-  // Replace mongodb connections: mongodb://username:password@host:port/database
-  text = text.replace(
-    /(mongodb:\/\/[^:]+):([^@]+)@([^\/]+\/[^\s]+)/gi, 
-    '$1:<YOUR_PASSWORD>@$3'
-  );
-  
-  // Replace mysql connections: mysql://username:password@host:port/database
-  text = text.replace(
-    /(mysql:\/\/[^:]+):([^@]+)@([^\/]+\/[^\s]+)/gi, 
-    '$1:<YOUR_PASSWORD>@$3'
-  );
-  
-  // Replace URLs with API keys in them: https://api.example.com?api_key=abcd1234
-  text = text.replace(
-    /([\?&](?:api_key|access_token|token|key|auth|apikey)=)([^&\s]+)/gi,
-    '$1<YOUR_API_KEY>'
-  );
-  
-  // Replace any other URL with basic auth: https://username:password@example.com
-  text = text.replace(
-    /(https?:\/\/[^:]+):([^@]+)@/gi,
-    '$1:<YOUR_PASSWORD>@'
-  );
-  
-  return text;
-}

--- a/app/actions/mcp-servers.ts
+++ b/app/actions/mcp-servers.ts
@@ -14,7 +14,7 @@ import {
   serverInstallationsTable,
   users
 } from '@/db/schema';
-import { withProfileAuth } from '@/lib/auth-helpers';
+import { withProfileAuth, withServerAuth } from '@/lib/auth-helpers';
 import { decryptServerData, encryptServerData } from '@/lib/encryption';
 import { mcpServerOperations } from '@/lib/mcp/metrics';
 import { validateCommand, validateCommandArgs, validateHeaders, validateMcpUrl } from '@/lib/security/validators';
@@ -878,42 +878,51 @@ export async function importSharedServer(
 /**
  * Create a shareable template from an MCP server by removing sensitive information
  * but preserving structure with placeholders
- *  
+ *
+ * The connection fields - command, args, env, url, transport and
+ * streamableHTTPOptions - are encrypted at rest because they carry the server's
+ * credentials. They are left out entirely by default so that publishing a share
+ * can never republish them. The share wizard asks for them explicitly via
+ * `includeOwnerSecrets` so the owner can review and redact before publishing;
+ * that path re-reads the server under an ownership check rather than decrypting
+ * whatever ciphertext the caller passed in, since this is a public server action.
+ *
  * @param server The original MCP server
+ * @param options.includeOwnerSecrets Include the owner's decrypted connection
+ *   fields. Requires an authenticated session that owns `server.uuid`.
  * @returns A sanitized version for sharing
  */
-export async function createShareableTemplate(server: McpServer): Promise<any> {
-  // Cast server to any to access encrypted fields
-  const serverAny = server as any;
-  
-  // First, ensure we have decrypted data to work with
-  let decryptedServer = server;
-  
-  // Check if server has encrypted fields and decrypt them if necessary
-  if (serverAny.command_encrypted || serverAny.args_encrypted || serverAny.env_encrypted || serverAny.url_encrypted) {
-    const { decryptServerData } = await import('@/lib/encryption');
-    decryptedServer = decryptServerData(serverAny);
-  }
-  
+export async function createShareableTemplate(
+  server: McpServer,
+  options: { includeOwnerSecrets?: boolean } = {}
+): Promise<any> {
   // Create template with basic server information (non-sensitive fields)
   const template: any = {
-    uuid: decryptedServer.uuid,
-    name: decryptedServer.name,
-    description: decryptedServer.description,
-    type: decryptedServer.type,
-    source: decryptedServer.source,
-    transport: (decryptedServer as any).transport,
-    streamableHTTPOptions: (decryptedServer as any).streamableHTTPOptions,
-    status: decryptedServer.status,
-    created_at: decryptedServer.created_at,
-    updated_at: (decryptedServer as any).updated_at,
-    // Add the decrypted sensitive fields so they can be edited in the dialog
-    command: decryptedServer.command,
-    args: decryptedServer.args,
-    env: decryptedServer.env,
-    url: decryptedServer.url,
+    uuid: server.uuid,
+    name: server.name,
+    description: server.description,
+    type: server.type,
+    source: server.source,
+    status: server.status,
+    created_at: server.created_at,
+    updated_at: (server as any).updated_at,
   };
-  
+
+  if (options.includeOwnerSecrets) {
+    const storedServer = await withServerAuth(
+      server.uuid,
+      async (_session, ownedServer) => ownedServer
+    );
+    const decryptedServer = decryptServerData(storedServer as any);
+
+    template.transport = (decryptedServer as any).transport;
+    template.streamableHTTPOptions = (decryptedServer as any).streamableHTTPOptions;
+    template.command = decryptedServer.command;
+    template.args = decryptedServer.args;
+    template.env = decryptedServer.env;
+    template.url = decryptedServer.url;
+  }
+
   // Add metadata about the source server
   template.originalServerUuid = server.uuid;
   
@@ -973,8 +982,8 @@ export async function createShareableTemplate(server: McpServer): Promise<any> {
         }
       }
     });
+    template.env = sanitizedEnv;
   }
-  template.env = sanitizedEnv;
   
   // Clear any API keys or tokens in the URL
   if (template.url) {

--- a/app/actions/memory.ts
+++ b/app/actions/memory.ts
@@ -500,6 +500,12 @@ export async function queryGutIntuition(
   topK?: number
 ): Promise<MemoryResult> {
   try {
+    // Gut patterns are cross-profile collective data (no profile scoping
+    // needed), but querying them runs an embedding call on caller-supplied
+    // text, so we still require an authenticated session - same as
+    // queryCBPPatterns below.
+    await requireAuthUserId();
+
     const parsed = queryGutSchema.parse({ query, topK });
     return queryIntuition(parsed.query, parsed.topK);
   } catch (error) {

--- a/app/actions/shared-content.ts
+++ b/app/actions/shared-content.ts
@@ -11,6 +11,7 @@ import {
   sharedMcpServersTable,
   users,
 } from '@/db/schema';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 import { SearchIndex } from '@/types/search';
 
 const usernameSchema = z.string().min(1).max(30);
@@ -96,8 +97,9 @@ export async function getFormattedSharedServersForUser(
       const avgRating = 0;
       const ratingCount = 0;
 
-      // Parse the template JSON
-      const template = sharedServer.template as any;
+      // Parse the template JSON. Shares stored before templates were sanitised
+      // on write still hold the owner's connection details.
+      const template = sanitizeServerTemplate(sharedServer.template) as any;
 
       formattedResults[sharedServer.uuid] = {
         name: sharedServer.title,
@@ -158,7 +160,7 @@ export async function getTopCommunitySharedServers(limit: number = 6): Promise<S
 
     const formattedResults: SearchIndex = {};
     for (const { sharedServer, user } of sharedServers) {
-      const template = sharedServer.template as any;
+      const template = sanitizeServerTemplate(sharedServer.template) as any;
       formattedResults[sharedServer.uuid] = {
         name: sharedServer.title,
         description: sharedServer.description || '',

--- a/app/actions/social.ts
+++ b/app/actions/social.ts
@@ -17,10 +17,55 @@ type User = typeof users.$inferSelect;
 type LanguageCode = typeof languageEnum.enumValues[number]; 
 
 import { getAuthSession } from '@/lib/auth';
-import { withAuth } from '@/lib/auth-helpers';
+import { withAuth, withProfileAuth } from '@/lib/auth-helpers';
+import type { PublicUser } from '@/lib/public-user';
+import { PUBLIC_USER_COLUMNS, publicUserSelection, toPublicUser } from '@/lib/public-user';
 
 // Additional validation schemas
 const uuidSchema = z.string().uuid('Invalid UUID format');
+
+/** Upper bound on any caller-supplied list size, so a single call cannot pull the whole table. */
+const MAX_LIST_LIMIT = 100;
+
+function clampLimit(limit: number): number {
+  if (!Number.isFinite(limit)) {
+    return 10;
+  }
+  return Math.min(Math.max(1, Math.trunc(limit)), MAX_LIST_LIMIT);
+}
+
+/** The session user's id, or undefined for an anonymous caller. */
+async function getCurrentUserId(): Promise<string | undefined> {
+  const session = await getAuthSession();
+  return session?.user?.id;
+}
+
+/**
+ * Whether the caller may see a user's follower/following list. Public profiles
+ * are browsable anonymously; a private one is only visible to its owner.
+ */
+async function canViewUserSocialGraph(userId: string): Promise<boolean> {
+  const currentUserId = await getCurrentUserId();
+  if (currentUserId === userId) {
+    return true;
+  }
+
+  const target = await db.query.users.findFirst({
+    where: eq(users.id, userId),
+    columns: PUBLIC_USER_COLUMNS,
+  });
+
+  return target?.is_public === true;
+}
+
+/** Whether the caller owns `profileUuid`. False for anonymous callers. */
+async function viewerOwnsProfile(profileUuid: string): Promise<boolean> {
+  const currentUserId = await getCurrentUserId();
+  if (!currentUserId) {
+    return false;
+  }
+  return userOwnsProfile(currentUserId, profileUuid);
+}
 
 // Validation schema for username
 const usernameSchema = z.string()
@@ -47,6 +92,7 @@ export async function checkUsernameAvailability(username: string): Promise<Usern
     // Check if username exists in the users table
     const existingUser = await db.query.users.findFirst({
       where: eq(users.username, username),
+      columns: { id: true },
     });
     return {
       available: !existingUser,
@@ -67,8 +113,15 @@ export async function checkUsernameAvailability(username: string): Promise<Usern
  * @param username The username to reserve
  * @returns Success status or error information
  */
-export async function reserveUsername(userId: string, username: string): Promise<{ success: boolean; user?: typeof users.$inferSelect; error?: string }> {
+export async function reserveUsername(userId: string, username: string): Promise<{ success: boolean; user?: PublicUser; error?: string }> {
   try {
+    // `userId` arrives from the client: a caller may only claim a username for
+    // themselves, never for another account.
+    return await withAuth(async (session) => {
+    if (session.user.id !== userId) {
+      return { success: false, error: 'Unauthorized' };
+    }
+
     // First verify the user exists
     const existingUser = await db.query.users.findFirst({
       where: eq(users.id, userId),
@@ -131,7 +184,7 @@ export async function reserveUsername(userId: string, username: string): Promise
 
       return {
         success: true,
-        user: updatedUser
+        user: toPublicUser(updatedUser)
       };
     } catch (updateError) {
       console.error('Error updating username:', updateError);
@@ -140,6 +193,7 @@ export async function reserveUsername(userId: string, username: string): Promise
         error: 'Database error while updating username'
       };
     }
+    });
   } catch (error) {
     console.error('Error in reserveUsername:', error);
     return {
@@ -173,8 +227,15 @@ export async function updateUserSocial(
     avatar_url?: string;
     language?: string; // Added language
   }
-): Promise<{ success: boolean; user?: User; error?: string }> {
+): Promise<{ success: boolean; user?: PublicUser; error?: string }> {
   try {
+    // `userId` arrives from the client: without this check anyone could flip
+    // another account's `is_public` flag and rewrite its bio.
+    return await withAuth(async (session) => {
+    if (session.user.id !== userId) {
+      return { success: false, error: 'Unauthorized' };
+    }
+
     // Update the users table directly
     // Use Omit to exclude language initially, then add it back if valid
     const updateData: Partial<Omit<User, 'language'>> & { updated_at: Date } = { 
@@ -220,8 +281,9 @@ export async function updateUserSocial(
     
     return {
       success: true,
-      user: updatedUser
+      user: toPublicUser(updatedUser)
     };
+    });
   } catch (error) {
     console.error('Error updating user social data:', error);
     return {
@@ -236,15 +298,15 @@ export async function updateUserSocial(
  * @param username The username to look up
  * @returns The user data if the user exists and visibility rules allow access
  */
-export async function getUserByUsername(username: string): Promise<User | null> {
+export async function getUserByUsername(username: string): Promise<PublicUser | null> {
   try {
-    // Get the session to check if the requester is authorized
-    const session = await getAuthSession();
-    const currentUserId = session?.user?.id;
+    const currentUserId = await getCurrentUserId();
 
-    // First, get the user without any visibility filters
+    // Never the bare `users` row: it also holds password, two_fa_secret,
+    // two_fa_backup_codes, last_login_ip and email.
     const user = await db.query.users.findFirst({
       where: eq(users.username, username),
+      columns: PUBLIC_USER_COLUMNS,
     });
 
     // If no user exists with this username, return null
@@ -252,15 +314,12 @@ export async function getUserByUsername(username: string): Promise<User | null> 
       return null;
     }
 
-    // If the user exists, check visibility rules:
-    // 1. The profile is public, OR
-    // 2. The requester is the profile owner, OR
-    // 3. The requester is authenticated
-    if (user.is_public || currentUserId === user.id || currentUserId) {
-      return user;
+    // Visibility: public profiles are world-readable, a private one is only
+    // ever returned to its owner. Merely being logged in grants nothing.
+    if (user.is_public || currentUserId === user.id) {
+      return toPublicUser(user);
     }
 
-    // If none of the visibility rules pass, return null
     return null;
   } catch (error) {
     console.error('Error getting user by username:', error);
@@ -274,19 +333,19 @@ export async function getUserByUsername(username: string): Promise<User | null> 
  * @param limit The maximum number of results to return
  * @returns An array of matching public users
  */
-export async function searchUsers(query: string, limit: number = 10): Promise<User[]> {
+export async function searchUsers(query: string, limit: number = 10): Promise<PublicUser[]> {
   try {
     // Search users directly by username
     const results = await db
-      .select()
+      .select(publicUserSelection)
       .from(users)
       .where(and(
         ilike(users.username, `%${query}%`), // Search username
         eq(users.is_public, true) // Only return public users
       ))
-      .limit(limit);
+      .limit(clampLimit(limit));
 
-    return results;
+    return results.map(toPublicUser);
   } catch (error) {
     console.error('Error searching users:', error); // Corrected log message
     return [];
@@ -462,7 +521,10 @@ export async function getSharedMcpServers(
   includePrivate: boolean = false
 ): Promise<SharedMcpServer[]> {
   try {
-    const whereClause = includePrivate
+    // `includePrivate` is caller-supplied, so it only counts once we know the
+    // caller actually owns the profile whose shares they are asking for.
+    const canSeePrivate = includePrivate && (await viewerOwnsProfile(profileUuid));
+    const whereClause = canSeePrivate
       ? eq(sharedMcpServersTable.profile_uuid, profileUuid)
       : and(
           eq(sharedMcpServersTable.profile_uuid, profileUuid),
@@ -470,7 +532,7 @@ export async function getSharedMcpServers(
         );
     const sharedServers = await db.query.sharedMcpServersTable.findMany({
       where: whereClause,
-      limit,
+      limit: clampLimit(limit),
       with: {
         server: {
           columns: {
@@ -511,7 +573,9 @@ export async function getSharedCollections(
   includePrivate: boolean = false
 ): Promise<SharedCollection[]> {
   try {
-    const whereClause = includePrivate
+    // Same rule as getSharedMcpServers: only the profile owner sees private shares.
+    const canSeePrivate = includePrivate && (await viewerOwnsProfile(profileUuid));
+    const whereClause = canSeePrivate
       ? eq(sharedCollectionsTable.profile_uuid, profileUuid)
       : and(
           eq(sharedCollectionsTable.profile_uuid, profileUuid),
@@ -519,7 +583,7 @@ export async function getSharedCollections(
         );
     const sharedCollections = await db.query.sharedCollectionsTable.findMany({
       where: whereClause,
-      limit,
+      limit: clampLimit(limit),
       orderBy: (collections: any) => [desc(collections.created_at)], // Added explicit type
     });
     return sharedCollections as unknown as SharedCollection[];
@@ -546,17 +610,21 @@ export async function getSharedCollections(
 export async function getFollowers(
   userId: string,
   limit: number = 10
-): Promise<User[]> {
+): Promise<PublicUser[]> {
   try {
+    if (!(await canViewUserSocialGraph(userId))) {
+      return [];
+    }
+
     const followersData = await db
-      .select({ followerUser: users }) // Select the user data directly
+      .select(publicUserSelection) // Public columns only - never the bare users row
       .from(followersTable)
       .innerJoin(users, eq(followersTable.follower_user_id, users.id)) // Join users table
       .where(eq(followersTable.followed_user_id, userId)) // Filter by followed user
       .orderBy(desc(followersTable.created_at))
-      .limit(limit);
+      .limit(clampLimit(limit));
 
-    return followersData.map((f: { followerUser: User }) => f.followerUser); // Added explicit type
+    return followersData.map(toPublicUser);
   } catch (error) {
     console.error('Error getting followers:', error);
     return [];
@@ -572,18 +640,22 @@ export async function getFollowers(
 export async function getFollowing(
   userId: string,
   limit: number = 10
-): Promise<User[]> { // Return User array
+): Promise<PublicUser[]> {
   try {
+    if (!(await canViewUserSocialGraph(userId))) {
+      return [];
+    }
+
     // Explicitly join followersTable with users table
     const followingData = await db
-      .select({ followedUser: users }) // Select the user data directly
+      .select(publicUserSelection) // Public columns only - never the bare users row
       .from(followersTable)
       .innerJoin(users, eq(followersTable.followed_user_id, users.id)) // Join users table
       .where(eq(followersTable.follower_user_id, userId)) // Filter by the follower user
       .orderBy(desc(followersTable.created_at)) // Order by follow date
-      .limit(limit);
+      .limit(clampLimit(limit));
 
-    return followingData.map((f: { followedUser: User }) => f.followedUser); // Added explicit type
+    return followingData.map(toPublicUser);
   } catch (error) {
     console.error('Error getting following:', error);
     return [];
@@ -610,10 +682,17 @@ export async function shareMcpServer(
   customTemplate?: any
 ): Promise<{ success: boolean; sharedServer?: SharedMcpServer; error?: string }> {
   try {
+    const validatedProfileUuid = uuidSchema.parse(profileUuid);
+    const validatedServerUuid = uuidSchema.parse(serverUuid);
+
+    // The caller must own the profile they are sharing under, and the server
+    // must live under that same profile - otherwise any serverUuid in the
+    // system could be republished by anyone who learns it.
+    return await withProfileAuth(validatedProfileUuid, async () => {
     const server = await db.query.mcpServersTable.findFirst({
-      where: eq(mcpServersTable.uuid, serverUuid),
+      where: eq(mcpServersTable.uuid, validatedServerUuid),
     });
-    if (!server) {
+    if (!server || server.profile_uuid !== validatedProfileUuid) {
       return { success: false, error: 'Server not found' };
     }
     const serverTemplate = customTemplate || await createShareableTemplate({
@@ -652,6 +731,7 @@ export async function shareMcpServer(
       success: true,
       sharedServer: finalSharedServer as unknown as SharedMcpServer
     };
+    });
   } catch (error) {
     console.error('Error sharing MCP server:', error);
     return {
@@ -679,8 +759,8 @@ export async function getSharedMcpServer(sharedServerUuid: string): Promise<Shar
           with: {
             project: {
               with: {
-                user: { // Select necessary user fields
-                  columns: { username: true, email: true, name: true }
+                user: { // Public attribution fields only - never email
+                  columns: { username: true, name: true }
                 }
               }
             }
@@ -694,10 +774,18 @@ export async function getSharedMcpServer(sharedServerUuid: string): Promise<Shar
       return null;
     }
 
+    // A private share, and its template, belongs to the owner alone.
+    if (
+      !sharedServerData.is_public &&
+      !(await viewerOwnsProfile(sharedServerData.profile_uuid))
+    ) {
+      return null;
+    }
+
     // Determine the display name
     const user = sharedServerData.profile?.project?.user;
     const profile = sharedServerData.profile;
-    const sharedByName = user?.username || user?.email || profile?.name || 'Unknown User';
+    const sharedByName = user?.username || user?.name || profile?.name || 'Unknown User';
 
     // Construct the final object without nested profile/project/user
     const result = {
@@ -861,6 +949,9 @@ export async function shareCollection(
   isPublic: boolean = true
 ): Promise<{ success: boolean; sharedCollection?: SharedCollection; error?: string }> {
   try {
+    // profileUuid arrives from the client; verify the session owns it before
+    // writing anything under it (same pattern as unshareServer above).
+    return await withProfileAuth(uuidSchema.parse(profileUuid), async () => {
     const [sharedCollection] = await db.insert(sharedCollectionsTable)
       .values({ profile_uuid: profileUuid, title, description, content, is_public: isPublic })
       .returning();
@@ -876,6 +967,7 @@ export async function shareCollection(
       success: true,
       sharedCollection: sharedCollection as unknown as SharedCollection
     };
+    });
   } catch (error) {
     console.error('Error sharing collection:', error);
     return {
@@ -904,6 +996,9 @@ export async function updateSharedCollection(
   }
 ): Promise<{ success: boolean; sharedCollection?: SharedCollection; error?: string }> {
   try {
+    // profileUuid arrives from the client; verify the session owns it before
+    // writing anything under it (same pattern as unshareServer above).
+    return await withProfileAuth(uuidSchema.parse(profileUuid), async () => {
     const existingCollection = await db.query.sharedCollectionsTable.findFirst({
       where: and(
         eq(sharedCollectionsTable.uuid, sharedCollectionUuid),
@@ -935,6 +1030,7 @@ export async function updateSharedCollection(
       success: true,
       sharedCollection: updatedCollection as unknown as SharedCollection
     };
+    });
   } catch (error) {
     console.error('Error updating shared collection:', error);
     return {
@@ -1015,6 +1111,9 @@ export async function unshareCollection(
   sharedCollectionUuid: string
 ): Promise<{ success: boolean; error?: string }> {
   try {
+    // profileUuid arrives from the client; verify the session owns it before
+    // writing anything under it (same pattern as unshareServer above).
+    return await withProfileAuth(uuidSchema.parse(profileUuid), async () => {
     const sharedCollection = await db.query.sharedCollectionsTable.findFirst({
       where: and(
         eq(sharedCollectionsTable.uuid, sharedCollectionUuid),
@@ -1036,6 +1135,7 @@ export async function unshareCollection(
       revalidatePath(`/to/${associatedUsername}`);
     }
     return { success: true };
+    });
   } catch (error) {
     console.error('Error unsharing collection:', error);
     return {
@@ -1063,6 +1163,9 @@ export async function shareEmbeddedChat(
   isPublic: boolean = true
 ): Promise<{ success: boolean; embeddedChat?: EmbeddedChat; error?: string }> {
   try {
+    // profileUuid arrives from the client; verify the session owns it before
+    // writing anything under it (same pattern as unshareServer above).
+    return await withProfileAuth(uuidSchema.parse(profileUuid), async () => {
     const [embeddedChat] = await db.insert(embeddedChatsTable)
       .values({ profile_uuid: profileUuid, title, description, settings, is_public: isPublic, is_active: true })
       .returning();
@@ -1078,6 +1181,7 @@ export async function shareEmbeddedChat(
       success: true,
       embeddedChat: embeddedChat as unknown as EmbeddedChat
     };
+    });
   } catch (error) {
     console.error('Error sharing embedded chat:', error);
     return {
@@ -1107,6 +1211,9 @@ export async function updateEmbeddedChat(
   }
 ): Promise<{ success: boolean; embeddedChat?: EmbeddedChat; error?: string }> {
   try {
+    // profileUuid arrives from the client; verify the session owns it before
+    // writing anything under it (same pattern as unshareServer above).
+    return await withProfileAuth(uuidSchema.parse(profileUuid), async () => {
     const existingChat = await db.query.embeddedChatsTable.findFirst({
       where: and(
         eq(embeddedChatsTable.uuid, embeddedChatUuid),
@@ -1139,6 +1246,7 @@ export async function updateEmbeddedChat(
       success: true,
       embeddedChat: updatedChat as unknown as EmbeddedChat
     };
+    });
   } catch (error) {
     console.error('Error updating embedded chat:', error);
     return {
@@ -1188,6 +1296,13 @@ export async function isServerShared(
   serverUuid: string
 ): Promise<{ isShared: boolean; server?: SharedMcpServer }> {
   try {
+    // Only the profile owner asks this question - it drives their own share
+    // dialog - and the answer must never carry the stored template, which can
+    // hold the server's connection details.
+    if (!(await viewerOwnsProfile(profileUuid))) {
+      return { isShared: false };
+    }
+
     const sharedServer = await db.query.sharedMcpServersTable.findFirst({
       where: and(
         eq(sharedMcpServersTable.profile_uuid, profileUuid),
@@ -1197,7 +1312,16 @@ export async function isServerShared(
     if (sharedServer) {
       return {
         isShared: true,
-        server: sharedServer as unknown as SharedMcpServer
+        server: {
+          uuid: sharedServer.uuid,
+          profile_uuid: sharedServer.profile_uuid,
+          server_uuid: sharedServer.server_uuid,
+          title: sharedServer.title,
+          description: sharedServer.description,
+          is_public: sharedServer.is_public,
+          created_at: sharedServer.created_at,
+          updated_at: sharedServer.updated_at,
+        } as unknown as SharedMcpServer
       };
     }
     return { isShared: false };

--- a/app/actions/social.ts
+++ b/app/actions/social.ts
@@ -3,6 +3,7 @@
 // Consolidated imports
 import { and, desc, eq, ilike, sql } from 'drizzle-orm'; 
 import { revalidatePath } from 'next/cache';
+import { isRedirectError } from 'next/dist/client/components/redirect-error';
 import { z } from 'zod';
 
 import { logAuditEvent } from '@/app/actions/audit-logger';
@@ -20,9 +21,22 @@ import { getAuthSession } from '@/lib/auth';
 import { withAuth, withProfileAuth } from '@/lib/auth-helpers';
 import type { PublicUser } from '@/lib/public-user';
 import { PUBLIC_USER_COLUMNS, publicUserSelection, toPublicUser } from '@/lib/public-user';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 
 // Additional validation schemas
 const uuidSchema = z.string().uuid('Invalid UUID format');
+
+/**
+ * The auth helpers deny an anonymous caller by redirecting, which they signal
+ * by throwing. That has to reach Next so the browser actually lands on /login;
+ * the broad `catch` blocks in this file would otherwise turn it into a generic
+ * "an error occurred" result and strand the user where they were.
+ */
+function rethrowIfRedirect(error: unknown): void {
+  if (isRedirectError(error)) {
+    throw error;
+  }
+}
 
 /** Upper bound on any caller-supplied list size, so a single call cannot pull the whole table. */
 const MAX_LIST_LIMIT = 100;
@@ -195,6 +209,7 @@ export async function reserveUsername(userId: string, username: string): Promise
     }
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error in reserveUsername:', error);
     return {
       success: false,
@@ -285,6 +300,7 @@ export async function updateUserSocial(
     };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error updating user social data:', error);
     return {
       success: false,
@@ -695,10 +711,13 @@ export async function shareMcpServer(
     if (!server || server.profile_uuid !== validatedProfileUuid) {
       return { success: false, error: 'Server not found' };
     }
-    const serverTemplate = customTemplate || await createShareableTemplate({
+    // Sanitise whatever we are about to store. `customTemplate` comes straight
+    // from the client - the share wizard lets the owner edit it - so it cannot
+    // be trusted to have had its credentials removed.
+    const serverTemplate = sanitizeServerTemplate(customTemplate || await createShareableTemplate({
       ...server,
       config: server.config as Record<string, any> | null
-    });
+    }));
     const existingShare = await db.query.sharedMcpServersTable.findFirst({
       where: and(
         eq(sharedMcpServersTable.profile_uuid, profileUuid),
@@ -733,6 +752,7 @@ export async function shareMcpServer(
     };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error sharing MCP server:', error);
     return {
       success: false,
@@ -795,7 +815,9 @@ export async function getSharedMcpServer(sharedServerUuid: string): Promise<Shar
       title: sharedServerData.title,
       description: sharedServerData.description,
       is_public: sharedServerData.is_public,
-      template: sharedServerData.template,
+      // Shares created before templates were sanitised on write still hold the
+      // owner's connection details, so scrub on the way out too.
+      template: sanitizeServerTemplate(sharedServerData.template),
       created_at: sharedServerData.created_at,
       updated_at: sharedServerData.updated_at,
       profile_username: sharedByName, // Use determined name
@@ -923,6 +945,7 @@ export async function unshareServer(
     return { success: true };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error unsharing server:', error);
     return {
       success: false,
@@ -969,6 +992,7 @@ export async function shareCollection(
     };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error sharing collection:', error);
     return {
       success: false,
@@ -1032,6 +1056,7 @@ export async function updateSharedCollection(
     };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error updating shared collection:', error);
     return {
       success: false,
@@ -1137,6 +1162,7 @@ export async function unshareCollection(
     return { success: true };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error unsharing collection:', error);
     return {
       success: false,
@@ -1183,6 +1209,7 @@ export async function shareEmbeddedChat(
     };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error sharing embedded chat:', error);
     return {
       success: false,
@@ -1248,6 +1275,7 @@ export async function updateEmbeddedChat(
     };
     });
   } catch (error) {
+    rethrowIfRedirect(error);
     console.error('Error updating embedded chat:', error);
     return {
       success: false,

--- a/app/api/service/search/route.ts
+++ b/app/api/service/search/route.ts
@@ -9,6 +9,7 @@ import { createErrorResponse, getSafeErrorMessage } from '@/lib/api-errors';
 import { RateLimiters } from '@/lib/rate-limiter';
 import { registryVPClient } from '@/lib/registry/pluggedin-registry-vp-client';
 import { transformPluggedinRegistryToMcpIndex } from '@/lib/registry/registry-transformer';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 import type { PaginatedSearchResult, SearchIndex } from '@/types/search';
 
 // Cache TTL in minutes for each source
@@ -318,8 +319,10 @@ async function searchCommunity(query: string): Promise<SearchIndex> {
     });
 
     for (const { sharedServer, profile, user } of resultsWithJoins) {
-      // We'll use the template field which contains the sanitized MCP server data
-      const template = sharedServer.template as Record<string, any>;
+      // We'll use the template field which contains the sanitized MCP server
+      // data. Re-sanitise: shares stored before the write path was fixed still
+      // hold the owner's connection details.
+      const template = sanitizeServerTemplate(sharedServer.template) as Record<string, any>;
 
       if (!template) continue;
 

--- a/app/to/[username]/page.tsx
+++ b/app/to/[username]/page.tsx
@@ -3,10 +3,8 @@ import { Metadata } from 'next';
 import { getUserByUsername, getUserFollowerCount, getUserFollowingCount, isFollowingUser } from '@/app/actions/social';
 import { ProfileHeader } from '@/components/profile/profile-header';
 import { ProfileTabs } from '@/components/profile/profile-tabs';
-import { users } from '@/db/schema';
 import { getAuthSession } from '@/lib/auth';
-
-type User = typeof users.$inferSelect;
+import type { PublicUser } from '@/lib/public-user';
 
 // --- Non-async Presentation Component ---
 function UserProfileDisplay({
@@ -18,7 +16,7 @@ function UserProfileDisplay({
   followingCount,
   isOwner,
 }: {
-  user: User;
+  user: PublicUser;
   username: string;
   currentUserId: string | undefined;
   currentlyFollowing: boolean;

--- a/components/profile/profile-header.tsx
+++ b/components/profile/profile-header.tsx
@@ -1,15 +1,12 @@
 // Removed Profile import
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-// Import User type (assuming it's defined or imported from schema)
-import { users } from '@/db/schema'; 
+import type { PublicUser } from '@/lib/public-user';
 
 import { FollowButton } from './follow-button';
 import { ProfileStats } from './profile-stats';
 
-type User = typeof users.$inferSelect;
-
 export interface ProfileHeaderProps { // Export interface
-  user: User; // Use the full User type
+  user: PublicUser; // Public columns only - never the raw users row
   currentUserId?: string | null; // Changed from currentUserProfile
   isFollowing: boolean;
   followerCount: number;

--- a/components/server/share-server-dialog.tsx
+++ b/components/server/share-server-dialog.tsx
@@ -141,8 +141,12 @@ export function ShareServerDialog({
 
       setIsLoadingPreview(true);
       try {
-        // Always generate a fresh template when opening the dialog
-        const templateData = await createShareableTemplate(server);
+        // Always generate a fresh template when opening the dialog. The owner
+        // reviews and redacts the connection fields here before sharing, so
+        // ask for them explicitly - they are not in the default template.
+        const templateData = await createShareableTemplate(server, {
+          includeOwnerSecrets: true,
+        });
         setServerData(templateData);
       } catch (error) {
         console.error("Error loading template data:", error);

--- a/components/server/share-server-dialog.tsx
+++ b/components/server/share-server-dialog.tsx
@@ -142,10 +142,11 @@ export function ShareServerDialog({
       setIsLoadingPreview(true);
       try {
         // Always generate a fresh template when opening the dialog. The owner
-        // reviews and redacts the connection fields here before sharing, so
-        // ask for them explicitly - they are not in the default template.
+        // reviews the install recipe here before sharing, so ask for the
+        // connection structure explicitly - it is not in the default template.
+        // Values come back redacted; what is shared is whatever is set here.
         const templateData = await createShareableTemplate(server, {
-          includeOwnerSecrets: true,
+          includeConnectionFields: true,
         });
         setServerData(templateData);
       } catch (error) {

--- a/lib/public-user.ts
+++ b/lib/public-user.ts
@@ -1,0 +1,73 @@
+import { users } from '@/db/schema';
+
+/**
+ * The `users` table is also the auth table: alongside the profile fields it
+ * holds `password`, `two_fa_secret`, `two_fa_backup_codes`, `last_login_ip`
+ * and `email`. Selecting the bare table object anywhere that feeds a public
+ * surface — a profile, a follower list, a search result — ships those to the
+ * client, so every such read goes through the projection below instead.
+ *
+ * Adding a column here makes it world-readable. Only add profile fields.
+ */
+export const PUBLIC_USER_COLUMN_NAMES = [
+  'id',
+  'username',
+  'name',
+  'bio',
+  'avatar_url',
+  'image',
+  'is_public',
+  'created_at',
+] as const;
+
+export type PublicUserColumn = (typeof PUBLIC_USER_COLUMN_NAMES)[number];
+
+/** Shape returned by every public-facing user read. */
+export type PublicUser = Pick<typeof users.$inferSelect, PublicUserColumn>;
+
+/** For `db.query.users.findFirst({ columns: PUBLIC_USER_COLUMNS })`. */
+export const PUBLIC_USER_COLUMNS = {
+  id: true,
+  username: true,
+  name: true,
+  bio: true,
+  avatar_url: true,
+  image: true,
+  is_public: true,
+  created_at: true,
+} as const satisfies Record<PublicUserColumn, true>;
+
+/** For `db.select(publicUserSelection)` on joined queries. */
+export const publicUserSelection = {
+  id: users.id,
+  username: users.username,
+  name: users.name,
+  bio: users.bio,
+  avatar_url: users.avatar_url,
+  image: users.image,
+  is_public: users.is_public,
+  created_at: users.created_at,
+};
+
+/**
+ * Narrow an already-fetched row. Defence in depth for the paths that cannot
+ * push the projection into SQL — the column list above is the primary control.
+ */
+export function toPublicUser<T extends Partial<PublicUser> | null | undefined>(
+  row: T
+): T extends null | undefined ? null : PublicUser {
+  if (!row) {
+    return null as any;
+  }
+
+  return {
+    id: row.id,
+    username: row.username,
+    name: row.name,
+    bio: row.bio,
+    avatar_url: row.avatar_url,
+    image: row.image,
+    is_public: row.is_public,
+    created_at: row.created_at,
+  } as any;
+}

--- a/lib/server-template.ts
+++ b/lib/server-template.ts
@@ -15,6 +15,24 @@ const REDACTED_PASSWORD = '<YOUR_PASSWORD>';
 const REDACTED_API_KEY = '<YOUR_API_KEY>';
 
 /**
+ * What a parameter or flag has to be called for its value to count as a
+ * credential. One definition drives both the query-string rule and the
+ * command-line rule, so the two cannot drift apart.
+ *
+ * The strong terms match as substrings, which catches `client_secret`,
+ * `refresh_token` and `x-auth-token`. A bare `key` has to be the whole name -
+ * matching it as a substring would redact `monkey` and `keyspace`.
+ */
+const CREDENTIAL_NAME = String.raw`(?:key|[\w-]*(?:token|secret|password|passwd|auth|credential|api[-_]?key|access[-_]?key)[\w-]*)`;
+
+/** `?client_secret=live-value` */
+const CREDENTIAL_QUERY_PARAM = new RegExp(String.raw`([?&]${CREDENTIAL_NAME}=)([^&\s]+)`, 'gi');
+/** `--client-secret=live-value` or `--client-secret live-value` */
+const CREDENTIAL_FLAG_INLINE = new RegExp(String.raw`(--${CREDENTIAL_NAME}[=\s])(\S+)`, 'gi');
+/** `--client-secret`, with the value in the next argv entry */
+const CREDENTIAL_FLAG_EXACT = new RegExp(String.raw`^--${CREDENTIAL_NAME}$`, 'i');
+
+/**
  * Mask credentials embedded in a connection string: database URLs with inline
  * passwords, HTTP basic auth, and api keys carried as query parameters.
  */
@@ -27,21 +45,14 @@ export function sanitizeConnectionString(text: string): string {
     `$1:${REDACTED_PASSWORD}@$3`
   );
 
-  // https://api.example.com?api_key=abcd1234
-  text = text.replace(
-    /([?&](?:api_key|access_token|token|key|auth|apikey)=)([^&\s]+)/gi,
-    `$1${REDACTED_API_KEY}`
-  );
+  // A credential carried as a query parameter
+  text = text.replace(CREDENTIAL_QUERY_PARAM, `$1${REDACTED_API_KEY}`);
 
   // https://user:password@example.com
   text = text.replace(/(https?:\/\/[^:]+):([^@]+)@/gi, `$1:${REDACTED_PASSWORD}@`);
 
-  // A credential passed inline as a command-line flag: keep the flag itself,
-  // replace whatever value follows it.
-  text = text.replace(
-    /(--[\w-]*(?:token|key|secret|password|auth)[\w-]*[=\s])(\S+)/gi,
-    `$1${REDACTED_VALUE}`
-  );
+  // A credential passed as a command-line flag: keep the flag, replace the value
+  text = text.replace(CREDENTIAL_FLAG_INLINE, `$1${REDACTED_VALUE}`);
 
   return text;
 }
@@ -63,9 +74,19 @@ export function sanitizeServerTemplate<T>(template: T): T {
   }
 
   if (Array.isArray(sanitized.args)) {
-    sanitized.args = sanitized.args.map((arg: unknown) =>
+    const args = sanitized.args.map((arg: unknown) =>
       typeof arg === 'string' ? sanitizeConnectionString(arg) : arg
     );
+
+    // `--client-secret live-value` splits the flag and its value across two
+    // entries, so the per-string pass above cannot see the pairing.
+    for (let i = 0; i < args.length - 1; i++) {
+      if (typeof args[i] === 'string' && CREDENTIAL_FLAG_EXACT.test(args[i])) {
+        args[i + 1] = REDACTED_VALUE;
+      }
+    }
+
+    sanitized.args = args;
   }
 
   if (typeof sanitized.url === 'string') {

--- a/lib/server-template.ts
+++ b/lib/server-template.ts
@@ -1,0 +1,97 @@
+/**
+ * Sanitizers for the `template` blob persisted on a shared MCP server.
+ *
+ * A share's template is world-readable once `is_public` is set, and it is the
+ * install recipe an importer follows. It therefore has to keep the *structure*
+ * of the connection (command, args, env keys) while carrying none of the
+ * owner's credentials. These helpers are the single place that decides where
+ * that line sits, and they run on both the write path (so nothing unsanitized
+ * is stored, including a caller-supplied `customTemplate`) and the read paths
+ * (so shares stored before this existed are covered without a backfill).
+ */
+
+const REDACTED_VALUE = '<YOUR_SECRET_HERE>';
+const REDACTED_PASSWORD = '<YOUR_PASSWORD>';
+const REDACTED_API_KEY = '<YOUR_API_KEY>';
+
+/**
+ * Mask credentials embedded in a connection string: database URLs with inline
+ * passwords, HTTP basic auth, and api keys carried as query parameters.
+ */
+export function sanitizeConnectionString(text: string): string {
+  if (!text) return text;
+
+  // postgresql://user:password@host/db, and the mongodb/mysql equivalents
+  text = text.replace(
+    /((?:postgresql|mongodb|mysql):\/\/[^:]+):([^@]+)@([^/]+\/[^\s]+)/gi,
+    `$1:${REDACTED_PASSWORD}@$3`
+  );
+
+  // https://api.example.com?api_key=abcd1234
+  text = text.replace(
+    /([?&](?:api_key|access_token|token|key|auth|apikey)=)([^&\s]+)/gi,
+    `$1${REDACTED_API_KEY}`
+  );
+
+  // https://user:password@example.com
+  text = text.replace(/(https?:\/\/[^:]+):([^@]+)@/gi, `$1:${REDACTED_PASSWORD}@`);
+
+  // A credential passed inline as a command-line flag: keep the flag itself,
+  // replace whatever value follows it.
+  text = text.replace(
+    /(--[\w-]*(?:token|key|secret|password|auth)[\w-]*[=\s])(\S+)/gi,
+    `$1${REDACTED_VALUE}`
+  );
+
+  return text;
+}
+
+/**
+ * Strip credentials from a shared-server template, preserving everything an
+ * importer needs to recreate the server. Pure: the input is never mutated, and
+ * running it twice gives the same result as running it once.
+ */
+export function sanitizeServerTemplate<T>(template: T): T {
+  if (!template || typeof template !== 'object') {
+    return template;
+  }
+
+  const sanitized: any = { ...(template as any) };
+
+  if (typeof sanitized.command === 'string') {
+    sanitized.command = sanitizeConnectionString(sanitized.command);
+  }
+
+  if (Array.isArray(sanitized.args)) {
+    sanitized.args = sanitized.args.map((arg: unknown) =>
+      typeof arg === 'string' ? sanitizeConnectionString(arg) : arg
+    );
+  }
+
+  if (typeof sanitized.url === 'string') {
+    sanitized.url = sanitizeConnectionString(sanitized.url);
+  }
+
+  // Every env value is redacted, not just the ones whose key reads as secret:
+  // a name like GITHUB_PAT or NOTION_DB carries a credential just as often, and
+  // guessing from the key is how the previous heuristic let them through. The
+  // keys stay so the importer still knows what to supply.
+  if (sanitized.env && typeof sanitized.env === 'object' && !Array.isArray(sanitized.env)) {
+    sanitized.env = Object.fromEntries(
+      Object.keys(sanitized.env).map((key) => [key, REDACTED_VALUE])
+    );
+  }
+
+  // Transport headers are pure credentials, and a session id is a live handle.
+  if (sanitized.streamableHTTPOptions && typeof sanitized.streamableHTTPOptions === 'object') {
+    const { sessionId: _sessionId, headers, ...rest } = sanitized.streamableHTTPOptions;
+    sanitized.streamableHTTPOptions = { ...rest };
+    if (headers && typeof headers === 'object') {
+      sanitized.streamableHTTPOptions.headers = Object.fromEntries(
+        Object.keys(headers).map((key) => [key, REDACTED_VALUE])
+      );
+    }
+  }
+
+  return sanitized as T;
+}

--- a/tests/actions/social-real.test.ts
+++ b/tests/actions/social-real.test.ts
@@ -17,6 +17,33 @@ vi.mock('@/app/actions/audit-logger', () => ({
 vi.mock('next/cache', () => ({
   revalidatePath: vi.fn(),
 }));
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ delete: vi.fn() })),
+}));
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    const error: any = new Error('NEXT_REDIRECT');
+    error.digest = 'NEXT_REDIRECT;replace;/login;307;';
+    throw error;
+  }),
+}));
+
+const SESSION_USER_ID = 'test-user-id';
+
+/**
+ * withAuth re-checks that the session user exists; it is the only users
+ * lookup that passes a callback as `where`. Everything else passes a drizzle
+ * expression, so this lets a test script the real lookups without the session
+ * probe eating one of them.
+ */
+function usersFindFirst(handler: (args: any) => any) {
+  (mockedDb.query.users.findFirst as any).mockImplementation(async (args: any) => {
+    if (typeof args?.where === 'function') {
+      return { id: SESSION_USER_ID };
+    }
+    return handler(args);
+  });
+}
 
 const mockedDb = vi.mocked(db);
 
@@ -112,11 +139,13 @@ describe('Social Actions (Real Functions)', () => {
   });
 
   describe('getUserByUsername', () => {
-    it('should return user when found and public', async () => {
+    it('should return a public user without their auth columns', async () => {
       const mockUser = {
         id: 'user-123',
         username: 'testuser',
         email: 'test@example.com',
+        password: 'hashed-secret',
+        two_fa_secret: 'JBSWY3DPEHPK3PXP',
         name: 'Test User',
         is_public: true,
       };
@@ -125,7 +154,11 @@ describe('Social Actions (Real Functions)', () => {
 
       const result = await getUserByUsername('testuser');
 
-      expect(result).toEqual(mockUser);
+      expect(result?.id).toBe('user-123');
+      expect(result?.username).toBe('testuser');
+      expect(result).not.toHaveProperty('email');
+      expect(result).not.toHaveProperty('password');
+      expect(result).not.toHaveProperty('two_fa_secret');
     });
 
     it('should return null when user not found', async () => {
@@ -136,11 +169,11 @@ describe('Social Actions (Real Functions)', () => {
       expect(result).toBeNull();
     });
 
-    it('should return user for private user when authenticated', async () => {
+    it('should not return a private user to an authenticated non-owner', async () => {
       const mockUser = {
         id: 'different-user-id',
         username: 'privateuser',
-        email: 'private@example.com', 
+        email: 'private@example.com',
         name: 'Private User',
         is_public: false,
       };
@@ -149,47 +182,70 @@ describe('Social Actions (Real Functions)', () => {
 
       const result = await getUserByUsername('privateuser');
 
-      // Since getAuthSession returns a valid user, this private user should be accessible
-      expect(result).toEqual(mockUser);
+      // Being signed in is not a licence to read someone else's private profile.
+      expect(result).toBeNull();
+    });
+
+    it('should return a private user to its owner', async () => {
+      const mockUser = {
+        id: SESSION_USER_ID,
+        username: 'privateuser',
+        name: 'Private User',
+        is_public: false,
+      };
+
+      mockedDb.query.users.findFirst.mockResolvedValue(mockUser);
+
+      const result = await getUserByUsername('privateuser');
+
+      expect(result?.id).toBe(SESSION_USER_ID);
     });
   });
 
   describe('reserveUsername', () => {
     it('should successfully reserve available username', async () => {
-      const mockUser = { id: 'user-123', username: null };
-      const updatedUser = { id: 'user-123', username: 'newuser' };
-      
-      mockedDb.query.users.findFirst
-        .mockResolvedValueOnce(mockUser) // For user existence check
-        .mockResolvedValueOnce(null); // For username availability check
-      
-      const result = await reserveUsername('user-123', 'newuser');
+      // `columns` narrows the availability lookup; the existence check does not.
+      usersFindFirst((args) =>
+        args?.columns ? null : { id: SESSION_USER_ID, username: null }
+      );
+
+      const result = await reserveUsername(SESSION_USER_ID, 'newuser');
 
       expect(result.success).toBe(true);
       expect(result.user).toBeDefined();
     });
 
     it('should fail when user not found', async () => {
-      mockedDb.query.users.findFirst.mockResolvedValue(null);
+      usersFindFirst(() => null);
 
-      const result = await reserveUsername('nonexistent', 'newuser');
+      const result = await reserveUsername(SESSION_USER_ID, 'newuser');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('User not found');
     });
 
     it('should fail when username is taken', async () => {
-      const mockUser = { id: 'user-123', username: null };
-      const existingUser = { id: 'other-user', username: 'takenuser' };
-      
-      mockedDb.query.users.findFirst
-        .mockResolvedValueOnce(mockUser) // For user existence check
-        .mockResolvedValueOnce(existingUser); // For username availability check
+      usersFindFirst((args) =>
+        args?.columns
+          ? { id: 'other-user' }
+          : { id: SESSION_USER_ID, username: null }
+      );
 
-      const result = await reserveUsername('user-123', 'takenuser');
+      const result = await reserveUsername(SESSION_USER_ID, 'takenuser');
 
       expect(result.success).toBe(false);
       expect(result.error).toBe('Username is already taken');
+    });
+
+    it('should refuse to claim a username for another user', async () => {
+      usersFindFirst((args) =>
+        args?.columns ? null : { id: 'someone-else', username: null }
+      );
+
+      const result = await reserveUsername('someone-else', 'newuser');
+
+      expect(result.success).toBe(false);
+      expect(mockedDb.update).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/security/memory-action-auth.test.ts
+++ b/tests/security/memory-action-auth.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getServerSession } from 'next-auth';
+
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ authOptions: {}, getAuthSession: vi.fn() }));
+vi.mock('@/db', () => ({ db: { query: {} } }));
+vi.mock('@/lib/memory/gut-agent', () => ({ queryIntuition: vi.fn() }));
+vi.mock('@/lib/memory/cbp/injection-engine', () => ({
+  injectContextual: vi.fn(),
+  submitFeedback: vi.fn(),
+}));
+
+const { queryGutIntuition, queryCBPPatterns } = await import('@/app/actions/memory');
+const { queryIntuition } = vi.mocked(await import('@/lib/memory/gut-agent'));
+const { injectContextual } = vi.mocked(await import('@/lib/memory/cbp/injection-engine'));
+
+const mockedGetServerSession = vi.mocked(getServerSession);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryIntuition.mockResolvedValue({ success: true } as any);
+  injectContextual.mockResolvedValue({ success: true } as any);
+});
+
+describe('queryGutIntuition authentication', () => {
+  it('refuses an unauthenticated caller', async () => {
+    mockedGetServerSession.mockResolvedValue(null as any);
+
+    const result = await queryGutIntuition('what do you know about me');
+
+    expect(result.success).toBe(false);
+  });
+
+  it('does not run an embedding search for an unauthenticated caller', async () => {
+    mockedGetServerSession.mockResolvedValue(null as any);
+
+    await queryGutIntuition('attacker supplied string');
+
+    expect(queryIntuition).not.toHaveBeenCalled();
+  });
+
+  it('rejects before validating input, like its authenticated siblings', async () => {
+    mockedGetServerSession.mockResolvedValue(null as any);
+
+    const gut = await queryGutIntuition('');
+    const cbp = await queryCBPPatterns('');
+
+    expect(gut.success).toBe(false);
+    expect(cbp.success).toBe(false);
+    expect(queryIntuition).not.toHaveBeenCalled();
+    expect(injectContextual).not.toHaveBeenCalled();
+  });
+
+  it('serves an authenticated caller', async () => {
+    mockedGetServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any);
+
+    const result = await queryGutIntuition('what do you know about me');
+
+    expect(result.success).toBe(true);
+    expect(queryIntuition).toHaveBeenCalled();
+  });
+});

--- a/tests/security/public-user-projection.test.ts
+++ b/tests/security/public-user-projection.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PUBLIC_USER_COLUMNS,
+  PUBLIC_USER_COLUMN_NAMES,
+  publicUserSelection,
+  toPublicUser,
+} from '@/lib/public-user';
+
+/**
+ * The `users` table doubles as the auth table: it holds `password`,
+ * `two_fa_secret`, `two_fa_backup_codes`, `last_login_ip` and `email`.
+ * Anything that renders a profile, a follower list or a search result must go
+ * through this projection, never through the whole row.
+ */
+const FORBIDDEN_COLUMNS = [
+  'password',
+  'two_fa_secret',
+  'two_fa_backup_codes',
+  'last_login_ip',
+  'email',
+  'emailVerified',
+  'failed_login_attempts',
+  'account_locked_until',
+  'password_changed_at',
+  'last_login_at',
+  'is_admin',
+  'requires_2fa',
+];
+
+/** A full `users` row, as `db.select({ user: users })` would hand it back. */
+const fullUserRow = {
+  id: 'user-1',
+  name: 'Test User',
+  email: 'victim@example.com',
+  password: '$2b$10$hashedpasswordhashedpassword',
+  emailVerified: new Date('2026-01-01'),
+  image: 'https://example.com/i.png',
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-02'),
+  username: 'victim',
+  bio: 'hello',
+  is_public: true,
+  language: 'en',
+  avatar_url: 'https://example.com/a.png',
+  failed_login_attempts: 3,
+  account_locked_until: null,
+  last_login_at: new Date('2026-02-01'),
+  last_login_ip: '203.0.113.9',
+  password_changed_at: new Date('2026-01-15'),
+  is_admin: true,
+  requires_2fa: true,
+  two_fa_secret: 'JBSWY3DPEHPK3PXP',
+  two_fa_backup_codes: '["11111111","22222222"]',
+};
+
+describe('public user projection', () => {
+  it('never lists an auth column as publicly selectable', () => {
+    for (const column of FORBIDDEN_COLUMNS) {
+      expect(PUBLIC_USER_COLUMN_NAMES).not.toContain(column);
+    }
+  });
+
+  it('exposes the fields the public profile and follower pages render', () => {
+    for (const column of ['id', 'username', 'name', 'bio', 'avatar_url', 'image', 'is_public']) {
+      expect(PUBLIC_USER_COLUMN_NAMES).toContain(column);
+    }
+  });
+
+  it('keeps the drizzle column map and the select projection in step with the name list', () => {
+    expect(Object.keys(PUBLIC_USER_COLUMNS).sort()).toEqual([...PUBLIC_USER_COLUMN_NAMES].sort());
+    expect(Object.keys(publicUserSelection).sort()).toEqual([...PUBLIC_USER_COLUMN_NAMES].sort());
+    expect(Object.values(PUBLIC_USER_COLUMNS).every((v) => v === true)).toBe(true);
+  });
+
+  it('drops every auth field when narrowing a full users row', () => {
+    const publicUser = toPublicUser(fullUserRow);
+
+    for (const column of FORBIDDEN_COLUMNS) {
+      expect(publicUser).not.toHaveProperty(column);
+    }
+    expect(Object.keys(publicUser).sort()).toEqual([...PUBLIC_USER_COLUMN_NAMES].sort());
+  });
+
+  it('leaks no secret value through serialization', () => {
+    const serialized = JSON.stringify(toPublicUser(fullUserRow));
+
+    expect(serialized).not.toContain('hashedpassword');
+    expect(serialized).not.toContain('JBSWY3DPEHPK3PXP');
+    expect(serialized).not.toContain('11111111');
+    expect(serialized).not.toContain('victim@example.com');
+    expect(serialized).not.toContain('203.0.113.9');
+  });
+
+  it('preserves the public values it does carry', () => {
+    const publicUser = toPublicUser(fullUserRow);
+
+    expect(publicUser.id).toBe('user-1');
+    expect(publicUser.username).toBe('victim');
+    expect(publicUser.bio).toBe('hello');
+    expect(publicUser.is_public).toBe(true);
+  });
+
+  it('returns null for a null row so callers can pass through misses', () => {
+    expect(toPublicUser(null)).toBeNull();
+  });
+});

--- a/tests/security/server-template-sanitizer.test.ts
+++ b/tests/security/server-template-sanitizer.test.ts
@@ -18,8 +18,44 @@ describe('sanitizeConnectionString', () => {
     expect(sanitized).toContain('db.example.com');
   });
 
-  it('masks api keys carried in query strings', () => {
-    expect(sanitizeConnectionString('https://api.example.com/mcp?api_key=live-abc123')).not.toContain('live-abc123');
+  it.each([
+    'api_key',
+    'apiKey',
+    'apikey',
+    'access_key',
+    'key',
+    'token',
+    'access_token',
+    'refresh_token',
+    'secret',
+    'client_secret',
+    'password',
+    'auth',
+    'x-auth-token',
+    'credential',
+  ])('masks a credential carried as the %s query parameter', (param) => {
+    const sanitized = sanitizeConnectionString(`https://api.example.com/mcp?${param}=live-abc123`);
+
+    expect(sanitized).not.toContain('live-abc123');
+    expect(sanitized).toContain(param);
+  });
+
+  it.each(['version', 'monkey', 'keyspace', 'format'])(
+    'leaves the innocuous %s query parameter alone',
+    (param) => {
+      const url = `https://api.example.com/mcp?${param}=2`;
+
+      expect(sanitizeConnectionString(url)).toBe(url);
+    }
+  );
+
+  it('masks a credential in a later query parameter, not just the first', () => {
+    const sanitized = sanitizeConnectionString(
+      'https://api.example.com/mcp?version=2&client_secret=live-abc123'
+    );
+
+    expect(sanitized).not.toContain('live-abc123');
+    expect(sanitized).toContain('version=2');
   });
 
   it('leaves an innocuous string alone', () => {
@@ -92,6 +128,24 @@ describe('sanitizeServerTemplate', () => {
     const sanitized = sanitizeServerTemplate(legacyTemplate);
 
     expect(sanitized.args.join(' ')).not.toContain('tok-live-abcdef');
+  });
+
+  it.each(['--token', '--api-key', '--client-secret', '--password', '--auth-header'])(
+    'redacts a credential passed as the %s flag',
+    (flag) => {
+      const sanitized: any = sanitizeServerTemplate({
+        args: [flag, 'live-flag-value', `${flag}=live-inline-value`],
+      });
+
+      expect(sanitized.args.join(' ')).not.toContain('live-flag-value');
+      expect(sanitized.args.join(' ')).not.toContain('live-inline-value');
+    }
+  );
+
+  it('leaves an ordinary flag and its value alone', () => {
+    const sanitized: any = sanitizeServerTemplate({ args: ['--port', '8080', '--verbose'] });
+
+    expect(sanitized.args).toEqual(['--port', '8080', '--verbose']);
   });
 
   it('leaks nothing when serialized', () => {

--- a/tests/security/server-template-sanitizer.test.ts
+++ b/tests/security/server-template-sanitizer.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeConnectionString, sanitizeServerTemplate } from '@/lib/server-template';
+
+const REDACTED = '<YOUR_SECRET_HERE>';
+
+describe('sanitizeConnectionString', () => {
+  // Assembled from parts rather than written inline. The value under test is
+  // identical, but a literal `scheme://user:pass@host` in the source reads as a
+  // real leaked connection string to secret scanners - which is exactly the
+  // shape this function exists to redact.
+  const dbUrl = (scheme: string) => `${scheme}://user:` + 'hunter2' + '@db.example.com/app';
+
+  it.each(['postgresql', 'mongodb', 'mysql'])('masks the password in a %s URL', (scheme) => {
+    const sanitized = sanitizeConnectionString(dbUrl(scheme));
+
+    expect(sanitized).not.toContain('hunter2');
+    expect(sanitized).toContain('db.example.com');
+  });
+
+  it('masks api keys carried in query strings', () => {
+    expect(sanitizeConnectionString('https://api.example.com/mcp?api_key=live-abc123')).not.toContain('live-abc123');
+  });
+
+  it('leaves an innocuous string alone', () => {
+    expect(sanitizeConnectionString('npx')).toBe('npx');
+  });
+});
+
+describe('sanitizeServerTemplate', () => {
+  /** A template of the shape stored before templates were sanitized on write. */
+  const legacyTemplate = {
+    name: 'victim-server',
+    type: 'STDIO',
+    command: 'npx',
+    args: ['-y', '@victim/server', '--token=tok-live-abcdef'],
+    env: {
+      GITHUB_PAT: 'ghp_liveVictimToken',
+      API_KEY: 'sk-live-secret',
+      HOME_DIR: '/home/victim',
+    },
+    url: 'https://api.example.com/mcp?api_key=live-url-key',
+    streamableHTTPOptions: {
+      sessionId: 'sess-live-1234',
+      headers: { Authorization: 'Bearer live-header-token' },
+    },
+    category: 'dev',
+  };
+
+  const SECRETS = [
+    'ghp_liveVictimToken',
+    'sk-live-secret',
+    'live-url-key',
+    'live-header-token',
+    'sess-live-1234',
+  ];
+
+  it('redacts every env value, not only the ones whose key looks secret', () => {
+    const sanitized = sanitizeServerTemplate(legacyTemplate);
+
+    expect(sanitized.env).toEqual({
+      GITHUB_PAT: REDACTED,
+      API_KEY: REDACTED,
+      HOME_DIR: REDACTED,
+    });
+  });
+
+  it('keeps env keys so an importer knows what to fill in', () => {
+    const sanitized = sanitizeServerTemplate(legacyTemplate);
+
+    expect(Object.keys(sanitized.env).sort()).toEqual(['API_KEY', 'GITHUB_PAT', 'HOME_DIR']);
+  });
+
+  it('redacts transport headers and drops the session id', () => {
+    const sanitized = sanitizeServerTemplate(legacyTemplate);
+
+    expect(sanitized.streamableHTTPOptions.headers.Authorization).toBe(REDACTED);
+    expect(sanitized.streamableHTTPOptions.sessionId).toBeUndefined();
+  });
+
+  it('keeps the installable structure', () => {
+    const sanitized = sanitizeServerTemplate(legacyTemplate);
+
+    expect(sanitized.command).toBe('npx');
+    expect(sanitized.args[0]).toBe('-y');
+    expect(sanitized.args[1]).toBe('@victim/server');
+    expect(sanitized.name).toBe('victim-server');
+    expect(sanitized.category).toBe('dev');
+  });
+
+  it('redacts a secret passed as an inline argument value', () => {
+    const sanitized = sanitizeServerTemplate(legacyTemplate);
+
+    expect(sanitized.args.join(' ')).not.toContain('tok-live-abcdef');
+  });
+
+  it('leaks nothing when serialized', () => {
+    const serialized = JSON.stringify(sanitizeServerTemplate(legacyTemplate));
+
+    for (const secret of SECRETS) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('does not mutate its input', () => {
+    const input = JSON.parse(JSON.stringify(legacyTemplate));
+    sanitizeServerTemplate(input);
+
+    expect(input.env.GITHUB_PAT).toBe('ghp_liveVictimToken');
+  });
+
+  it('is idempotent', () => {
+    const once = sanitizeServerTemplate(legacyTemplate);
+    const twice = sanitizeServerTemplate(once);
+
+    expect(twice).toEqual(once);
+  });
+
+  it('passes null and undefined through', () => {
+    expect(sanitizeServerTemplate(null)).toBeNull();
+    expect(sanitizeServerTemplate(undefined)).toBeUndefined();
+  });
+});

--- a/tests/security/shareable-template.test.ts
+++ b/tests/security/shareable-template.test.ts
@@ -108,12 +108,12 @@ describe('createShareableTemplate default output', () => {
   });
 });
 
-describe('createShareableTemplate with owner secrets requested', () => {
+describe('createShareableTemplate with connection fields requested', () => {
   it('refuses an anonymous caller', async () => {
     getAuthSession.mockResolvedValue(null as any);
 
     await expect(
-      createShareableTemplate(encryptedServer, { includeOwnerSecrets: true })
+      createShareableTemplate(encryptedServer, { includeConnectionFields: true })
     ).rejects.toThrow();
   });
 
@@ -139,7 +139,7 @@ describe('createShareableTemplate with owner secrets requested', () => {
     });
 
     await expect(
-      createShareableTemplate(encryptedServer, { includeOwnerSecrets: true })
+      createShareableTemplate(encryptedServer, { includeConnectionFields: true })
     ).rejects.toThrow(/access/i);
   });
 
@@ -168,10 +168,45 @@ describe('createShareableTemplate with owner secrets requested', () => {
     const { decryptServerData } = vi.mocked(await import('@/lib/encryption'));
     const template = await createShareableTemplate(
       { ...encryptedServer, command_encrypted: 'someone-elses-ciphertext' } as any,
-      { includeOwnerSecrets: true }
+      { includeConnectionFields: true }
     );
 
     expect(decryptServerData).toHaveBeenCalledWith(expect.objectContaining({ name: 'stored-name' }));
     expect(template.command).toBeDefined();
+  });
+
+  it('gives the owner the structure with placeholders, not raw credentials', async () => {
+    getAuthSession.mockResolvedValue({ user: { id: 'owner' }, expires: '2099-01-01' } as any);
+    mockedDb.query.users.findFirst.mockResolvedValue({ id: 'owner' });
+    mockedDb.select = vi.fn(() => {
+      const chain: any = {
+        from: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        innerJoin: vi.fn(() => chain),
+        limit: vi.fn(() => chain),
+        then: (resolve: any, reject: any) =>
+          Promise.resolve([
+            {
+              server: encryptedServer,
+              profile: { uuid: PROFILE_UUID, project_uuid: 'project-1' },
+              project: { uuid: 'project-1', user_id: 'owner' },
+            },
+          ]).then(resolve, reject),
+      };
+      return chain;
+    });
+
+    const template = await createShareableTemplate(encryptedServer, {
+      includeConnectionFields: true,
+    });
+
+    // Structure the importer needs survives...
+    expect(template.command).toBe('npx');
+    expect(Object.keys(template.env)).toEqual(['GITHUB_PAT', 'HOME_DIR']);
+    // ...the credentials do not.
+    const serialized = JSON.stringify(template);
+    for (const secret of SECRETS) {
+      expect(serialized).not.toContain(secret);
+    }
   });
 });

--- a/tests/security/shareable-template.test.ts
+++ b/tests/security/shareable-template.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/db');
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn(), authOptions: {} }));
+vi.mock('@/lib/encryption', () => ({
+  decryptServerData: vi.fn((s: any) => ({
+    ...s,
+    command: 'npx',
+    args: ['-y', '@victim/server', '--token=tok-live-abcdef'],
+    env: { GITHUB_PAT: 'ghp_liveVictimToken', HOME_DIR: '/home/victim' },
+    url: 'https://api.example.com/mcp?apikey=live-url-key',
+    transport: 'streamable_http',
+    streamableHTTPOptions: {
+      sessionId: 'sess-live-1234',
+      headers: { Authorization: 'Bearer live-header-token' },
+    },
+  })),
+  encryptServerData: vi.fn((s: any) => s),
+}));
+vi.mock('next/headers', () => ({ cookies: vi.fn(async () => ({ delete: vi.fn() })) }));
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    const error: any = new Error('NEXT_REDIRECT');
+    error.digest = 'NEXT_REDIRECT;replace;/login;307;';
+    throw error;
+  }),
+}));
+
+const { createShareableTemplate } = await import('@/app/actions/mcp-servers');
+const { db } = await import('@/db');
+const { getAuthSession } = vi.mocked(await import('@/lib/auth'));
+
+const mockedDb = vi.mocked(db) as any;
+
+const SERVER_UUID = '22222222-2222-4222-8222-222222222222';
+const PROFILE_UUID = '11111111-1111-4111-8111-111111111111';
+
+const encryptedServer: any = {
+  uuid: SERVER_UUID,
+  profile_uuid: PROFILE_UUID,
+  name: 'victim-server',
+  description: 'desc',
+  type: 'STDIO',
+  source: 'COMMUNITY',
+  status: 'ACTIVE',
+  created_at: new Date('2026-01-01'),
+  command_encrypted: 'ciphertext-command',
+  args_encrypted: 'ciphertext-args',
+  env_encrypted: 'ciphertext-env',
+  url_encrypted: 'ciphertext-url',
+};
+
+const SECRETS = [
+  'ghp_liveVictimToken',
+  'tok-live-abcdef',
+  'live-url-key',
+  'live-header-token',
+  'sess-live-1234',
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAuthSession.mockResolvedValue(null as any);
+  mockedDb.query = {
+    profilesTable: { findFirst: vi.fn().mockResolvedValue(null) },
+    customInstructionsTable: { findFirst: vi.fn().mockResolvedValue(null) },
+    mcpServersTable: { findFirst: vi.fn().mockResolvedValue(null) },
+    users: { findFirst: vi.fn().mockResolvedValue(null) },
+  };
+  mockedDb.select = vi.fn(() => {
+    const chain: any = {
+      from: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      limit: vi.fn(() => chain),
+      then: (resolve: any, reject: any) => Promise.resolve([]).then(resolve, reject),
+    };
+    return chain;
+  });
+});
+
+describe('createShareableTemplate default output', () => {
+  it('carries no connection secrets', async () => {
+    const template = await createShareableTemplate(encryptedServer);
+
+    const serialized = JSON.stringify(template);
+    for (const secret of SECRETS) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('omits the fields that hold them', async () => {
+    const template = await createShareableTemplate(encryptedServer);
+
+    expect(template.command).toBeUndefined();
+    expect(template.args).toBeUndefined();
+    expect(template.env).toBeUndefined();
+    expect(template.url).toBeUndefined();
+    expect(template.streamableHTTPOptions).toBeUndefined();
+  });
+
+  it('still describes the server', async () => {
+    const template = await createShareableTemplate(encryptedServer);
+
+    expect(template.name).toBe('victim-server');
+    expect(template.type).toBe('STDIO');
+    expect(template.originalServerUuid).toBe(SERVER_UUID);
+  });
+});
+
+describe('createShareableTemplate with owner secrets requested', () => {
+  it('refuses an anonymous caller', async () => {
+    getAuthSession.mockResolvedValue(null as any);
+
+    await expect(
+      createShareableTemplate(encryptedServer, { includeOwnerSecrets: true })
+    ).rejects.toThrow();
+  });
+
+  it('refuses a caller who does not own the server', async () => {
+    getAuthSession.mockResolvedValue({ user: { id: 'attacker' }, expires: '2099-01-01' } as any);
+    mockedDb.query.users.findFirst.mockResolvedValue({ id: 'attacker' });
+    mockedDb.select = vi.fn(() => {
+      const chain: any = {
+        from: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        innerJoin: vi.fn(() => chain),
+        limit: vi.fn(() => chain),
+        then: (resolve: any, reject: any) =>
+          Promise.resolve([
+            {
+              server: encryptedServer,
+              profile: { uuid: PROFILE_UUID, project_uuid: 'project-1' },
+              project: { uuid: 'project-1', user_id: 'owner' },
+            },
+          ]).then(resolve, reject),
+      };
+      return chain;
+    });
+
+    await expect(
+      createShareableTemplate(encryptedServer, { includeOwnerSecrets: true })
+    ).rejects.toThrow(/access/i);
+  });
+
+  it('ignores caller-supplied ciphertext and decrypts the stored row instead', async () => {
+    getAuthSession.mockResolvedValue({ user: { id: 'owner' }, expires: '2099-01-01' } as any);
+    mockedDb.query.users.findFirst.mockResolvedValue({ id: 'owner' });
+    const storedServer = { ...encryptedServer, name: 'stored-name' };
+    mockedDb.select = vi.fn(() => {
+      const chain: any = {
+        from: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        innerJoin: vi.fn(() => chain),
+        limit: vi.fn(() => chain),
+        then: (resolve: any, reject: any) =>
+          Promise.resolve([
+            {
+              server: storedServer,
+              profile: { uuid: PROFILE_UUID, project_uuid: 'project-1' },
+              project: { uuid: 'project-1', user_id: 'owner' },
+            },
+          ]).then(resolve, reject),
+      };
+      return chain;
+    });
+
+    const { decryptServerData } = vi.mocked(await import('@/lib/encryption'));
+    const template = await createShareableTemplate(
+      { ...encryptedServer, command_encrypted: 'someone-elses-ciphertext' } as any,
+      { includeOwnerSecrets: true }
+    );
+
+    expect(decryptServerData).toHaveBeenCalledWith(expect.objectContaining({ name: 'stored-name' }));
+    expect(template.command).toBeDefined();
+  });
+});

--- a/tests/security/social-action-auth.test.ts
+++ b/tests/security/social-action-auth.test.ts
@@ -98,6 +98,8 @@ let selectResults: Map<unknown, any>;
 let selectProjections: any[];
 /** Arguments passed to the terminal `.limit()` of each select chain. */
 let selectLimits: number[];
+/** Values passed to every insert/update in a test. */
+let writtenValues: any[];
 
 function signedInAs(userId: string | null) {
   mockedGetAuthSession.mockResolvedValue(
@@ -125,6 +127,7 @@ beforeEach(() => {
   selectResults = new Map();
   selectProjections = [];
   selectLimits = [];
+  writtenValues = [];
 
   mockedDb.query = {
     users: {
@@ -171,8 +174,14 @@ beforeEach(() => {
 
   const writeChain = (result: any = []) => {
     const chain: any = {
-      values: vi.fn(() => chain),
-      set: vi.fn(() => chain),
+      values: vi.fn((v: any) => {
+        writtenValues.push(v);
+        return chain;
+      }),
+      set: vi.fn((v: any) => {
+        writtenValues.push(v);
+        return chain;
+      }),
       where: vi.fn(() => chain),
       returning: vi.fn(() => Promise.resolve(result)),
       then: (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject),
@@ -253,12 +262,12 @@ describe('updateUserSocial identity', () => {
     });
   });
 
-  it('refuses an anonymous caller', async () => {
+  it('redirects an anonymous caller to login', async () => {
     signedInAs(null);
 
-    const result = await updateUserSocial(OWNER_ID, { is_public: true });
-
-    expect(result.success).toBe(false);
+    await expect(updateUserSocial(OWNER_ID, { is_public: true })).rejects.toMatchObject({
+      digest: expect.stringContaining('NEXT_REDIRECT'),
+    });
     expect(mockedDb.update).not.toHaveBeenCalled();
   });
 
@@ -320,13 +329,13 @@ describe('reserveUsername identity', () => {
     });
   });
 
-  it('refuses an anonymous caller even when the username is free', async () => {
+  it('redirects an anonymous caller to login even when the username is free', async () => {
     signedInAs(null);
     usernameIsFree(OWNER_ID);
 
-    const result = await reserveUsername(OWNER_ID, 'newname');
-
-    expect(result.success).toBe(false);
+    await expect(reserveUsername(OWNER_ID, 'newname')).rejects.toMatchObject({
+      digest: expect.stringContaining('NEXT_REDIRECT'),
+    });
     expect(mockedDb.update).not.toHaveBeenCalled();
   });
 
@@ -479,13 +488,13 @@ describe('shareMcpServer ownership', () => {
     mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue(null);
   });
 
-  it('refuses an anonymous caller', async () => {
+  it('redirects an anonymous caller to login instead of swallowing it', async () => {
     signedInAs(null);
     profileOwnedBy(OWNER_ID);
 
-    const result = await shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title');
-
-    expect(result.success).toBe(false);
+    await expect(shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title')).rejects.toMatchObject({
+      digest: expect.stringContaining('NEXT_REDIRECT'),
+    });
     expect(mockedDb.insert).not.toHaveBeenCalled();
   });
 
@@ -523,6 +532,85 @@ describe('shareMcpServer ownership', () => {
 
     expect(result.success).toBe(true);
     expect(mockedDb.insert).toHaveBeenCalled();
+  });
+});
+
+describe('shared MCP server template handling', () => {
+  const SECRETS = ['ghp_liveVictimToken', 'sk-live-secret', 'live-header-token'];
+
+  const dirtyTemplate = {
+    name: 'srv',
+    type: 'STDIO',
+    command: 'npx',
+    args: ['-y', '@victim/server'],
+    env: { GITHUB_PAT: 'ghp_liveVictimToken', API_KEY: 'sk-live-secret' },
+    streamableHTTPOptions: { headers: { Authorization: 'Bearer live-header-token' } },
+  };
+
+  it('sanitises a caller-supplied customTemplate before persisting it', async () => {
+    signedInAs(OWNER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.mcpServersTable.findFirst.mockResolvedValue({
+      uuid: SERVER_UUID,
+      profile_uuid: PROFILE_UUID,
+      name: 'srv',
+      config: null,
+    });
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue(null);
+
+    await shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title', undefined, true, dirtyTemplate);
+
+    const serialized = JSON.stringify(writtenValues);
+    expect(serialized).not.toBe('[]');
+    for (const secret of SECRETS) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('sanitises a legacy template on the way out of a public share', async () => {
+    signedInAs(null);
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      server_uuid: SERVER_UUID,
+      title: 'public share',
+      description: null,
+      is_public: true,
+      // Stored before templates were sanitised on write.
+      template: dirtyTemplate,
+      created_at: new Date(),
+      updated_at: new Date(),
+      server: null,
+      profile: { name: 'p', uuid: PROFILE_UUID, project: { user: { username: 'victim', name: 'Victim' } } },
+    });
+
+    const serialized = JSON.stringify(await getSharedMcpServer(SHARED_UUID));
+
+    for (const secret of SECRETS) {
+      expect(serialized).not.toContain(secret);
+    }
+  });
+
+  it('keeps the install recipe intact on a public share', async () => {
+    signedInAs(null);
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      server_uuid: SERVER_UUID,
+      title: 'public share',
+      description: null,
+      is_public: true,
+      template: dirtyTemplate,
+      created_at: new Date(),
+      updated_at: new Date(),
+      server: null,
+      profile: { name: 'p', uuid: PROFILE_UUID, project: { user: { username: 'victim', name: 'Victim' } } },
+    });
+
+    const result: any = await getSharedMcpServer(SHARED_UUID);
+
+    expect(result.template.command).toBe('npx');
+    expect(Object.keys(result.template.env)).toEqual(['GITHUB_PAT', 'API_KEY']);
   });
 });
 
@@ -660,13 +748,13 @@ describe.each(MUTATIONS)('%s profile ownership', (_name, callAction) => {
     });
   });
 
-  it('refuses an anonymous caller and writes nothing', async () => {
+  it('redirects an anonymous caller to login and writes nothing', async () => {
     signedInAs(null);
     profileOwnedBy(OWNER_ID);
 
-    const result = await callAction();
-
-    expect(result.success).toBe(false);
+    await expect(callAction()).rejects.toMatchObject({
+      digest: expect.stringContaining('NEXT_REDIRECT'),
+    });
     expect(mockedDb.insert).not.toHaveBeenCalled();
     expect(mockedDb.update).not.toHaveBeenCalled();
     expect(mockedDb.delete).not.toHaveBeenCalled();

--- a/tests/security/social-action-auth.test.ts
+++ b/tests/security/social-action-auth.test.ts
@@ -1,0 +1,698 @@
+import { and, eq } from 'drizzle-orm';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  embeddedChatsTable,
+  followersTable,
+  profilesTable,
+  sharedCollectionsTable,
+  sharedMcpServersTable,
+  users,
+} from '@/db/schema';
+import { db } from '@/db';
+import { getAuthSession } from '@/lib/auth';
+import { PUBLIC_USER_COLUMN_NAMES } from '@/lib/public-user';
+
+vi.mock('@/db');
+vi.mock('@/lib/auth', () => ({
+  getAuthSession: vi.fn(),
+  authOptions: {},
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+vi.mock('@/app/actions/audit-logger', () => ({ logAuditEvent: vi.fn() }));
+vi.mock('@/app/actions/notifications', () => ({ createNotification: vi.fn() }));
+vi.mock('@/app/actions/mcp-servers', () => ({ createShareableTemplate: vi.fn() }));
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({ delete: vi.fn() })),
+}));
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    const error: any = new Error('NEXT_REDIRECT');
+    error.digest = 'NEXT_REDIRECT;replace;/login;307;';
+    throw error;
+  }),
+}));
+
+const {
+  updateUserSocial,
+  reserveUsername,
+  getUserByUsername,
+  searchUsers,
+  getFollowers,
+  getFollowing,
+  shareMcpServer,
+  getSharedMcpServer,
+  getSharedMcpServers,
+  isServerShared,
+  shareCollection,
+  updateSharedCollection,
+  unshareCollection,
+  shareEmbeddedChat,
+  updateEmbeddedChat,
+} = await import('@/app/actions/social');
+
+const { createShareableTemplate } = vi.mocked(await import('@/app/actions/mcp-servers'));
+
+const mockedDb = vi.mocked(db) as any;
+const mockedGetAuthSession = vi.mocked(getAuthSession);
+
+const OWNER_ID = 'owner-user-id';
+const ATTACKER_ID = 'attacker-user-id';
+const PROFILE_UUID = '11111111-1111-4111-8111-111111111111';
+const SERVER_UUID = '22222222-2222-4222-8222-222222222222';
+const SHARED_UUID = '33333333-3333-4333-8333-333333333333';
+const OTHER_UUID = '44444444-4444-4444-8444-444444444444';
+
+/** A full users row — what a bare `select({ user: users })` hands back. */
+function fullUserRow(overrides: Record<string, any> = {}) {
+  return {
+    id: OWNER_ID,
+    name: 'Victim',
+    email: 'victim@example.com',
+    password: '$2b$10$hashedpasswordhashedpassword',
+    emailVerified: null,
+    image: null,
+    created_at: new Date('2026-01-01'),
+    updated_at: new Date('2026-01-01'),
+    username: 'victim',
+    bio: null,
+    is_public: true,
+    language: 'en',
+    avatar_url: null,
+    failed_login_attempts: 0,
+    account_locked_until: null,
+    last_login_at: null,
+    last_login_ip: '203.0.113.9',
+    password_changed_at: null,
+    is_admin: false,
+    requires_2fa: false,
+    two_fa_secret: 'JBSWY3DPEHPK3PXP',
+    two_fa_backup_codes: '["11111111"]',
+    ...overrides,
+  };
+}
+
+/** Results handed to `db.select(...).from(<table>)`, keyed by table. */
+let selectResults: Map<unknown, any>;
+/** Projections passed to every `db.select()` call in a test. */
+let selectProjections: any[];
+/** Arguments passed to the terminal `.limit()` of each select chain. */
+let selectLimits: number[];
+
+function signedInAs(userId: string | null) {
+  mockedGetAuthSession.mockResolvedValue(
+    userId ? ({ user: { id: userId }, expires: '2099-01-01' } as any) : null
+  );
+}
+
+/** Makes `withProfileAuth(PROFILE_UUID, …)` succeed for `ownerId`. */
+function profileOwnedBy(ownerId: string) {
+  selectResults.set(profilesTable, [
+    {
+      profile: { uuid: PROFILE_UUID, project_uuid: 'project-1' },
+      project: { uuid: 'project-1', user_id: ownerId },
+    },
+  ]);
+  mockedDb.query.profilesTable.findFirst.mockResolvedValue({
+    uuid: PROFILE_UUID,
+    project_uuid: 'project-1',
+    project: { uuid: 'project-1', user_id: ownerId },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectResults = new Map();
+  selectProjections = [];
+  selectLimits = [];
+
+  mockedDb.query = {
+    users: {
+      // withAuth re-checks the session user exists; it asks for `id` only.
+      findFirst: vi.fn(async (args: any) => {
+        if (typeof args?.where === 'function') {
+          const session = await mockedGetAuthSession();
+          return session?.user?.id ? { id: session.user.id } : null;
+        }
+        return null;
+      }),
+      findMany: vi.fn(),
+    },
+    projectsTable: { findFirst: vi.fn(), findMany: vi.fn() },
+    profilesTable: { findFirst: vi.fn(), findMany: vi.fn() },
+    mcpServersTable: { findFirst: vi.fn(), findMany: vi.fn() },
+    sharedMcpServersTable: { findFirst: vi.fn(), findMany: vi.fn() },
+    sharedCollectionsTable: { findFirst: vi.fn(), findMany: vi.fn() },
+    embeddedChatsTable: { findFirst: vi.fn(), findMany: vi.fn() },
+    followersTable: { findFirst: vi.fn(), findMany: vi.fn() },
+  };
+
+  mockedDb.select = vi.fn((projection: any) => {
+    selectProjections.push(projection);
+    let table: unknown;
+    const chain: any = {
+      from: vi.fn((t: unknown) => {
+        table = t;
+        return chain;
+      }),
+      where: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn((n: number) => {
+        selectLimits.push(n);
+        return chain;
+      }),
+      then: (resolve: any, reject: any) =>
+        Promise.resolve(selectResults.get(table) ?? []).then(resolve, reject),
+    };
+    return chain;
+  });
+
+  const writeChain = (result: any = []) => {
+    const chain: any = {
+      values: vi.fn(() => chain),
+      set: vi.fn(() => chain),
+      where: vi.fn(() => chain),
+      returning: vi.fn(() => Promise.resolve(result)),
+      then: (resolve: any, reject: any) => Promise.resolve(result).then(resolve, reject),
+    };
+    return chain;
+  };
+
+  mockedDb.insert = vi.fn(() => writeChain([{ uuid: SHARED_UUID }]));
+  mockedDb.update = vi.fn(() => writeChain([{ uuid: SHARED_UUID }]));
+  mockedDb.delete = vi.fn(() => writeChain());
+});
+
+// ---------------------------------------------------------------------------
+// #2 — getUserByUsername
+// ---------------------------------------------------------------------------
+describe('getUserByUsername visibility', () => {
+  it('returns a public profile to an anonymous visitor', async () => {
+    signedInAs(null);
+    mockedDb.query.users.findFirst.mockResolvedValue(fullUserRow({ is_public: true }));
+
+    const result = await getUserByUsername('victim');
+
+    expect(result?.username).toBe('victim');
+  });
+
+  it('does not return a private profile to a logged-in non-owner', async () => {
+    signedInAs(ATTACKER_ID);
+    mockedDb.query.users.findFirst.mockResolvedValue(fullUserRow({ is_public: false }));
+
+    const result = await getUserByUsername('victim');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns a private profile to its owner', async () => {
+    signedInAs(OWNER_ID);
+    mockedDb.query.users.findFirst.mockResolvedValue(fullUserRow({ is_public: false }));
+
+    const result = await getUserByUsername('victim');
+
+    expect(result?.id).toBe(OWNER_ID);
+  });
+
+  it('asks the database only for public columns', async () => {
+    signedInAs(null);
+    mockedDb.query.users.findFirst.mockResolvedValue(fullUserRow());
+
+    await getUserByUsername('victim');
+
+    const call = mockedDb.query.users.findFirst.mock.calls.at(-1)?.[0];
+    expect(Object.keys(call.columns).sort()).toEqual([...PUBLIC_USER_COLUMN_NAMES].sort());
+  });
+
+  it('strips auth columns even if the row arrives wide', async () => {
+    signedInAs(null);
+    mockedDb.query.users.findFirst.mockResolvedValue(fullUserRow());
+
+    const serialized = JSON.stringify(await getUserByUsername('victim'));
+
+    expect(serialized).not.toContain('hashedpassword');
+    expect(serialized).not.toContain('JBSWY3DPEHPK3PXP');
+    expect(serialized).not.toContain('victim@example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Self-service writes that took a caller-supplied userId
+// ---------------------------------------------------------------------------
+describe('updateUserSocial identity', () => {
+  beforeEach(() => {
+    mockedDb.update = vi.fn(() => {
+      const chain: any = {
+        set: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        returning: vi.fn(() => Promise.resolve([fullUserRow()])),
+      };
+      return chain;
+    });
+  });
+
+  it('refuses an anonymous caller', async () => {
+    signedInAs(null);
+
+    const result = await updateUserSocial(OWNER_ID, { is_public: true });
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to write to another user', async () => {
+    signedInAs(ATTACKER_ID);
+
+    const result = await updateUserSocial(OWNER_ID, { is_public: true });
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.update).not.toHaveBeenCalled();
+  });
+
+  it('lets a user update themselves', async () => {
+    signedInAs(OWNER_ID);
+
+    const result = await updateUserSocial(OWNER_ID, { is_public: true });
+
+    expect(result.success).toBe(true);
+    expect(mockedDb.update).toHaveBeenCalled();
+  });
+
+  it('returns no auth columns to the user it updated', async () => {
+    signedInAs(OWNER_ID);
+
+    const serialized = JSON.stringify(await updateUserSocial(OWNER_ID, { is_public: true }));
+
+    expect(serialized).not.toContain('hashedpassword');
+    expect(serialized).not.toContain('JBSWY3DPEHPK3PXP');
+    expect(serialized).not.toContain('victim@example.com');
+  });
+});
+
+describe('reserveUsername identity', () => {
+  /** The user exists, and the username they are asking for is unclaimed. */
+  function usernameIsFree(userId: string) {
+    mockedDb.query.users.findFirst.mockImplementation(async (args: any) => {
+      // withAuth's session probe passes a callback as `where`.
+      if (typeof args?.where === 'function') {
+        const session = await mockedGetAuthSession();
+        return session?.user?.id ? { id: session.user.id } : null;
+      }
+      // The availability check narrows to `id`; nobody holds the name.
+      if (args?.columns) {
+        return null;
+      }
+      // The existence check: this user is real.
+      return fullUserRow({ id: userId });
+    });
+  }
+
+  beforeEach(() => {
+    mockedDb.update = vi.fn(() => {
+      const chain: any = {
+        set: vi.fn(() => chain),
+        where: vi.fn(() => chain),
+        returning: vi.fn(() => Promise.resolve([fullUserRow({ username: 'newname' })])),
+      };
+      return chain;
+    });
+  });
+
+  it('refuses an anonymous caller even when the username is free', async () => {
+    signedInAs(null);
+    usernameIsFree(OWNER_ID);
+
+    const result = await reserveUsername(OWNER_ID, 'newname');
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.update).not.toHaveBeenCalled();
+  });
+
+  it('refuses to claim a username for another user', async () => {
+    signedInAs(ATTACKER_ID);
+    usernameIsFree(OWNER_ID);
+
+    const result = await reserveUsername(OWNER_ID, 'newname');
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.update).not.toHaveBeenCalled();
+  });
+
+  it('lets a user claim their own username', async () => {
+    signedInAs(OWNER_ID);
+    usernameIsFree(OWNER_ID);
+
+    const result = await reserveUsername(OWNER_ID, 'newname');
+
+    expect(result.success).toBe(true);
+    expect(mockedDb.update).toHaveBeenCalled();
+  });
+
+  it('returns no auth columns on success', async () => {
+    signedInAs(OWNER_ID);
+    usernameIsFree(OWNER_ID);
+
+    const serialized = JSON.stringify(await reserveUsername(OWNER_ID, 'newname'));
+
+    expect(serialized).not.toContain('hashedpassword');
+    expect(serialized).not.toContain('JBSWY3DPEHPK3PXP');
+    expect(serialized).not.toContain('victim@example.com');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #1 — getFollowers / getFollowing
+// ---------------------------------------------------------------------------
+describe.each([
+  ['getFollowers', (...args: any[]) => (getFollowers as any)(...args)],
+  ['getFollowing', (...args: any[]) => (getFollowing as any)(...args)],
+])('%s column projection and visibility', (_name, callAction) => {
+  function targetUser(overrides: Record<string, any> = {}) {
+    mockedDb.query.users.findFirst.mockImplementation(async (args: any) => {
+      if (typeof args?.where === 'function') {
+        const session = await mockedGetAuthSession();
+        return session?.user?.id ? { id: session.user.id } : null;
+      }
+      return fullUserRow(overrides);
+    });
+  }
+
+  it('never selects the whole users table', async () => {
+    signedInAs(null);
+    targetUser({ is_public: true });
+    selectResults.set(followersTable, []);
+
+    await callAction(OWNER_ID);
+
+    const joinProjection = selectProjections.find((p) => p && !('profile' in p));
+    expect(Object.values(joinProjection ?? {})).not.toContain(users);
+    expect(Object.keys(joinProjection ?? {}).sort()).toEqual(
+      [...PUBLIC_USER_COLUMN_NAMES].sort()
+    );
+  });
+
+  it('serves a public user\'s list to an anonymous visitor', async () => {
+    signedInAs(null);
+    targetUser({ is_public: true });
+    selectResults.set(followersTable, [
+      { id: 'f1', username: 'follower', name: null, bio: null, avatar_url: null, image: null, is_public: true, created_at: new Date() },
+    ]);
+
+    const result = await callAction(OWNER_ID);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].username).toBe('follower');
+  });
+
+  it('withholds a private user\'s list from a non-owner', async () => {
+    signedInAs(ATTACKER_ID);
+    targetUser({ is_public: false });
+    selectResults.set(followersTable, [fullUserRow({ id: 'f1' })]);
+
+    const result = await callAction(OWNER_ID);
+
+    expect(result).toEqual([]);
+  });
+
+  it('serves a private user\'s list to the owner', async () => {
+    signedInAs(OWNER_ID);
+    targetUser({ is_public: false });
+    selectResults.set(followersTable, [
+      { id: 'f1', username: 'follower', name: null, bio: null, avatar_url: null, image: null, is_public: true, created_at: new Date() },
+    ]);
+
+    const result = await callAction(OWNER_ID);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('clamps a caller-supplied limit', async () => {
+    signedInAs(null);
+    targetUser({ is_public: true });
+    selectResults.set(followersTable, []);
+
+    await callAction(OWNER_ID, 100000);
+
+    expect(Math.max(...selectLimits)).toBeLessThanOrEqual(100);
+  });
+
+  it('leaks no secret even if the driver returns wide rows', async () => {
+    signedInAs(null);
+    targetUser({ is_public: true });
+    selectResults.set(followersTable, [fullUserRow({ id: 'f1' })]);
+
+    const serialized = JSON.stringify(await callAction(OWNER_ID));
+
+    expect(serialized).not.toContain('hashedpassword');
+    expect(serialized).not.toContain('JBSWY3DPEHPK3PXP');
+    expect(serialized).not.toContain('victim@example.com');
+  });
+});
+
+describe('searchUsers column projection', () => {
+  it('never selects the whole users table', async () => {
+    selectResults.set(users, []);
+
+    await searchUsers('vic');
+
+    expect(Object.values(selectProjections[0] ?? {})).not.toContain(users);
+    expect(Object.keys(selectProjections[0] ?? {}).sort()).toEqual(
+      [...PUBLIC_USER_COLUMN_NAMES].sort()
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3 — MCP server sharing
+// ---------------------------------------------------------------------------
+describe('shareMcpServer ownership', () => {
+  beforeEach(() => {
+    createShareableTemplate.mockResolvedValue({ name: 'srv', type: 'STDIO' });
+    mockedDb.query.mcpServersTable.findFirst.mockResolvedValue({
+      uuid: SERVER_UUID,
+      profile_uuid: PROFILE_UUID,
+      name: 'srv',
+      config: null,
+    });
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue(null);
+  });
+
+  it('refuses an anonymous caller', async () => {
+    signedInAs(null);
+    profileOwnedBy(OWNER_ID);
+
+    const result = await shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title');
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('refuses a caller who does not own the profile', async () => {
+    signedInAs(ATTACKER_ID);
+    profileOwnedBy(OWNER_ID);
+
+    const result = await shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title');
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('refuses a server that lives under another profile', async () => {
+    signedInAs(OWNER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.mcpServersTable.findFirst.mockResolvedValue({
+      uuid: SERVER_UUID,
+      profile_uuid: OTHER_UUID,
+      name: 'victim-server',
+      config: null,
+    });
+
+    const result = await shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title');
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.insert).not.toHaveBeenCalled();
+  });
+
+  it('lets the owner share their own server', async () => {
+    signedInAs(OWNER_ID);
+    profileOwnedBy(OWNER_ID);
+
+    const result = await shareMcpServer(PROFILE_UUID, SERVER_UUID, 'title');
+
+    expect(result.success).toBe(true);
+    expect(mockedDb.insert).toHaveBeenCalled();
+  });
+});
+
+describe('shared MCP server read paths', () => {
+  it('getSharedMcpServers ignores includePrivate for a non-owner', async () => {
+    signedInAs(ATTACKER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.sharedMcpServersTable.findMany.mockResolvedValue([]);
+
+    await getSharedMcpServers(PROFILE_UUID, 10, true);
+
+    const call = mockedDb.query.sharedMcpServersTable.findMany.mock.calls.at(-1)?.[0];
+    expect(call.where).toEqual(
+      and(
+        eq(sharedMcpServersTable.profile_uuid, PROFILE_UUID),
+        eq(sharedMcpServersTable.is_public, true)
+      )
+    );
+  });
+
+  it('getSharedMcpServers honours includePrivate for the owner', async () => {
+    signedInAs(OWNER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.sharedMcpServersTable.findMany.mockResolvedValue([]);
+
+    await getSharedMcpServers(PROFILE_UUID, 10, true);
+
+    const call = mockedDb.query.sharedMcpServersTable.findMany.mock.calls.at(-1)?.[0];
+    expect(call.where).toEqual(eq(sharedMcpServersTable.profile_uuid, PROFILE_UUID));
+  });
+
+  it('getSharedMcpServer withholds a private share from a non-owner', async () => {
+    signedInAs(ATTACKER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      server_uuid: SERVER_UUID,
+      title: 'secret',
+      description: null,
+      is_public: false,
+      template: { env: { API_KEY: 'sk-live-secret' } },
+      created_at: new Date(),
+      updated_at: new Date(),
+      server: null,
+      profile: { name: 'p', uuid: PROFILE_UUID, project: { user: { username: 'victim', email: 'victim@example.com', name: 'Victim' } } },
+    });
+
+    const result = await getSharedMcpServer(SHARED_UUID);
+
+    expect(result).toBeNull();
+  });
+
+  it('getSharedMcpServer never returns the owner email', async () => {
+    signedInAs(null);
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      server_uuid: SERVER_UUID,
+      title: 'public share',
+      description: null,
+      is_public: true,
+      template: {},
+      created_at: new Date(),
+      updated_at: new Date(),
+      server: null,
+      profile: { name: 'p', uuid: PROFILE_UUID, project: { user: { username: null, email: 'victim@example.com', name: 'Victim' } } },
+    });
+
+    const serialized = JSON.stringify(await getSharedMcpServer(SHARED_UUID));
+
+    expect(serialized).not.toContain('victim@example.com');
+  });
+
+  it('isServerShared returns nothing to a caller who does not own the profile', async () => {
+    signedInAs(ATTACKER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      server_uuid: SERVER_UUID,
+      title: 'secret',
+      is_public: false,
+      template: { env: { API_KEY: 'sk-live-secret' } },
+    });
+
+    const result = await isServerShared(PROFILE_UUID, SERVER_UUID);
+
+    expect(result.isShared).toBe(false);
+    expect(JSON.stringify(result)).not.toContain('sk-live-secret');
+  });
+
+  it('isServerShared never hands back the raw template to the owner either', async () => {
+    signedInAs(OWNER_ID);
+    profileOwnedBy(OWNER_ID);
+    mockedDb.query.sharedMcpServersTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      server_uuid: SERVER_UUID,
+      title: 'mine',
+      description: null,
+      is_public: true,
+      template: { env: { API_KEY: 'sk-live-secret' } },
+    });
+
+    const result = await isServerShared(PROFILE_UUID, SERVER_UUID);
+
+    expect(result.isShared).toBe(true);
+    expect(result.server).not.toHaveProperty('template');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #5 — collection and embedded-chat mutations
+// ---------------------------------------------------------------------------
+const MUTATIONS: Array<[string, () => Promise<{ success: boolean }>]> = [
+  ['shareCollection', () => shareCollection(PROFILE_UUID, 'title', undefined, {}, true)],
+  ['updateSharedCollection', () => updateSharedCollection(PROFILE_UUID, SHARED_UUID, { title: 'x' })],
+  ['unshareCollection', () => unshareCollection(PROFILE_UUID, SHARED_UUID)],
+  ['shareEmbeddedChat', () => shareEmbeddedChat(PROFILE_UUID, 'title', undefined, {}, true)],
+  ['updateEmbeddedChat', () => updateEmbeddedChat(PROFILE_UUID, SHARED_UUID, { title: 'x' })],
+];
+
+describe.each(MUTATIONS)('%s profile ownership', (_name, callAction) => {
+  beforeEach(() => {
+    mockedDb.query.sharedCollectionsTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      title: 'existing',
+    });
+    mockedDb.query.embeddedChatsTable.findFirst.mockResolvedValue({
+      uuid: SHARED_UUID,
+      profile_uuid: PROFILE_UUID,
+      title: 'existing',
+    });
+  });
+
+  it('refuses an anonymous caller and writes nothing', async () => {
+    signedInAs(null);
+    profileOwnedBy(OWNER_ID);
+
+    const result = await callAction();
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.insert).not.toHaveBeenCalled();
+    expect(mockedDb.update).not.toHaveBeenCalled();
+    expect(mockedDb.delete).not.toHaveBeenCalled();
+  });
+
+  it('refuses a caller who does not own the supplied profile', async () => {
+    signedInAs(ATTACKER_ID);
+    profileOwnedBy(OWNER_ID);
+
+    const result = await callAction();
+
+    expect(result.success).toBe(false);
+    expect(mockedDb.insert).not.toHaveBeenCalled();
+    expect(mockedDb.update).not.toHaveBeenCalled();
+    expect(mockedDb.delete).not.toHaveBeenCalled();
+  });
+
+  it('allows the profile owner', async () => {
+    signedInAs(OWNER_ID);
+    profileOwnedBy(OWNER_ID);
+
+    const result = await callAction();
+
+    expect(result.success).toBe(true);
+  });
+});
+
+// Keep the table imports meaningful to the reader / linter.
+void [sharedCollectionsTable, sharedMcpServersTable, embeddedChatsTable];


### PR DESCRIPTION
Every export in `app/actions/social.ts` and `app/actions/memory.ts` sits behind `'use server'`, so each one is a public HTTP endpoint. Several took an identifier from the caller and used it as the authorisation decision; several returned the whole `users` row, which is also the auth table (`password`, `two_fa_secret`, `two_fa_backup_codes`, `last_login_ip`, `email`).

## What changed

New `lib/public-user.ts` holds one public-safe column set (`id, username, name, bio, avatar_url, image, is_public, created_at`) as a drizzle column map, a select projection, and a `toPublicUser()` narrowing helper. Every public-facing user read goes through it.

**Column projection** — `getFollowers`, `getFollowing`, `searchUsers` and `getUserByUsername` no longer select the bare `users` table. (`searchUsers` had the same defect and is included.)

**Visibility** — `getUserByUsername`'s check was `user.is_public || currentUserId === user.id || currentUserId`; the third clause made `is_public` decorative for any signed-in caller. Dropped. Follower/following lists are gated on the *target* profile's visibility rather than on the caller being logged in, so anonymous visitors keep browsing public profiles and their `/followers` pages while private ones stay closed to non-owners.

**Server sharing** — `shareMcpServer` now runs under `withProfileAuth` and requires the server to live under that same profile. `createShareableTemplate` no longer folds decrypted `command`/`args`/`env`/`url`/`streamableHTTPOptions` into the persisted template. Read paths (`getSharedMcpServer`, `getSharedMcpServers`, `getSharedCollections`, `isServerShared`) filter on `is_public` unless the caller owns the profile; `isServerShared` no longer returns the stored template at all, and shared-server reads no longer leak the owner's email.

**Profile-scoped mutations** — `shareCollection`, `updateSharedCollection`, `unshareCollection`, `shareEmbeddedChat` and `updateEmbeddedChat` go through `withProfileAuth`, matching the existing `unshareServer` pattern.

**Memory** — `queryGutIntuition` requires an authenticated session, matching `queryCBPPatterns` and every other sibling action.

Caller-supplied list limits are clamped to 100.

## Three judgement calls worth reviewing

**Follower lists are not behind blanket auth.** Requiring a session would have broken anonymous viewing of public profiles. The gate is the target's `is_public` (or being its owner), which closes the leak without changing who can browse.

**`createShareableTemplate` uses an opt-in rather than a hard strip.** Removing the connection fields outright would break the share wizard's review-and-redact step and the community import path. The default output is clean; the wizard passes `includeOwnerSecrets: true`, and that path re-reads the server from the database under `withServerAuth` instead of decrypting whatever ciphertext the caller passed in. That second part closes a separate hole: the action was unauthenticated and decrypted caller-supplied ciphertext with a global key, i.e. a decryption oracle for any MCP server ciphertext. `streamableHTTPOptions` is treated as sensitive too, since it carries auth headers and a session id.

**A sixth issue, fixed here.** `updateUserSocial` and `reserveUsername` took a caller-supplied `userId` with no session check and returned the full `users` row — so anyone could flip another account's `is_public` flag and read back its password hash and TOTP seed in the same call. Same class as the rest and in the same file; both now derive identity from the session. Shout if you would rather split it out.

## Verification

`pnpm test` and `pnpm lint` **do not pass, and did not before this branch.** Baseline on `main` is 203 failing tests across ~30 files, plus pre-existing lint errors. So instead:

- **Tests**: 203 failures before, 203 after, **no file regressed**; +70 passing. Baselines captured with `vitest --reporter=json` and diffed per file.
- **Lint**: zero new findings in the changed files. The remaining warnings there (`unshareServer`, the share dialog) predate this branch.
- **`npx tsc --noEmit`**: clean across application code.
- `grep 'select({' app/actions/social.ts` leaves only two `count(*)` aggregates — no bare `users` object in any projection.

New coverage — 68 tests in four files, each written before its fix and watched fail first:

- `tests/security/public-user-projection.test.ts` — the column list and `toPublicUser()` never carry an auth field
- `tests/security/social-action-auth.test.ts` — projection shape, public/private visibility for anonymous / non-owner / owner, ownership on every share and mutation path, limit clamping, and that no payload serializes a password hash, TOTP seed or email
- `tests/security/shareable-template.test.ts` — default template carries no secrets; the opt-in path refuses anonymous and non-owner callers and ignores caller-supplied ciphertext
- `tests/security/memory-action-auth.test.ts` — `queryGutIntuition` rejects before running an embedding search

Five assertions in `tests/actions/social-real.test.ts` encoded the old behaviour (one asserted outright that a private profile *is* returned to any authenticated caller); they now assert the fixed behaviour.

## Not covered

- Anonymous `/to/<username>/followers` is verified by unit test, not by loading the running app.
- `tests/actions/social.test.ts` (12 pre-existing failures) calls these actions with signatures that no longer exist. Left alone — separate cleanup.
- Not deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/202"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790289052&installation_model_id=430597&pr_number=202&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F202&signature=837dd8b7147ac5ff12a1daa0e8797c7c886b3703dcbad5963005898663680543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Harden social, sharing, and memory server actions by deriving authorization from authenticated ownership and returning only sanitized public data.

Bug Fixes:
- Prevent unauthorized profile, social-sharing, and memory actions from using caller-supplied identities or exposing private data.
- Stop public user and shared-server responses from leaking authentication fields, owner email addresses, or server connection credentials.
- Enforce profile and server ownership checks for sharing and mutation operations, while applying visibility rules to private content.

Enhancements:
- Centralize safe public-user projections and shared-server template sanitization, including protection for legacy stored templates.
- Preserve anonymous access to public profiles and follower lists while restricting private profiles and shares to their owners.
- Clamp caller-supplied list limits to a maximum of 100 and preserve redirect behavior for unauthenticated server actions.

Tests:
- Add security coverage for public-user projections, action authorization, visibility rules, memory authentication, and server-template sanitization.
- Update social action tests to reflect private-profile visibility and safe response behavior.