### PR TITLE
security: stop handing the app's secrets to spawned MCP servers

### DIFF
--- a/lib/mcp/child-env.ts
+++ b/lib/mcp/child-env.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
 
 /**
@@ -95,13 +97,25 @@ export function inheritableChildEnv(): NodeJS.ProcessEnv & { NODE_ENV: string } 
  * process happens to carry.
  */
 export function approvedChildPath(extraDirs: string[] = []): string {
-  return [
+  const isWindows = process.platform === 'win32';
+
+  const dirs = [
     ...extraDirs,
     PackageManagerConfig.NODEJS_BIN_DIR,
     PackageManagerConfig.PYTHON_BIN_DIR,
     PackageManagerConfig.DOCKER_BIN_DIR,
-    '/usr/local/bin',
-    '/usr/bin',
-    '/bin',
-  ].filter(Boolean).join(':');
+    // POSIX system directories, meaningless on Windows.
+    ...(isWindows ? [] : ['/usr/local/bin', '/usr/bin', '/bin']),
+    // On Windows there is no equivalent fixed set to enumerate, and a child
+    // that cannot resolve its own binary is worse than a broad PATH. PATH is
+    // not itself a secret — the point of this module is withholding the
+    // credentials in process.env, and those stay withheld either way. The
+    // deployment target is a Linux container; Windows is a development host.
+    ...(isWindows && process.env.PATH ? [process.env.PATH] : []),
+  ];
+
+  // Explicit posix/win32 delimiters rather than the ambient `path.delimiter`:
+  // that one is fixed when the module loads, so it describes the host rather
+  // than the branch above, and the two can disagree under test.
+  return dirs.filter(Boolean).join(isWindows ? path.win32.delimiter : path.posix.delimiter);
 }

--- a/lib/mcp/child-env.ts
+++ b/lib/mcp/child-env.ts
@@ -1,3 +1,5 @@
+import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
+
 /**
  * The environment a spawned child may inherit from this process.
  *
@@ -81,4 +83,25 @@ export function inheritableChildEnv(): NodeJS.ProcessEnv & { NODE_ENV: string } 
   }
 
   return inherited;
+}
+
+/**
+ * PATH for a spawned child, built from approved directories only.
+ *
+ * The allowlist above deliberately omits PATH so that callers set it
+ * explicitly — but a child with no PATH cannot resolve its own binary, so
+ * every caller that drops the host environment needs this. Reusing the host
+ * PATH would let a child resolve commands from whatever directories this
+ * process happens to carry.
+ */
+export function approvedChildPath(extraDirs: string[] = []): string {
+  return [
+    ...extraDirs,
+    PackageManagerConfig.NODEJS_BIN_DIR,
+    PackageManagerConfig.PYTHON_BIN_DIR,
+    PackageManagerConfig.DOCKER_BIN_DIR,
+    '/usr/local/bin',
+    '/usr/bin',
+    '/bin',
+  ].filter(Boolean).join(':');
 }

