### PR TITLE
fix(infra): let deploy.sh run more than once

### DIFF
--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -63,16 +63,20 @@ install_secret_file() {
   local src="$1" dest="$2"
   SECRET_FILES+=("$dest")
   chmod u+w "$dest" 2>/dev/null || true
-  cat "$src" > "$dest"
+  # `|| copy_status=$?` is load-bearing: under `set -e` a failing cat would
+  # otherwise exit here, before KEEP_TMP is set, and the trap would delete the
+  # very temp file this is meant to preserve.
+  local copy_status=0
+  cat "$src" > "$dest" || copy_status=$?
   # A file's *contents* cannot be replaced atomically - only its name can, via
   # rename - and rename is out here because the inode is bind-mounted into
   # running containers. The write window therefore cannot be removed, only made
-  # detectable: if the copy came up short (a full tmpfs being the realistic
-  # cause) fail loudly and keep the good copy for recovery, rather than leaving
-  # a silently truncated secret behind for the next container start to read.
-  if [ "$(wc -c < "$src")" != "$(wc -c < "$dest")" ]; then
+  # detectable: if the copy failed or came up short (a full tmpfs being the
+  # realistic cause) fail loudly and keep the good copy for recovery, rather
+  # than leaving a truncated secret for the next container start to read.
+  if [ "$copy_status" != "0" ] || [ "$(wc -c < "$src")" != "$(wc -c < "$dest")" ]; then
     KEEP_TMP=1
-    die "short write to ${dest} - intact copy kept at ${src}"
+    die "failed to write ${dest} (copy exit ${copy_status}) - intact copy kept at ${src}"
   fi
   chmod 0400 "$dest"
 }

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -62,7 +62,13 @@ chmod 0700 "$RUNTIME_DIR"
 #    --input-type/--output-type are mandatory here: sops infers format from
 #    the file extension, and `.sops` is not a format it knows, so it falls
 #    back to JSON and dies on the first `#` comment in the dotenv payload.
+#    The 0400 below means a *second* deploy cannot redirect into this path -
+#    not even as its owner - so make it writable first. `chmod`, not `rm`:
+#    these files are bind-mounted into pluggedin-app, postgres and traefik,
+#    and replacing the inode would leave those mounts pointing at a deleted
+#    file until every container is recreated.
 log "decrypting secrets"
+chmod u+w "$SECRETS_DECRYPTED" 2>/dev/null || true
 sops --decrypt --input-type dotenv --output-type dotenv \
   "$SECRETS_ENCRYPTED" > "$SECRETS_DECRYPTED"
 chmod 0400 "$SECRETS_DECRYPTED"
