### PR TITLE
security: stop /api/search/users returning password hashes to anonymous callers

### DIFF
--- a/app/api/search/users/route.ts
+++ b/app/api/search/users/route.ts
@@ -3,12 +3,15 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { db } from '@/db';
 import { users } from '@/db/schema';
-import { getAuthSession } from '@/lib/auth';
+import { PUBLIC_USER_COLUMNS, toPublicUser } from '@/lib/public-user';
 
 export async function GET(request: NextRequest) {
   try {
-    const session = await getAuthSession();
-    
+    // Deliberately public: this searches profiles that opted into being public,
+    // the same surface /to/<username> serves anonymously. There was a
+    // getAuthSession() call here whose result was never read, which made the
+    // route look guarded when it was not.
+    //
     // Get search query from URL params
     const searchParams = request.nextUrl.searchParams;
     const query = searchParams.get('q');
@@ -22,6 +25,8 @@ export async function GET(request: NextRequest) {
     
     // Search for profiles by name or username
     const searchTerm = `%${query}%`;
+    // Never the bare row: `users` is also the auth table, holding password,
+    // two_fa_secret, two_fa_backup_codes, last_login_ip and email.
     const results = await db.query.users.findMany({
       where: and(
         or(
@@ -30,10 +35,11 @@ export async function GET(request: NextRequest) {
         ),
         eq(users.is_public, true)
       ),
+      columns: PUBLIC_USER_COLUMNS,
       limit: 20
     });
     
-    return NextResponse.json(results);
+    return NextResponse.json(results.map(toPublicUser));
   } catch (error) {
     console.error('Error searching users:', error);
     return NextResponse.json(

--- a/tests/security/search-users-route.test.ts
+++ b/tests/security/search-users-route.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/db');
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn(async () => null), authOptions: {} }));
+
+const { db } = await import('@/db');
+const { PUBLIC_USER_COLUMN_NAMES } = await import('@/lib/public-user');
+const { GET } = await import('@/app/api/search/users/route');
+
+const mockedDb = vi.mocked(db) as any;
+
+/** A full users row, as findMany returns it without a `columns` restriction. */
+const fullRow = {
+  id: 'u1',
+  name: 'Victim',
+  email: 'victim@example.com',
+  password: '$2b$10$hashedpasswordhashedpassword',
+  emailVerified: null,
+  image: null,
+  created_at: new Date('2026-01-01'),
+  updated_at: new Date('2026-01-01'),
+  username: 'victim',
+  bio: null,
+  is_public: true,
+  language: 'en',
+  avatar_url: null,
+  failed_login_attempts: 0,
+  account_locked_until: null,
+  last_login_at: null,
+  last_login_ip: '203.0.113.9',
+  password_changed_at: null,
+  is_admin: true,
+  requires_2fa: false,
+  two_fa_secret: 'JBSWY3DPEHPK3PXP',
+  two_fa_backup_codes: '["11111111"]',
+};
+
+function request(q: string) {
+  return { nextUrl: new URL(`https://plugged.in/api/search/users?q=${q}`) } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedDb.query = { users: { findMany: vi.fn(async () => [fullRow]) } };
+});
+
+describe('GET /api/search/users', () => {
+  it('asks the database only for public columns', async () => {
+    await GET(request('vi'));
+
+    const call = mockedDb.query.users.findMany.mock.calls.at(-1)?.[0];
+    expect(call?.columns).toBeDefined();
+    expect(Object.keys(call.columns).sort()).toEqual([...PUBLIC_USER_COLUMN_NAMES].sort());
+  });
+
+  it('returns no auth columns even when the driver hands back a wide row', async () => {
+    const body = await (await GET(request('vi'))).json();
+
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain('hashedpassword');
+    expect(serialized).not.toContain('JBSWY3DPEHPK3PXP');
+    expect(serialized).not.toContain('victim@example.com');
+    expect(serialized).not.toContain('203.0.113.9');
+    for (const field of ['password', 'two_fa_secret', 'two_fa_backup_codes', 'email', 'is_admin', 'last_login_ip']) {
+      expect(body[0]).not.toHaveProperty(field);
+    }
+  });
+
+  it('still returns the public fields a search result needs', async () => {
+    const body = await (await GET(request('vi'))).json();
+
+    expect(body[0].id).toBe('u1');
+    expect(body[0].username).toBe('victim');
+    expect(body[0].name).toBe('Victim');
+  });
+
+  it('still rejects a too-short query', async () => {
+    expect((await GET(request('a'))).status).toBe(400);
+  });
+});


### PR DESCRIPTION
**Live in production until this ships.** Verified by requesting the endpoint anonymously and reading back the field names — `password`, `two_fa_secret`, `two_fa_backup_codes`, `email`, `is_admin` and `last_login_ip` were all present in the response. I read field names only, not values.

## What was wrong

```ts
const session = await getAuthSession();   // assigned, never read
…
const results = await db.query.users.findMany({
  where: and(or(like(users.name, searchTerm), like(users.username, searchTerm)),
             eq(users.is_public, true)),
  limit: 20                                // no `columns`
});
return NextResponse.json(results);          // the whole row
```

Two failures compounding: an auth call whose result is discarded, which makes the route *look* guarded, and a relational query with no column restriction on a table that doubles as the auth table. The only filter is `is_public = true` — and public profiles are this app's core feature, so that is a large share of real accounts.

## The fix

Project through `PUBLIC_USER_COLUMNS` from `lib/public-user.ts`, which #202 already introduced for exactly this, and map results through `toPublicUser`. The dead `getAuthSession()` call is removed, with a comment recording that the route is deliberately anonymous — it searches profiles that opted into being public, the same surface `/to/<username>` already serves. The fix is the projection, not new auth.

## Scope check

17 API routes query `users`. Only this one and `/api/users/[id]` return the row to the caller, and the latter is already restricted to `id`/`name`/`username`/`image` with `email` deliberately removed. The rest fetch a user for internal checks (`is_admin`, password comparison) and do not return it.

## Where it came from

The deepsec report generated **2026-08-25** already contained this, among **30 CRITICAL findings that had not been triaged**. The scanner named the route, the missing `columns`, the discarded session, and noted that every other `users` lookup in the codebase restricts columns correctly — so it read as an oversight rather than a design choice. It was found the moment someone opened the report.

#202 fixed this class in `app/actions/social.ts`. It did not reach here because this is an API route rather than a server action, and my scope then was the file the report named.

## Tests

Four, asserting the query is issued with `PUBLIC_USER_COLUMNS`, that a deliberately wide driver row still yields no auth field in the response body, that the public fields a search result needs survive, and that the short-query guard still returns 400.

Suite: 203 failing before, 203 after, no file regressed. `tsc` clean, no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790860525&installation_model_id=430597&pr_number=207&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F207&signature=812bdeaf1b130a0ff138a5df775d94782838faf7f19837c810e85f6715e8ccb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Restrict anonymous user search responses to approved public profile data and add regression coverage for sensitive-field exposure.

Bug Fixes:
- Prevent anonymous user searches from exposing password hashes, authentication secrets, email addresses, administrative flags, and other sensitive account fields.

Enhancements:
- Make the public search endpoint explicitly anonymous while projecting and sanitizing results to the approved public user shape.

Tests:
- Add coverage verifying public-column projection, removal of sensitive fields from responses, preservation of required public fields, and the short-query validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * User search results now expose only approved public profile information.
  * Sensitive account details are excluded, even when present in database records.
  * Searches below the minimum query length are rejected.
* **Bug Fixes**
  * User search is now reliably available as a public, unauthenticated endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->