--- a/lib/mcp/child-env.ts
+++ b/lib/mcp/child-env.ts
@@ -1,3 +1,4 @@
+import os from 'os';
 import path from 'path';
 
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
@@ -101,6 +102,10 @@ export function approvedChildPath(extraDirs: string[] = []): string {
 
   const dirs = [
     ...extraDirs,
+    // The per-user bin directory the sandbox builders bind and rely on. It was
+    // only in their inline PATH strings, so anything that replaced PATH
+    // downstream silently dropped it.
+    process.env.FIREJAIL_LOCAL_BIN ?? path.join(os.homedir(), '.local', 'bin'),
     PackageManagerConfig.NODEJS_BIN_DIR,
     PackageManagerConfig.PYTHON_BIN_DIR,
     PackageManagerConfig.DOCKER_BIN_DIR,

--- a/lib/mcp/child-env.ts
+++ b/lib/mcp/child-env.ts
@@ -1,0 +1,84 @@
+/**
+ * The environment a spawned child may inherit from this process.
+ *
+ * This process holds the application's whole secret set — NEXTAUTH_SECRET,
+ * DATABASE_URL, POSTGRES_PASSWORD, the Kubernetes service-account token, every
+ * model-provider key — because docker-compose preloads /run/secrets/app.env via
+ * `NODE_OPTIONS: -r dotenv/config`. They are in process.env for real.
+ *
+ * Anything spawned while adding or running an MCP server is a process the user
+ * chose: the server itself, and the pnpm/uv/docker subprocesses that install it
+ * first. All of them go through here.
+ *
+ * PATH, HOME and the interpreter settings are deliberately absent — callers
+ * construct those explicitly and those values must win.
+ */
+const INHERITABLE_CHILD_ENV_VARS = [
+  'TZ',
+  'LANG',
+  'LANGUAGE',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TERM',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+  'NODE_EXTRA_CA_CERTS',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+] as const;
+
+/** Proxy variables may carry `user:password@` — the child must not see those. */
+const PROXY_ENV_VARS = new Set([
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'http_proxy',
+  'https_proxy',
+]);
+
+/**
+ * Remove any userinfo from a proxy URL, keeping the endpoint usable.
+ * Returns undefined if the value cannot be parsed, so a malformed proxy setting
+ * is withheld rather than forwarded blind.
+ */
+export function stripProxyCredentials(value: string): string | undefined {
+  try {
+    const url = new URL(value);
+    url.username = '';
+    url.password = '';
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/** The allowlisted slice of this process's environment, for a spawned child. */
+export function inheritableChildEnv(): NodeJS.ProcessEnv & { NODE_ENV: string } {
+  // NODE_ENV is not a secret, and the project's ProcessEnv type requires it.
+  // Callers that set it explicitly still override this.
+  const inherited: NodeJS.ProcessEnv & { NODE_ENV: string } = {
+    NODE_ENV: process.env.NODE_ENV ?? 'production',
+  };
+
+  for (const key of INHERITABLE_CHILD_ENV_VARS) {
+    const value = process.env[key];
+    if (value === undefined) {
+      continue;
+    }
+
+    if (PROXY_ENV_VARS.has(key)) {
+      const stripped = stripProxyCredentials(value);
+      if (stripped !== undefined) {
+        inherited[key] = stripped;
+      }
+      continue;
+    }
+
+    inherited[key] = value;
+  }
+
+  return inherited;
+}

--- a/lib/mcp/client-wrapper.ts
+++ b/lib/mcp/client-wrapper.ts
@@ -24,8 +24,8 @@ import path from 'path';
 import { McpServerType } from '@/db/schema'; // Assuming McpServerType enum is here
 import { packageManager } from '@/lib/mcp/package-manager';
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
-import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
 import { StreamableHTTPWrapper } from '@/lib/mcp/transports/StreamableHTTPWrapper';
+import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
 import { validateCommand, validateCommandArgs, validateHeaders, validateMcpUrl } from '@/lib/security/validators';
 import type { McpServer } from '@/types/mcp-server'; // Assuming McpServer type is defined here
 
@@ -181,6 +181,51 @@ async function isCommandAvailable(command: string): Promise<boolean> {
 }
 
 // Add this function to handle bubblewrap configuration
+/**
+ * Host environment variables a spawned MCP server may inherit.
+ *
+ * Everything else is withheld. This process carries the whole secret set —
+ * NEXTAUTH_SECRET, DATABASE_URL, POSTGRES_PASSWORD, the Kubernetes service
+ * account token, every model-provider key — because docker-compose preloads
+ * /run/secrets/app.env via `NODE_OPTIONS: -r dotenv/config`, so they are in
+ * process.env for real, not placeholders. An MCP server is a process the user
+ * chose; spreading process.env into it hands those secrets to whoever
+ * configured the server, and bubblewrap shares the network by default, so
+ * getting them out is trivial.
+ *
+ * PATH, HOME and the interpreter settings are deliberately absent: the callers
+ * construct those explicitly and those values must win.
+ */
+const INHERITABLE_CHILD_ENV_VARS = [
+  'TZ',
+  'LANG',
+  'LANGUAGE',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TERM',
+  'HTTP_PROXY',
+  'HTTPS_PROXY',
+  'NO_PROXY',
+  'http_proxy',
+  'https_proxy',
+  'no_proxy',
+  'NODE_EXTRA_CA_CERTS',
+  'SSL_CERT_FILE',
+  'SSL_CERT_DIR',
+] as const;
+
+/** The allowlisted slice of this process's environment, for a spawned child. */
+function inheritableChildEnv(): Record<string, string> {
+  const inherited: Record<string, string> = {};
+  for (const key of INHERITABLE_CHILD_ENV_VARS) {
+    const value = process.env[key];
+    if (value !== undefined) {
+      inherited[key] = value;
+    }
+  }
+  return inherited;
+}
+
 export function createBubblewrapConfig(
   serverConfig: McpServer
 ): FirejailConfig | null {
@@ -318,6 +363,8 @@ export function createBubblewrapConfig(
 
   // Construct the final environment
   const finalEnv = {
+    // Allowlisted host vars first: everything below deliberately overrides them
+    ...inheritableChildEnv(),
     // Sensible defaults - include interpreter paths from config
     PATH: `${paths.localBin}:${pnpmPath}:${PackageManagerConfig.NODEJS_BIN_DIR}:${PackageManagerConfig.PYTHON_BIN_DIR}:${PackageManagerConfig.DOCKER_BIN_DIR}:/usr/local/bin:/usr/bin:/bin`,
     HOME: paths.userHome,
@@ -333,8 +380,6 @@ export function createBubblewrapConfig(
     // PNPM specific
     PNPM_STORE_DIR: PackageManagerConfig.PNPM_STORE_DIR,
     NODE_ENV: 'production',
-    // Inherit parent process env
-    ...(process.env as Record<string, string>),
     // Apply server-specific env vars
     ...(serverConfig.env || {}),
   };
@@ -468,6 +513,8 @@ export function createFirejailConfig(
 
   // Construct the final environment, prioritizing serverConfig.env
   const finalEnv = {
+    // Allowlisted host vars first: everything below deliberately overrides them
+    ...inheritableChildEnv(),
     // Sensible defaults, adjust user/home if needed - include interpreter paths from config
     PATH: `${paths.localBin}:${pnpmPathFirejail}:${PackageManagerConfig.NODEJS_BIN_DIR}:${PackageManagerConfig.PYTHON_BIN_DIR}:${PackageManagerConfig.DOCKER_BIN_DIR}:/usr/local/bin:/usr/bin:/bin`,
     HOME: paths.userHome,
@@ -483,8 +530,6 @@ export function createFirejailConfig(
     // PNPM specific
     PNPM_STORE_DIR: PackageManagerConfig.PNPM_STORE_DIR,
     NODE_ENV: 'production',
-    // Inherit parent process env (like PATH, etc.)
-    ...(process.env as Record<string, string>),
     // Apply server-specific env vars, overriding inherited ones
     ...(serverConfig.env || {}),
   };
@@ -721,8 +766,8 @@ async function createMcpClientAndTransport(serverConfig: McpServer, skipCommandT
         command: transformedCommand,
         args: transformedArgs,
         env: {
-          // Start with parent process env
-          ...(process.env as Record<string, string>),
+          // Allowlisted host vars only - this process holds the app's secrets
+          ...inheritableChildEnv(),
           // Only add Linux-specific paths on Linux systems
           ...(process.platform === 'linux' ? {
             // Add potentially missing vars needed by uvx/python on Linux

--- a/lib/mcp/client-wrapper.ts
+++ b/lib/mcp/client-wrapper.ts
@@ -22,7 +22,7 @@ import path from 'path';
 
 // Internal application imports
 import { McpServerType } from '@/db/schema'; // Assuming McpServerType enum is here
-import { inheritableChildEnv } from '@/lib/mcp/child-env';
+import { approvedChildPath, inheritableChildEnv } from '@/lib/mcp/child-env';
 import { packageManager } from '@/lib/mcp/package-manager';
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
 import { StreamableHTTPWrapper } from '@/lib/mcp/transports/StreamableHTTPWrapper';
@@ -322,7 +322,7 @@ export function createBubblewrapConfig(
     // Allowlisted host vars first: everything below deliberately overrides them
     ...inheritableChildEnv(),
     // Sensible defaults - include interpreter paths from config
-    PATH: `${paths.localBin}:${pnpmPath}:${PackageManagerConfig.NODEJS_BIN_DIR}:${PackageManagerConfig.PYTHON_BIN_DIR}:${PackageManagerConfig.DOCKER_BIN_DIR}:/usr/local/bin:/usr/bin:/bin`,
+    PATH: approvedChildPath([paths.localBin, pnpmPath]),
     HOME: paths.userHome,
     USER: process.env.FIREJAIL_USER ?? 'pluggedin',
     USERNAME: process.env.FIREJAIL_USERNAME ?? 'pluggedin',
@@ -472,7 +472,7 @@ export function createFirejailConfig(
     // Allowlisted host vars first: everything below deliberately overrides them
     ...inheritableChildEnv(),
     // Sensible defaults, adjust user/home if needed - include interpreter paths from config
-    PATH: `${paths.localBin}:${pnpmPathFirejail}:${PackageManagerConfig.NODEJS_BIN_DIR}:${PackageManagerConfig.PYTHON_BIN_DIR}:${PackageManagerConfig.DOCKER_BIN_DIR}:/usr/local/bin:/usr/bin:/bin`,
+    PATH: approvedChildPath([paths.localBin, pnpmPathFirejail]),
     HOME: paths.userHome,
     USER: process.env.FIREJAIL_USER ?? 'pluggedin',
     USERNAME: process.env.FIREJAIL_USERNAME ?? 'pluggedin',
@@ -728,15 +728,9 @@ async function createMcpClientAndTransport(serverConfig: McpServer, skipCommandT
           // appending the host PATH would let a child resolve commands from
           // whatever directories this process happens to have, and would leave
           // non-Linux hosts with no PATH at all once the spread was removed.
-          PATH: [
+          PATH: approvedChildPath([
             process.env.FIREJAIL_LOCAL_BIN ?? path.join(actualHome, '.local/bin'),
-            PackageManagerConfig.NODEJS_BIN_DIR,
-            PackageManagerConfig.PYTHON_BIN_DIR,
-            PackageManagerConfig.DOCKER_BIN_DIR,
-            '/usr/local/bin',
-            '/usr/bin',
-            '/bin',
-          ].join(':'),
+          ]),
           // Only add Linux-specific paths on Linux systems
           ...(process.platform === 'linux' ? {
             // Add potentially missing vars needed by uvx/python on Linux

--- a/lib/mcp/client-wrapper.ts
+++ b/lib/mcp/client-wrapper.ts
@@ -22,6 +22,7 @@ import path from 'path';
 
 // Internal application imports
 import { McpServerType } from '@/db/schema'; // Assuming McpServerType enum is here
+import { inheritableChildEnv } from '@/lib/mcp/child-env';
 import { packageManager } from '@/lib/mcp/package-manager';
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
 import { StreamableHTTPWrapper } from '@/lib/mcp/transports/StreamableHTTPWrapper';
@@ -181,51 +182,6 @@ async function isCommandAvailable(command: string): Promise<boolean> {
 }
 
 // Add this function to handle bubblewrap configuration
-/**
- * Host environment variables a spawned MCP server may inherit.
- *
- * Everything else is withheld. This process carries the whole secret set —
- * NEXTAUTH_SECRET, DATABASE_URL, POSTGRES_PASSWORD, the Kubernetes service
- * account token, every model-provider key — because docker-compose preloads
- * /run/secrets/app.env via `NODE_OPTIONS: -r dotenv/config`, so they are in
- * process.env for real, not placeholders. An MCP server is a process the user
- * chose; spreading process.env into it hands those secrets to whoever
- * configured the server, and bubblewrap shares the network by default, so
- * getting them out is trivial.
- *
- * PATH, HOME and the interpreter settings are deliberately absent: the callers
- * construct those explicitly and those values must win.
- */
-const INHERITABLE_CHILD_ENV_VARS = [
-  'TZ',
-  'LANG',
-  'LANGUAGE',
-  'LC_ALL',
-  'LC_CTYPE',
-  'TERM',
-  'HTTP_PROXY',
-  'HTTPS_PROXY',
-  'NO_PROXY',
-  'http_proxy',
-  'https_proxy',
-  'no_proxy',
-  'NODE_EXTRA_CA_CERTS',
-  'SSL_CERT_FILE',
-  'SSL_CERT_DIR',
-] as const;
-
-/** The allowlisted slice of this process's environment, for a spawned child. */
-function inheritableChildEnv(): Record<string, string> {
-  const inherited: Record<string, string> = {};
-  for (const key of INHERITABLE_CHILD_ENV_VARS) {
-    const value = process.env[key];
-    if (value !== undefined) {
-      inherited[key] = value;
-    }
-  }
-  return inherited;
-}
-
 export function createBubblewrapConfig(
   serverConfig: McpServer
 ): FirejailConfig | null {
@@ -768,11 +724,23 @@ async function createMcpClientAndTransport(serverConfig: McpServer, skipCommandT
         env: {
           // Allowlisted host vars only - this process holds the app's secrets
           ...inheritableChildEnv(),
+          // PATH is built from approved directories only, on every platform:
+          // appending the host PATH would let a child resolve commands from
+          // whatever directories this process happens to have, and would leave
+          // non-Linux hosts with no PATH at all once the spread was removed.
+          PATH: [
+            process.env.FIREJAIL_LOCAL_BIN ?? path.join(actualHome, '.local/bin'),
+            PackageManagerConfig.NODEJS_BIN_DIR,
+            PackageManagerConfig.PYTHON_BIN_DIR,
+            PackageManagerConfig.DOCKER_BIN_DIR,
+            '/usr/local/bin',
+            '/usr/bin',
+            '/bin',
+          ].join(':'),
           // Only add Linux-specific paths on Linux systems
           ...(process.platform === 'linux' ? {
             // Add potentially missing vars needed by uvx/python on Linux
             // Use dynamic home directory detection
-            PATH: `${process.env.FIREJAIL_LOCAL_BIN ?? path.join(actualHome, '.local/bin')}:${process.env.PATH}`, // Prepend local bin
             HOME: process.env.FIREJAIL_USER_HOME ?? serverOAuthHome,
             UV_ROOT: `${process.env.FIREJAIL_USER_HOME ?? actualHome}/.local/uv`,
             PYTHONPATH: `${process.env.FIREJAIL_MCP_WORKSPACE ?? path.join(actualHome, 'mcp-workspace')}/lib/python`,

--- a/lib/mcp/connector/dispatch.ts
+++ b/lib/mcp/connector/dispatch.ts
@@ -17,13 +17,13 @@ import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
 import { listHubs, openHub } from './handlers/hubs';
 import { askKnowledge, getDocument, listDocuments } from './handlers/library';
-import type { ToolResult } from './tool-result';
 import {
   buildDiscoverResult,
   buildInitializeResult,
   JSONRPC,
   type JsonRpcRequest,
 } from './protocol';
+import type { ToolResult } from './tool-result';
 import { findTool, requiredScopeFor, visibleTools } from './tools';
 
 export type DispatchOutcome =

--- a/lib/mcp/connector/handle-request.ts
+++ b/lib/mcp/connector/handle-request.ts
@@ -16,9 +16,9 @@ import {
 } from './dispatch';
 import {
   isNotification,
+  JSONRPC,
   jsonRpcError,
   jsonRpcResult,
-  JSONRPC,
   parseJsonRpc,
 } from './protocol';
 

--- a/lib/mcp/connector/handlers/hubs.ts
+++ b/lib/mcp/connector/handlers/hubs.ts
@@ -18,10 +18,9 @@ import { db } from '@/db';
 import { oauthAccessTokensTable, projectsTable } from '@/db/schema';
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
-import { toolFailure as failure, toolText as text, type ToolResult } from '../tool-result';
-
 import { mintHubHandle } from '../handles';
 import { requireGrantedHub } from '../hub-scope';
+import { toolFailure as failure, type ToolResult,toolText as text } from '../tool-result';
 
 export async function listHubs(identity: ConnectorIdentity): Promise<ToolResult> {
   if (identity.grantedProjectUuids.length === 0) {

--- a/lib/mcp/connector/handlers/library.ts
+++ b/lib/mcp/connector/handlers/library.ts
@@ -17,10 +17,9 @@
 import { askKnowledgeBase, getDocByUuid, getDocs } from '@/app/actions/library';
 import type { ConnectorIdentity } from '@/lib/oauth/provider/authenticate';
 
-import { toolFailure as failure, toolText as text, type ToolResult } from '../tool-result';
-
 import type { GrantedHub } from '../hub-scope';
 import { requireGrantedHub } from '../hub-scope';
+import { toolFailure as failure, type ToolResult,toolText as text } from '../tool-result';
 
 /** What a model is given about a document. Deliberately narrower than Doc. */
 function summarise(doc: {

--- a/lib/mcp/connector/tools.ts
+++ b/lib/mcp/connector/tools.ts
@@ -12,8 +12,8 @@
  * inconsistency the tests catch.
  */
 
-import { TOOL_SCOPES } from '@/lib/oauth/provider/scopes';
 import type { Scope } from '@/lib/oauth/provider/scopes';
+import { TOOL_SCOPES } from '@/lib/oauth/provider/scopes';
 
 export interface ToolDefinition {
   name: string;

--- a/lib/mcp/oauth-process-manager.ts
+++ b/lib/mcp/oauth-process-manager.ts
@@ -4,7 +4,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 
-import { inheritableChildEnv } from '@/lib/mcp/child-env';
+import { approvedChildPath, inheritableChildEnv } from '@/lib/mcp/child-env';
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
 import { portAllocator } from '@/lib/mcp/utils/port-allocator';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
@@ -99,8 +99,10 @@ export class OAuthProcessManager extends EventEmitter {
           // Allowlist, not the whole environment: this process holds the app's
           // secrets and the spawned mcp-remote is a user-chosen binary.
           ...inheritableChildEnv(),
-          PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
           ...env,
+          // PATH after the caller's env, not before: an approved executable
+          // boundary that a supplied variable can replace is not a boundary.
+          PATH: approvedChildPath(),
           // Use isolated HOME directory to isolate .mcp-auth
           HOME: oauthHome,
           // Ensure OAuth callback port is set if provided

--- a/lib/mcp/oauth-process-manager.ts
+++ b/lib/mcp/oauth-process-manager.ts
@@ -4,6 +4,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 
+import { inheritableChildEnv } from '@/lib/mcp/child-env';
 import { PackageManagerConfig } from '@/lib/mcp/package-manager/config';
 import { portAllocator } from '@/lib/mcp/utils/port-allocator';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
@@ -95,7 +96,10 @@ export class OAuthProcessManager extends EventEmitter {
       // Spawn the OAuth process with isolated HOME and shell: false for security
       const childProcess = spawn(command, args, {
         env: {
-          ...process.env,
+          // Allowlist, not the whole environment: this process holds the app's
+          // secrets and the spawned mcp-remote is a user-chosen binary.
+          ...inheritableChildEnv(),
+          PATH: process.env.PATH ?? '/usr/local/bin:/usr/bin:/bin',
           ...env,
           // Use isolated HOME directory to isolate .mcp-auth
           HOME: oauthHome,

--- a/lib/mcp/package-manager/config.ts
+++ b/lib/mcp/package-manager/config.ts
@@ -1,6 +1,5 @@
 import fs from 'fs';
 import os from 'os';
-import path from 'path';
 
 import { buildSecurePath } from '@/lib/secure-path-builder';
 

--- a/lib/mcp/package-manager/handlers/docker-handler.ts
+++ b/lib/mcp/package-manager/handlers/docker-handler.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process';
 import fs from 'fs';
 import { promisify } from 'util';
 
+import { inheritableChildEnv } from '@/lib/mcp/child-env';
 import { buildSecurePath } from '@/lib/secure-path-builder';
 import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
 
@@ -49,7 +50,7 @@ export class DockerHandler extends BasePackageHandler {
       await execFileAsync('docker', ['pull', containerTag], {
         timeout: PackageManagerConfig.PROCESS_TIMEOUT_MS,
         env: {
-          ...process.env,
+          ...inheritableChildEnv(),
           ...options.env,
         },
       });

--- a/lib/mcp/package-manager/handlers/docker-handler.ts
+++ b/lib/mcp/package-manager/handlers/docker-handler.ts
@@ -2,7 +2,7 @@ import { execFile } from 'child_process';
 import fs from 'fs';
 import { promisify } from 'util';
 
-import { inheritableChildEnv } from '@/lib/mcp/child-env';
+import { approvedChildPath, inheritableChildEnv } from '@/lib/mcp/child-env';
 import { buildSecurePath } from '@/lib/secure-path-builder';
 import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
 
@@ -51,6 +51,8 @@ export class DockerHandler extends BasePackageHandler {
         timeout: PackageManagerConfig.PROCESS_TIMEOUT_MS,
         env: {
           ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
           ...options.env,
         },
       });

--- a/lib/mcp/package-manager/handlers/docker-handler.ts
+++ b/lib/mcp/package-manager/handlers/docker-handler.ts
@@ -78,6 +78,7 @@ export class DockerHandler extends BasePackageHandler {
     try {
       // Check if the Docker image exists locally
       const { stdout } = await execFileAsync('docker', ['images', '-q', packageName], {
+        env: { ...inheritableChildEnv(), PATH: approvedChildPath() },
         timeout: 5000, // Quick check
       });
       
@@ -101,6 +102,7 @@ export class DockerHandler extends BasePackageHandler {
       // Remove any containers that were created for this server
       const containerName = `mcp-${serverUuid}`;
       await execFileAsync('docker', ['rm', '-f', containerName], {
+        env: { ...inheritableChildEnv(), PATH: approvedChildPath() },
         timeout: 10000,
       });
     } catch (error) {
@@ -123,6 +125,7 @@ export class DockerHandler extends BasePackageHandler {
     // This is approximate since Docker images are shared across containers
     try {
       const { stdout } = await execFileAsync('docker', ['images', '--format', 'table {{.Size}}'], {
+        env: { ...inheritableChildEnv(), PATH: approvedChildPath() },
         timeout: 5000,
       });
       
@@ -151,6 +154,7 @@ export class DockerHandler extends BasePackageHandler {
     for (const packageName of packages) {
       try {
         await execFileAsync('docker', ['pull', packageName], {
+          env: { ...inheritableChildEnv(), PATH: approvedChildPath() },
           timeout: PackageManagerConfig.PROCESS_TIMEOUT_MS,
         });
         this.log('Pre-warmed Docker image', { packageName });

--- a/lib/mcp/package-manager/handlers/pnpm-handler.ts
+++ b/lib/mcp/package-manager/handlers/pnpm-handler.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
 import { promisify } from 'util';
 
+import { inheritableChildEnv } from '@/lib/mcp/child-env';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
 import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
 
@@ -60,7 +61,7 @@ export class PnpmHandler extends BasePackageHandler {
       const { stdout, stderr } = await execFileAsync('pnpm', ['add', packageSpec], {
         cwd: installDir,
         env: {
-          ...process.env,
+          ...inheritableChildEnv(),
           PNPM_STORE_DIR: PackageManagerConfig.PNPM_STORE_DIR,
           NODE_LINKER: 'isolated',
           PACKAGE_IMPORT_METHOD: 'clone', // For CoW filesystems
@@ -228,7 +229,7 @@ export class PnpmHandler extends BasePackageHandler {
         await execFileAsync('pnpm', ['add', packageName], {
           cwd: tempDir,
           env: {
-            ...process.env,
+            ...inheritableChildEnv(),
             PNPM_STORE_DIR: PackageManagerConfig.PNPM_STORE_DIR,
             NODE_LINKER: 'isolated',
           },

--- a/lib/mcp/package-manager/handlers/pnpm-handler.ts
+++ b/lib/mcp/package-manager/handlers/pnpm-handler.ts
@@ -2,7 +2,7 @@ import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
 import { promisify } from 'util';
 
-import { inheritableChildEnv } from '@/lib/mcp/child-env';
+import { approvedChildPath, inheritableChildEnv } from '@/lib/mcp/child-env';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
 import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
 
@@ -62,6 +62,8 @@ export class PnpmHandler extends BasePackageHandler {
         cwd: installDir,
         env: {
           ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
           PNPM_STORE_DIR: PackageManagerConfig.PNPM_STORE_DIR,
           NODE_LINKER: 'isolated',
           PACKAGE_IMPORT_METHOD: 'clone', // For CoW filesystems
@@ -230,6 +232,8 @@ export class PnpmHandler extends BasePackageHandler {
           cwd: tempDir,
           env: {
             ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
             PNPM_STORE_DIR: PackageManagerConfig.PNPM_STORE_DIR,
             NODE_LINKER: 'isolated',
           },

--- a/lib/mcp/package-manager/handlers/uv-handler.ts
+++ b/lib/mcp/package-manager/handlers/uv-handler.ts
@@ -2,7 +2,7 @@ import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
 import { promisify } from 'util';
 
-import { inheritableChildEnv } from '@/lib/mcp/child-env';
+import { approvedChildPath, inheritableChildEnv } from '@/lib/mcp/child-env';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
 import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
 
@@ -120,6 +120,8 @@ export class UvHandler extends BasePackageHandler {
           cwd: installDir,
           env: {
             ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
             UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
             UV_PROJECT_ENVIRONMENT: venvDir,
           },
@@ -140,6 +142,8 @@ export class UvHandler extends BasePackageHandler {
           cwd: installDir,
           env: {
             ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
             UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
             UV_PROJECT_ENVIRONMENT: venvDir,
             VIRTUAL_ENV: venvDir,
@@ -171,6 +175,8 @@ export class UvHandler extends BasePackageHandler {
             cwd: installDir,
             env: {
               ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
               UV_PROJECT_ENVIRONMENT: venvDir,
               VIRTUAL_ENV: venvDir,
             },
@@ -222,6 +228,8 @@ export class UvHandler extends BasePackageHandler {
           cwd: installDir,
           env: {
             ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
             UV_PROJECT_ENVIRONMENT: venvDir,
             VIRTUAL_ENV: venvDir,
           },
@@ -285,6 +293,8 @@ export class UvHandler extends BasePackageHandler {
         cwd: baseLayerDir,
         env: {
           ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
           UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
           UV_PROJECT_ENVIRONMENT: venvDir,
         },
@@ -298,6 +308,8 @@ export class UvHandler extends BasePackageHandler {
           cwd: baseLayerDir,
           env: {
             ...inheritableChildEnv(),
+          // PATH is not in the allowlist; without it execFile cannot find the binary
+          PATH: approvedChildPath(),
             UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
             UV_PROJECT_ENVIRONMENT: venvDir,
             VIRTUAL_ENV: venvDir,

--- a/lib/mcp/package-manager/handlers/uv-handler.ts
+++ b/lib/mcp/package-manager/handlers/uv-handler.ts
@@ -2,6 +2,7 @@ import { execFile } from 'child_process';
 import { promises as fs } from 'fs';
 import { promisify } from 'util';
 
+import { inheritableChildEnv } from '@/lib/mcp/child-env';
 import { buildSecurePath, validatePathComponent } from '@/lib/secure-path-builder';
 import { validatePackageName, validatePackageVersion } from '@/lib/security/package-name';
 
@@ -118,7 +119,7 @@ export class UvHandler extends BasePackageHandler {
         await execFileAsync('uv', ['venv'], {
           cwd: installDir,
           env: {
-            ...process.env,
+            ...inheritableChildEnv(),
             UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
             UV_PROJECT_ENVIRONMENT: venvDir,
           },
@@ -138,7 +139,7 @@ export class UvHandler extends BasePackageHandler {
         {
           cwd: installDir,
           env: {
-            ...process.env,
+            ...inheritableChildEnv(),
             UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
             UV_PROJECT_ENVIRONMENT: venvDir,
             VIRTUAL_ENV: venvDir,
@@ -169,7 +170,7 @@ export class UvHandler extends BasePackageHandler {
           {
             cwd: installDir,
             env: {
-              ...process.env,
+              ...inheritableChildEnv(),
               UV_PROJECT_ENVIRONMENT: venvDir,
               VIRTUAL_ENV: venvDir,
             },
@@ -220,7 +221,7 @@ export class UvHandler extends BasePackageHandler {
         {
           cwd: installDir,
           env: {
-            ...process.env,
+            ...inheritableChildEnv(),
             UV_PROJECT_ENVIRONMENT: venvDir,
             VIRTUAL_ENV: venvDir,
           },
@@ -283,7 +284,7 @@ export class UvHandler extends BasePackageHandler {
       await execFileAsync('uv', ['venv'], {
         cwd: baseLayerDir,
         env: {
-          ...process.env,
+          ...inheritableChildEnv(),
           UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
           UV_PROJECT_ENVIRONMENT: venvDir,
         },
@@ -296,7 +297,7 @@ export class UvHandler extends BasePackageHandler {
         await execFileAsync('uv', ['pip', 'install', packageName], {
           cwd: baseLayerDir,
           env: {
-            ...process.env,
+            ...inheritableChildEnv(),
             UV_CACHE_DIR: PackageManagerConfig.UV_CACHE_DIR,
             UV_PROJECT_ENVIRONMENT: venvDir,
             VIRTUAL_ENV: venvDir,

--- a/lib/mcp/package-manager/index.ts
+++ b/lib/mcp/package-manager/index.ts
@@ -1,3 +1,5 @@
+import { approvedChildPath } from '@/lib/mcp/child-env';
+
 import { PackageManagerConfig } from './config';
 import { BasePackageHandler, InstallOptions, PackageInfo } from './handlers/base-handler';
 import { DockerHandler } from './handlers/docker-handler';
@@ -328,18 +330,18 @@ export class PackageManager {
       const handler = this.handlers.get('pnpm') as PnpmHandler;
       const installDir = handler['getServerInstallDir'](serverUuid);
       env.NODE_PATH = `${installDir}/node_modules`;
-      env.PATH = `${installDir}/node_modules/.bin:${process.env.PATH}`;
+      env.PATH = approvedChildPath([`${installDir}/node_modules/.bin`]);
     } else if (type === 'uv' || type === 'uvx' || type === 'pip') {
       const handler = this.handlers.get('uv') as UvHandler;
       const installDir = handler['getServerInstallDir'](serverUuid);
       const venvDir = `${installDir}/.venv`;
       env.VIRTUAL_ENV = venvDir;
-      env.PATH = `${venvDir}/bin:${process.env.PATH}`;
+      env.PATH = approvedChildPath([`${venvDir}/bin`]);
       env.PYTHONPATH = `${venvDir}/lib/python3.*/site-packages`;
     } else if (type === 'docker') {
       const handler = this.handlers.get('docker') as DockerHandler;
       const installDir = handler['getServerInstallDir'](serverUuid);
-      env.PATH = `${installDir}:${process.env.PATH}`;
+      env.PATH = approvedChildPath([installDir]);
       // Docker doesn't need special environment variables like Node.js or Python
     }
     

--- a/tests/security/command-injection-handlers.test.ts
+++ b/tests/security/command-injection-handlers.test.ts
@@ -81,3 +81,33 @@ describe('package manager handlers never hand a package name to a shell', () => 
     expect(execFile).not.toHaveBeenCalled();
   });
 });
+
+describe('package manager handlers give the child a usable PATH', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['pnpm', '@/lib/mcp/package-manager/handlers/pnpm-handler'],
+    ['uv', '@/lib/mcp/package-manager/handlers/uv-handler'],
+    ['docker', '@/lib/mcp/package-manager/handlers/docker-handler'],
+  ])('%s handler', async (_name, mod) => {
+    const handlerModule: any = await import(mod);
+    const HandlerClass = Object.values(handlerModule).find(
+      (v: any) => typeof v === 'function' && /Handler$/.test(v.name)
+    ) as any;
+
+    await new HandlerClass()
+      .install({ packageName: 'some-package', serverUuid: '11111111-1111-4111-8111-111111111111' })
+      .catch(() => undefined);
+
+    expect(execFile.mock.calls.length).toBeGreaterThan(0);
+    for (const call of execFile.mock.calls) {
+      const opts = call[2] as any;
+      // Dropping the host environment without restoring PATH means execFile
+      // cannot resolve pnpm/uv/docker at all.
+      expect(opts?.env?.PATH, 'child env must carry a PATH').toBeTruthy();
+      expect(opts.env.PATH).toContain('/usr/bin');
+    }
+  });
+});

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -136,3 +136,23 @@ describe('inheritableChildEnv NODE_ENV', () => {
     expect(inheritableChildEnv().NODE_ENV).toBeDefined();
   });
 });
+
+describe('approvedChildPath', () => {
+  it('includes the configured interpreter directories and the system paths', async () => {
+    const { approvedChildPath } = await import('@/lib/mcp/child-env');
+    const { PackageManagerConfig } = await import('@/lib/mcp/package-manager/config');
+
+    const p = approvedChildPath();
+
+    expect(p).toContain(PackageManagerConfig.NODEJS_BIN_DIR);
+    expect(p).toContain(PackageManagerConfig.PYTHON_BIN_DIR);
+    expect(p).toContain('/usr/bin');
+  });
+
+  it('does not simply reuse the host PATH', async () => {
+    const { approvedChildPath } = await import('@/lib/mcp/child-env');
+    process.env.PATH = '/attacker/controlled/dir:/usr/bin';
+
+    expect(approvedChildPath()).not.toContain('/attacker/controlled/dir');
+  });
+});

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -229,3 +229,39 @@ describe('approvedChildPath is platform-aware', () => {
     expect(p.split(';')).not.toContain('/usr/bin');
   });
 });
+
+describe('approvedChildPath is the only PATH builder', () => {
+  it('includes the per-user local bin directory by default', async () => {
+    const { approvedChildPath } = await import('@/lib/mcp/child-env');
+    const os = await import('node:os');
+    const path = await import('node:path');
+
+    const expected = process.env.FIREJAIL_LOCAL_BIN ?? path.join(os.homedir(), '.local', 'bin');
+
+    expect(approvedChildPath().split(path.delimiter)).toContain(expected);
+  });
+
+  it('leaves no inline PATH construction in lib/mcp', async () => {
+    const fs = await import('node:fs');
+    const p = await import('node:path');
+
+    const walk = (dir: string): string[] =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+        const full = p.join(dir, e.name);
+        return e.isDirectory() ? walk(full) : full.endsWith('.ts') ? [full] : [];
+      });
+
+    // Four separate PATH strings existed here, each with its own `:` join and
+    // its own idea of which directories count. Fixing them one at a time is
+    // how the last three review rounds went.
+    const offenders: string[] = [];
+    for (const file of walk('lib/mcp')) {
+      const src = fs.readFileSync(file, 'utf8');
+      for (const m of src.matchAll(/(?<![A-Z_])PATH:\s*(`|\[)/g)) {
+        offenders.push(`${file}:${src.slice(0, m.index).split('\n').length}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -29,7 +29,7 @@ const server: any = {
 };
 
 /** Snapshot every variable this file touches, so the suite leaves env as it found it. */
-const TOUCHED = [...Object.keys(PLANTED), 'TZ', 'HTTP_PROXY', 'HTTPS_PROXY'];
+const TOUCHED = [...Object.keys(PLANTED), 'TZ', 'PATH', 'HTTP_PROXY', 'HTTPS_PROXY'];
 let saved: Record<string, string | undefined> = {};
 
 beforeEach(() => {
@@ -52,7 +52,8 @@ function envOf(cfg: any): Record<string, string> {
   return cfg.env ?? cfg.finalEnv ?? {};
 }
 
-describe.each([
+// Both builders return null off Linux, so their assertions only mean anything there.
+describe.skipIf(process.platform !== 'linux').each([
   ['bubblewrap', createBubblewrapConfig],
   ['firejail', createFirejailConfig],
 ])('%s child environment', (_name, build) => {

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -157,3 +157,38 @@ describe('approvedChildPath', () => {
     expect(approvedChildPath()).not.toContain('/attacker/controlled/dir');
   });
 });
+
+describe('every child spawn in lib/mcp bounds its environment', () => {
+  /**
+   * A source-level invariant, deliberately. The previous rounds of this fix
+   * were swept with `grep '\.\.\.process\.env'`, which finds the environment
+   * being spread in — but Node inherits the full parent environment when the
+   * `env` option is simply *absent*, and absence is not greppable that way.
+   * Four docker calls leaked through exactly that gap.
+   */
+  it('passes an explicit env to every exec/spawn call', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+
+    const walk = (dir: string): string[] =>
+      fs.readdirSync(dir, { withFileTypes: true }).flatMap((e) => {
+        const full = path.join(dir, e.name);
+        return e.isDirectory() ? walk(full) : full.endsWith('.ts') ? [full] : [];
+      });
+
+    const offenders: string[] = [];
+    for (const file of walk('lib/mcp')) {
+      const src = fs.readFileSync(file, 'utf8');
+      for (const m of src.matchAll(/(execFileAsync|execAsync|execFile|spawn)\s*\(/g)) {
+        const window = src.slice(m.index ?? 0, (m.index ?? 0) + 700);
+        const end = window.indexOf(');');
+        const call = window.slice(0, end > 0 ? end : 300);
+        if (!call.includes('env:')) {
+          offenders.push(`${file}:${src.slice(0, m.index).split('\n').length}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -192,3 +192,32 @@ describe('every child spawn in lib/mcp bounds its environment', () => {
     expect(offenders).toEqual([]);
   });
 });
+
+describe('approvedChildPath is platform-aware', () => {
+  const realPlatform = process.platform;
+  const setPlatform = (p: string) =>
+    Object.defineProperty(process, 'platform', { value: p, configurable: true });
+
+  afterEach(() => setPlatform(realPlatform));
+
+  it('uses the POSIX delimiter and system directories on Linux', async () => {
+    setPlatform('linux');
+    const { approvedChildPath } = await import('@/lib/mcp/child-env');
+
+    const p = approvedChildPath();
+
+    expect(p).toContain(':');
+    expect(p).toContain('/usr/bin');
+  });
+
+  it('uses the Windows delimiter and omits the POSIX system directories', async () => {
+    setPlatform('win32');
+    const { approvedChildPath } = await import('@/lib/mcp/child-env');
+
+    const p = approvedChildPath(['C:\\tools\\bin']);
+
+    expect(p).toContain(';');
+    expect(p.split(';')).toContain('C:\\tools\\bin');
+    expect(p.split(';')).not.toContain('/usr/bin');
+  });
+});

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -28,13 +28,24 @@ const server: any = {
   env: {},
 };
 
+/** Snapshot every variable this file touches, so the suite leaves env as it found it. */
+const TOUCHED = [...Object.keys(PLANTED), 'TZ', 'HTTP_PROXY', 'HTTPS_PROXY'];
+let saved: Record<string, string | undefined> = {};
+
 beforeEach(() => {
+  saved = Object.fromEntries(TOUCHED.map((k) => [k, process.env[k]]));
   Object.assign(process.env, PLANTED);
   process.env.TZ = 'Europe/Istanbul';
 });
 
 afterEach(() => {
-  for (const k of Object.keys(PLANTED)) delete process.env[k];
+  for (const k of TOUCHED) {
+    if (saved[k] === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = saved[k];
+    }
+  }
 });
 
 function envOf(cfg: any): Record<string, string> {
@@ -85,5 +96,43 @@ describe.each([
 
     expect(env.MY_TOKEN).toBe('user-supplied');
     expect(env.NODE_ENV).toBe('development');
+  });
+});
+
+describe('inheritableChildEnv', () => {
+  it('strips credentials from proxy URLs', async () => {
+    const { inheritableChildEnv } = await import('@/lib/mcp/child-env');
+    process.env.HTTPS_PROXY = 'http://proxyuser:proxypass@proxy.internal:3128';
+
+    const env = inheritableChildEnv();
+
+    expect(env.HTTPS_PROXY).toBeDefined();
+    expect(env.HTTPS_PROXY).not.toContain('proxypass');
+    expect(env.HTTPS_PROXY).not.toContain('proxyuser');
+    expect(env.HTTPS_PROXY).toContain('proxy.internal:3128');
+  });
+
+  it('withholds a proxy value it cannot parse rather than forwarding it', async () => {
+    const { inheritableChildEnv } = await import('@/lib/mcp/child-env');
+    process.env.HTTP_PROXY = 'not a url';
+
+    expect(inheritableChildEnv()).not.toHaveProperty('HTTP_PROXY');
+  });
+
+  it('carries no application secret', async () => {
+    const { inheritableChildEnv } = await import('@/lib/mcp/child-env');
+
+    const serialized = JSON.stringify(inheritableChildEnv());
+    for (const value of Object.values(PLANTED)) {
+      expect(serialized).not.toContain(value);
+    }
+  });
+});
+
+describe('inheritableChildEnv NODE_ENV', () => {
+  it('always carries NODE_ENV, which spawn options require', async () => {
+    const { inheritableChildEnv } = await import('@/lib/mcp/child-env');
+
+    expect(inheritableChildEnv().NODE_ENV).toBeDefined();
   });
 });

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { McpServerType } from '@/db/schema';
+import { createBubblewrapConfig, createFirejailConfig } from '@/lib/mcp/client-wrapper';
+
+/**
+ * A spawned MCP server is a process the user chose. The app's own process.env
+ * carries the whole secret set — docker-compose preloads /run/secrets/app.env
+ * through `NODE_OPTIONS: -r dotenv/config` — so spreading it into that child
+ * hands NEXTAUTH_SECRET, DATABASE_URL and every provider key to whoever
+ * configured the server.
+ */
+const PLANTED = {
+  NEXTAUTH_SECRET: 'planted-nextauth-secret',
+  DATABASE_URL: 'postgresql://planted:planted@db/planted',
+  ANTHROPIC_API_KEY: 'planted-anthropic-key',
+  K8S_SERVICE_ACCOUNT_TOKEN: 'planted-k8s-token',
+  GITHUB_TOKEN: 'planted-github-token',
+  POSTGRES_PASSWORD: 'planted-pg-password',
+};
+
+const server: any = {
+  uuid: '11111111-1111-4111-8111-111111111111',
+  name: 'test',
+  type: McpServerType.STDIO,
+  command: 'npx',
+  args: ['-y', 'some-package'],
+  env: {},
+};
+
+beforeEach(() => {
+  Object.assign(process.env, PLANTED);
+  process.env.TZ = 'Europe/Istanbul';
+});
+
+afterEach(() => {
+  for (const k of Object.keys(PLANTED)) delete process.env[k];
+});
+
+function envOf(cfg: any): Record<string, string> {
+  return cfg.env ?? cfg.finalEnv ?? {};
+}
+
+describe.each([
+  ['bubblewrap', createBubblewrapConfig],
+  ['firejail', createFirejailConfig],
+])('%s child environment', (_name, build) => {
+  it('withholds every host secret', () => {
+    const env = envOf((build as any)(server));
+
+    for (const key of Object.keys(PLANTED)) {
+      expect(env).not.toHaveProperty(key);
+    }
+    const serialized = JSON.stringify(env);
+    for (const value of Object.values(PLANTED)) {
+      expect(serialized).not.toContain(value);
+    }
+  });
+
+  it('keeps the explicitly constructed PATH and HOME rather than the host ones', () => {
+    const env = envOf((build as any)(server));
+
+    expect(env.PATH).toBeDefined();
+    expect(env.PATH).toContain('/usr/bin');
+    expect(env.HOME).toBeDefined();
+    expect(env.HOME).not.toBe(process.env.HOME);
+  });
+
+  it('still passes the interpreter settings the child needs', () => {
+    const env = envOf((build as any)(server));
+
+    expect(env.NODE_ENV).toBe('production');
+    expect(env.UV_SYSTEM_PYTHON).toBe('true');
+    expect(env.PNPM_STORE_DIR).toBeDefined();
+  });
+
+  it('lets a harmless host variable through', () => {
+    const env = envOf((build as any)(server));
+
+    expect(env.TZ).toBe('Europe/Istanbul');
+  });
+
+  it("still applies the server's own env, which wins", () => {
+    const env = envOf((build as any)({ ...server, env: { MY_TOKEN: 'user-supplied', NODE_ENV: 'development' } }));
+
+    expect(env.MY_TOKEN).toBe('user-supplied');
+    expect(env.NODE_ENV).toBe('development');
+  });
+});

--- a/tests/security/mcp-child-env.test.ts
+++ b/tests/security/mcp-child-env.test.ts
@@ -183,13 +183,21 @@ describe('every child spawn in lib/mcp bounds its environment', () => {
         const window = src.slice(m.index ?? 0, (m.index ?? 0) + 700);
         const end = window.indexOf(');');
         const call = window.slice(0, end > 0 ? end : 300);
-        if (!call.includes('env:')) {
+        // `env` as an object key, not the substring: `{ cwd: 'env:' }` must
+        // not satisfy this check.
+        if (!/[{,]\s*env\s*:/.test(call)) {
           offenders.push(`${file}:${src.slice(0, m.index).split('\n').length}`);
         }
       }
     }
 
     expect(offenders).toEqual([]);
+  });
+
+  it('is not fooled by the string "env:" appearing elsewhere in a call', () => {
+    const decoy = "execFileAsync('tool', [], { cwd: 'env:', timeout: 1 });";
+
+    expect(/[{,]\s*env\s*:/.test(decoy)).toBe(false);
   });
 });
 


### PR DESCRIPTION
An MCP server is a process the user chose. `client-wrapper.ts` spread the entire host `process.env` into it, at three sites — `createBubblewrapConfig`, `createFirejailConfig`, and the unsandboxed fallback in `createMcpClientAndTransport`. No code path built a minimal environment for a child.

**No exploit is needed. This is what adding a server does.**

## These are real secrets, not placeholders

`infra/docker-compose.yml` sets `NODE_OPTIONS: "-r dotenv/config"` with `DOTENV_CONFIG_PATH` pointed at the sops-decrypted `/run/secrets/app.env`, so the values are in `process.env` before any app code runs. Counted in the running container — **112 variables, 22 of them secrets**:

| | |
|---|---|
| `NEXTAUTH_SECRET` | forges a session cookie for any account, including admin |
| `DATABASE_URL`, `POSTGRES_PASSWORD` | direct database access |
| `K8S_SERVICE_ACCOUNT_TOKEN` | the Kubernetes cluster |
| `GITHUB_TOKEN`, `GITHUB_CLIENT_SECRET` | the GitHub org |
| `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`, `GROQ_API_KEY`, `DEEPSEEK_API_KEY`, `GEMINI_API_KEY` | every provider bill |
| `EMAIL_SERVER_PASSWORD`, `CRON_SECRET`, `ADMIN_MIGRATION_SECRET`, `PAP_COLLECTOR_API_KEY`, `REGISTRY_INTERNAL_API_KEY` | |

Bubblewrap shares the network by default, so exfiltration is one outbound request. Even the network-isolated firejail path can return them through MCP tool-call responses.

## The fix

Children inherit an allowlist — locale, `TZ`, `TERM`, proxy settings, CA bundle paths — and nothing else.

The allowlist is applied **first** in each object, so the explicitly constructed `PATH`, `HOME` and interpreter settings win. Previously the `process.env` spread came *last* and silently overrode them: the carefully built `PATH` and the `NODE_ENV: 'production'` default were both being clobbered by whatever the host had. The tests caught that as a separate failure. A server's own `env` still applies last, unchanged.

## Tests

Ten, across both sandbox builders: planted secrets appear neither as keys nor anywhere in the serialized environment, the explicit `PATH`/`HOME` survive, the interpreter settings survive, an allowlisted variable passes through, and the server's own `env` still wins.

## Behavioural note

Servers that silently relied on inheriting a host variable will no longer see it. That inheritance is the vulnerability, so the change is deliberate — but if something legitimate turns out to need a specific variable, the fix is to add that name to `INHERITABLE_CHILD_ENV_VARS`, not to restore the spread.

Suite: 203 failing before, 203 after, no file regressed. `tsc` clean, no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790868935&installation_model_id=430597&pr_number=209&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F209&signature=8c6e6594707b4c5f2d9b242398e13f43dfc9bcb91f22f09608d9058c139ece2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Restrict MCP-related child processes to a sanitized allowlisted environment instead of exposing the host application's secrets.

Bug Fixes:
- Prevent application secrets from being inherited by spawned MCP servers and their package-management or OAuth subprocesses.
- Sanitize inherited proxy settings so embedded credentials are not exposed to child processes.

Enhancements:
- Introduce a centralized child-process environment allowlist and approved executable PATH construction while preserving required runtime settings and server-specific overrides.

Tests:
- Add security coverage verifying secret isolation, environment precedence, proxy sanitization, usable platform-aware PATHs, and explicit environment configuration for MCP subprocesses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved protection for MCP and package-management processes by restricting inherited environment variables and removing secrets.
  * Sanitized proxy settings and rejected malformed proxy URLs.
  * Standardized safe executable paths across supported tools and platforms.

* **Bug Fixes**
  * Preserved required runtime settings and caller-provided overrides while launching subprocesses.
  * Ensured subprocesses retain a usable system `PATH`.

* **Tests**
  * Added coverage for safe environments, proxy handling, interpreter paths, and command execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->