@@ -81,6 +87,9 @@ extract_secret() {
     log "WARN: ${key} missing from secrets.env (skipping ${dest})"
     return
   fi
+  # Same reason as the secrets file above: 0400 from the previous run would
+  # otherwise make this redirect fail.
+  chmod u+w "$dest" 2>/dev/null || true
   printf '%s' "$value" > "$dest"
   chmod 0400 "$dest"
 }

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -40,6 +40,30 @@ done
 log() { printf '[deploy %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 die() { printf '[deploy] FATAL: %s\n' "$*" >&2; exit 1; }
 
+# Secret files are written through a temp file and their mode is relaxed only
+# for the copy. This trap is the backstop: whatever happens - a failed decrypt,
+# a full tmpfs, a Ctrl-C between the chmod and the write - temps go away and
+# every file we touched ends up back at 0400.
+TMP_FILES=()
+SECRET_FILES=()
+cleanup() {
+  if [ ${#TMP_FILES[@]} -gt 0 ]; then rm -f "${TMP_FILES[@]}" 2>/dev/null || true; fi
+  if [ ${#SECRET_FILES[@]} -gt 0 ]; then chmod 0400 "${SECRET_FILES[@]}" 2>/dev/null || true; fi
+}
+trap cleanup EXIT
+
+# Copy $1's contents into $2 without replacing $2's inode: these files are
+# bind-mounted into pluggedin-app, postgres and traefik, and a new inode would
+# leave the running mounts pointing at a deleted file. The previous run left $2
+# at 0400 - not writable even by its owner - so the mode has to come off first.
+install_secret_file() {
+  local src="$1" dest="$2"
+  SECRET_FILES+=("$dest")
+  chmod u+w "$dest" 2>/dev/null || true
+  cat "$src" > "$dest"
+  chmod 0400 "$dest"
+}
+
 # 1. Preflight
 command -v sops >/dev/null || die "sops not installed"
 command -v age >/dev/null  || die "age not installed"
@@ -62,16 +86,16 @@ chmod 0700 "$RUNTIME_DIR"
 #    --input-type/--output-type are mandatory here: sops infers format from
 #    the file extension, and `.sops` is not a format it knows, so it falls
 #    back to JSON and dies on the first `#` comment in the dotenv payload.
-#    The 0400 below means a *second* deploy cannot redirect into this path -
-#    not even as its owner - so make it writable first. `chmod`, not `rm`:
-#    these files are bind-mounted into pluggedin-app, postgres and traefik,
-#    and replacing the inode would leave those mounts pointing at a deleted
-#    file until every container is recreated.
+#    Decrypt into a temp file rather than straight into the mounted path. `>`
+#    truncates before sops runs, so decrypting in place would empty the stack's
+#    live secrets file on any sops failure - a wrong age key would take the
+#    secrets with it. On success install_secret_file copies it into place.
 log "decrypting secrets"
-chmod u+w "$SECRETS_DECRYPTED" 2>/dev/null || true
+secrets_tmp="$(mktemp "${RUNTIME_DIR}/.secrets.env.XXXXXX")"
+TMP_FILES+=("$secrets_tmp")
 sops --decrypt --input-type dotenv --output-type dotenv \
-  "$SECRETS_ENCRYPTED" > "$SECRETS_DECRYPTED"
-chmod 0400 "$SECRETS_DECRYPTED"
+  "$SECRETS_ENCRYPTED" > "$secrets_tmp"
+install_secret_file "$secrets_tmp" "$SECRETS_DECRYPTED"
 
 # 3a. Project specific secrets out of the env file into single-line files
 #     under /run/sops/, because Traefik and a few other services consume
@@ -87,11 +111,12 @@ extract_secret() {
     log "WARN: ${key} missing from secrets.env (skipping ${dest})"
     return
   fi
-  # Same reason as the secrets file above: 0400 from the previous run would
-  # otherwise make this redirect fail.
-  chmod u+w "$dest" 2>/dev/null || true
-  printf '%s' "$value" > "$dest"
-  chmod 0400 "$dest"
+  # Same temp-then-install dance as the secrets file above.
+  local tmp
+  tmp="$(mktemp "${RUNTIME_DIR}/.$(basename "$dest").XXXXXX")"
+  TMP_FILES+=("$tmp")
+  printf '%s' "$value" > "$tmp"
+  install_secret_file "$tmp" "$dest"
 }
 
 extract_secret TRAEFIK_DASHBOARD_AUTH traefik-users

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -46,8 +46,11 @@ die() { printf '[deploy] FATAL: %s\n' "$*" >&2; exit 1; }
 # every file we touched ends up back at 0400.
 TMP_FILES=()
 SECRET_FILES=()
+KEEP_TMP=0
 cleanup() {
-  if [ ${#TMP_FILES[@]} -gt 0 ]; then rm -f "${TMP_FILES[@]}" 2>/dev/null || true; fi
+  if [ "$KEEP_TMP" = "0" ] && [ ${#TMP_FILES[@]} -gt 0 ]; then
+    rm -f "${TMP_FILES[@]}" 2>/dev/null || true
+  fi
   if [ ${#SECRET_FILES[@]} -gt 0 ]; then chmod 0400 "${SECRET_FILES[@]}" 2>/dev/null || true; fi
 }
 trap cleanup EXIT
@@ -61,6 +64,16 @@ install_secret_file() {
   SECRET_FILES+=("$dest")
   chmod u+w "$dest" 2>/dev/null || true
   cat "$src" > "$dest"
+  # A file's *contents* cannot be replaced atomically - only its name can, via
+  # rename - and rename is out here because the inode is bind-mounted into
+  # running containers. The write window therefore cannot be removed, only made
+  # detectable: if the copy came up short (a full tmpfs being the realistic
+  # cause) fail loudly and keep the good copy for recovery, rather than leaving
+  # a silently truncated secret behind for the next container start to read.
+  if [ "$(wc -c < "$src")" != "$(wc -c < "$dest")" ]; then
+    KEEP_TMP=1
+    die "short write to ${dest} - intact copy kept at ${src}"
+  fi
   chmod 0400 "$dest"
 }
 


### PR DESCRIPTION
`deploy.sh` writes `/run/sops/secrets.env` and then `chmod 0400`s it. The next run redirects into that same path and dies with `Permission denied` before pulling anything — the owner has no write bit either. `extract_secret()` has the identical shape for `pg-password` and `traefik-users`.

It only survives on a reboot-fresh `/run` (tmpfs), which is why it went unnoticed between the 2026-07-31 cutover and the first redeploy today. The failure reads like a credentials or age-key problem and sends you hunting through the sops config, which is where the time goes.

## The fix

`chmod u+w` before each write — **not** `rm`. Those files are bind-mounted into `pluggedin-app`, `postgres` and `traefik`, so replacing the inode would leave the running mounts pointing at a deleted file until every container is recreated.

## Verification

Run against the actual failing state — secret files sitting at `0400` from the previous deploy:

```
$ ls -l /run/sops/secrets.env
-r-------- 1 pluggedin pluggedin 5216 Aug 26 11:44 /run/sops/secrets.env

$ IMAGE_TAG=sha-316b1c8 ./infra/scripts/deploy.sh --no-pull
[deploy 13:51:19] decrypting secrets
 Container pluggedin-app Running
[verify] all green
```

No `Permission denied`, and `docker inspect pluggedin-app --format '{{.State.StartedAt}}'` is byte-identical before and after, so nothing was recreated. `https://plugged.in/` stayed 200 throughout. `bash -n` clean.

Found while deploying #202 — that deploy hit this and had to be unblocked by hand with `chmod u+w`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790333508&installation_model_id=430597&pr_number=203&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F203&signature=e9deee87b41e9d4cd05b478a861a973e42213167ad18c8522891745fba034fad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Make secret deployment safe and repeatable without disrupting running containers or risking loss of valid credentials.

Bug Fixes:
- Make repeated deployments reliably update existing secret files after previous runs have restricted them to read-only permissions.
- Preserve live bind-mounted secret file inodes while preventing failed or partial writes from leaving truncated secrets.

Enhancements:
- Add cleanup and failure handling that restores secret permissions, removes temporary files, and retains intact copies when writes fail.