### PR TITLE
security: apply the SSRF primitive everywhere a stored url is fetched

### DIFF
--- a/app/actions/test-mcp-connection.ts
+++ b/app/actions/test-mcp-connection.ts
@@ -324,6 +324,10 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
               },
             };
           } else {
+            // Clone before reading: once the body is consumed the response is
+            // disturbed, and clone() then throws rather than returning a copy.
+            const forCorsCheck = initResponse.clone();
+
             // Try to read response body for CORS checking
             let responseText = '';
             try {
@@ -331,9 +335,9 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
             } catch {
               // Ignore errors reading response body
             }
-            
+
             // Check for CORS issues
-            const corsDetails = await checkForCorsIssue(initResponse.clone(), validated.url, responseText);
+            const corsDetails = await checkForCorsIssue(forCorsCheck, validated.url, responseText);
             
             // Check if this is a 401 authentication error
             const requiresAuth = initResponse.status === 401;

--- a/app/actions/test-mcp-connection.ts
+++ b/app/actions/test-mcp-connection.ts
@@ -3,6 +3,7 @@
 import { z } from 'zod';
 
 import { McpServerType } from '@/db/schema';
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 import { requireAuthUserId } from '@/lib/require-auth';
 import { validateCommand, validateCommandArgs, validateHeaders } from '@/lib/security/validators';
 
@@ -143,7 +144,9 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
         
         // Test the remote URL to see if it needs authentication
         try {
-          const response = await fetch(remoteUrl, {
+          // remoteUrl comes out of the server's own args, so the caller
+          // chooses it and the outcome is reported back to them.
+          const response = await safeFetch(remoteUrl, {
             method: 'HEAD',
             headers: {
               'User-Agent': 'Plugged.in MCP Client',
@@ -228,7 +231,7 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
           // ✅ First, check if server requires authentication with a simple HEAD request
           // This avoids CORS issues from POST requests without auth
           try {
-            const headResponse = await fetch(validated.url, {
+            const headResponse = await safeFetch(validated.url, {
               method: 'HEAD',
               headers,
               signal: AbortSignal.timeout(5000),
@@ -251,7 +254,7 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
           }
 
           // Try to send an initialize request
-          const initResponse = await fetch(validated.url, {
+          const initResponse = await safeFetch(validated.url, {
             method: 'POST',
             headers: {
               'Content-Type': 'application/json',
@@ -376,7 +379,7 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
 
       // For other servers, try HEAD request first
       try {
-        const response = await fetch(validated.url, {
+        const response = await safeFetch(validated.url, {
           method: 'HEAD',
           headers,
           signal: AbortSignal.timeout(5000), // 5 second timeout
@@ -402,7 +405,7 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
       } catch (fetchError) {
         // If HEAD fails, try OPTIONS as a fallback
         try {
-          const optionsResponse = await fetch(validated.url, {
+          const optionsResponse = await safeFetch(validated.url, {
             method: 'OPTIONS',
             headers,
             signal: AbortSignal.timeout(5000),

--- a/app/actions/test-mcp-connection.ts
+++ b/app/actions/test-mcp-connection.ts
@@ -324,10 +324,6 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
               },
             };
           } else {
-            // Clone before reading: once the body is consumed the response is
-            // disturbed, and clone() then throws rather than returning a copy.
-            const forCorsCheck = initResponse.clone();
-
             // Try to read response body for CORS checking
             let responseText = '';
             try {
@@ -336,8 +332,11 @@ export async function testMcpConnection(config: TestConfig): Promise<TestResult>
               // Ignore errors reading response body
             }
 
-            // Check for CORS issues
-            const corsDetails = await checkForCorsIssue(forCorsCheck, validated.url, responseText);
+            // No clone: checkForCorsIssue reads only status and headers, both of
+            // which survive the body being consumed. Cloning first threw
+            // because the body was already read; cloning here would leave a
+            // second buffered stream nobody drains.
+            const corsDetails = await checkForCorsIssue(initResponse, validated.url, responseText);
             
             // Check if this is a 401 authentication error
             const requiresAuth = initResponse.status === 401;

--- a/app/actions/trigger-mcp-oauth.ts
+++ b/app/actions/trigger-mcp-oauth.ts
@@ -220,6 +220,22 @@ async function handleMcpRemoteOAuth(server: McpServer) {
   );
   const remoteUrl = urlIndex !== -1 && urlIndex !== undefined && server.args ? server.args[urlIndex] : null;
 
+  // The sibling handler validates server.url before contacting it; this one
+  // spawns `npx -y mcp-remote <remoteUrl>` against a URL taken from the
+  // server's own args and never did. That is worse than a blind probe: the
+  // process manager reflects the child's stdout and stderr back to the caller
+  // on failure, so an internal service's banner comes with it.
+  if (remoteUrl) {
+    try {
+      validateUrlForSSRF(remoteUrl);
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'The remote URL is not allowed',
+      };
+    }
+  }
+
   if (!remoteUrl) {
     return {
       success: false,

--- a/app/api/clusters/[clusterId]/agents/[agentId]/route.ts
+++ b/app/api/clusters/[clusterId]/agents/[agentId]/route.ts
@@ -12,6 +12,7 @@ import { NextResponse } from 'next/server';
 import { authenticate } from '@/app/api/auth';
 import { db } from '@/db';
 import { clustersTable } from '@/db/schema';
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 
 /**
  * Timeout for collector requests in milliseconds.
@@ -69,7 +70,8 @@ export async function GET(
     }
 
     // Proxy request to collector
-    const collectorResponse = await fetch(
+    // Same collector_url as the sibling listing route, one directory down.
+    const collectorResponse = await safeFetch(
       `${cluster.collector_url}/agents/${agentId}`,
       {
         method: 'GET',

--- a/app/api/clusters/[clusterId]/agents/route.ts
+++ b/app/api/clusters/[clusterId]/agents/route.ts
@@ -18,6 +18,7 @@ import { NextResponse } from 'next/server';
 import { authenticate } from '@/app/api/auth';
 import { db } from '@/db';
 import { clustersTable } from '@/db/schema';
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 
 /**
  * Timeout for collector requests in milliseconds.
@@ -75,7 +76,9 @@ export async function GET(
     }
 
     // Proxy request to collector
-    const collectorResponse = await fetch(`${cluster.collector_url}/agents`, {
+    // collector_url was checked against a denylist once, at creation time, and
+    // never resolved. safeFetch resolves and revalidates every hop.
+    const collectorResponse = await safeFetch(`${cluster.collector_url}/agents`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/app/api/mcp-servers/health/route.ts
+++ b/app/api/mcp-servers/health/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 
 import { getMcpServers } from '@/app/actions/mcp-servers'; // Use path alias relative to app root
 import { authenticateApiKey } from '@/app/api/auth'; // Use path alias relative to app root
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 
 /**
  * @swagger
@@ -127,7 +128,8 @@ export async function GET(request: Request) {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), 5000); // 5-second timeout
 
-        const response = await fetch(server.url, {
+        // server.url is stored per server and chosen by whoever configured it.
+        const response = await safeFetch(server.url, {
           method: 'HEAD', // Use HEAD for efficiency
           signal: controller.signal,
           // Add headers if needed, e.g., Authorization if the health endpoint is protected

--- a/app/api/oauth/callback/route.ts
+++ b/app/api/oauth/callback/route.ts
@@ -9,6 +9,7 @@ import { mcpOAuthCallbacks } from '@/lib/mcp/metrics';
 import { validatePkceState } from '@/lib/oauth/integrity';
 import { getOAuthConfig } from '@/lib/oauth/oauth-config-store';
 import { cleanupExpiredPkceStates } from '@/lib/oauth/pkce-cleanup';
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 import { createRateLimiter } from '@/lib/rate-limiter';
 
 // P0 Security: Rate limiter for OAuth callback (10 requests per 15 minutes per IP)
@@ -248,7 +249,10 @@ export async function GET(request: NextRequest) {
     console.log('[OAuth Callback] Using client_id:', clientId);
 
     // Add 5-second timeout to prevent hanging requests (reduced from 10s for security)
-    const tokenResponse = await fetch(tokenEndpoint, {
+    // token_endpoint comes from the stored OAuth config, which is influenced by
+    // the server the user registered — so it is not a trusted constant, and the
+    // response is reflected back to the caller.
+    const tokenResponse = await safeFetch(tokenEndpoint, {
       method: 'POST',
       headers,
       body: tokenParams,

--- a/lib/oauth/rfc9728-discovery.ts
+++ b/lib/oauth/rfc9728-discovery.ts
@@ -5,6 +5,7 @@
  * This module implements OAuth discovery for MCP servers that follow RFC 9728.
  */
 
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 import { log } from '@/lib/observability/logger';
 import { recordDiscovery } from '@/lib/observability/oauth-metrics';
 
@@ -100,7 +101,10 @@ export async function discoverOAuthMetadata(
       metadataUrl
     });
 
-    const response = await fetch(metadataUrl, {
+    // metadataUrl is built from the WWW-Authenticate header of a server the
+    // user configured, so its host is theirs to choose. The first hop being
+    // validated says nothing about this one.
+    const response = await safeFetch(metadataUrl, {
       method: 'GET',
       headers: {
         Accept: 'application/json',

--- a/lib/oauth/ssrf-protection.ts
+++ b/lib/oauth/ssrf-protection.ts
@@ -169,10 +169,22 @@ export async function safeFetch(
   options?: RequestInit,
   allowPrivate = false
 ): Promise<Response> {
-  // Reassigned when a 301/302/303 downgrades the method — see below.
-   
+  // Reassigned when a 301/302/303 downgrades the method, and when a
+  // cross-origin hop drops credentials — see below.
   let requestInit = options;
   let currentUrl = url;
+
+  // 307 and 308 replay the body, so it has to survive being sent twice.
+  // URLSearchParams — what the OAuth callers send — is consumed by the first
+  // request, and the replay would go out empty. Serializing it up front costs
+  // nothing and makes the body replayable.
+  if (requestInit?.body instanceof URLSearchParams) {
+    const headers = new Headers(requestInit.headers);
+    if (!headers.has('content-type')) {
+      headers.set('content-type', 'application/x-www-form-urlencoded;charset=UTF-8');
+    }
+    requestInit = { ...requestInit, body: requestInit.body.toString(), headers };
+  }
 
   for (let hop = 0; hop < MAX_REDIRECTS; hop++) {
     // Fetch the URL the validator returned rather than the string that went

--- a/lib/oauth/ssrf-protection.ts
+++ b/lib/oauth/ssrf-protection.ts
@@ -131,13 +131,46 @@ const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
  * @param options - Fetch options
  * @param allowPrivate - Allow private IPs (default: false) - use ONLY for testing
  */
+/**
+ * Headers that authenticate the request, and so must not survive a hop to an
+ * origin the caller never addressed.
+ *
+ * The named three are what browsers drop on a cross-origin redirect. The
+ * pattern covers what this application sends beyond them — X-Collector-Key to
+ * a cluster collector, X-Api-Key to a server — because the destination of a
+ * redirect is chosen by the very host the credential authenticates against.
+ */
+const CREDENTIAL_HEADER = /^(authorization|cookie|proxy-authorization)$/i;
+const CREDENTIAL_HEADER_PATTERN = /(^|-)(key|token|secret|password|auth|credential)(-|$)/i;
+
+function isCredentialHeader(name: string): boolean {
+  return CREDENTIAL_HEADER.test(name) || CREDENTIAL_HEADER_PATTERN.test(name);
+}
+
+/** The same request with every credential header removed. */
+function withoutCredentials(init: RequestInit | undefined): RequestInit | undefined {
+  if (!init?.headers) return init;
+
+  const kept = new Headers();
+  new Headers(init.headers).forEach((value, name) => {
+    if (!isCredentialHeader(name)) kept.set(name, value);
+  });
+
+  return { ...init, headers: kept };
+}
+
+/** Whether two URLs differ in scheme, host or port. */
+function crossOrigin(from: string, to: string): boolean {
+  return new URL(from).origin !== new URL(to).origin;
+}
+
 export async function safeFetch(
   url: string,
   options?: RequestInit,
   allowPrivate = false
 ): Promise<Response> {
   // Reassigned when a 301/302/303 downgrades the method — see below.
-  // eslint-disable-next-line prefer-const
+   
   let requestInit = options;
   let currentUrl = url;
 
@@ -178,7 +211,17 @@ export async function safeFetch(
       // to release it must not fail the request that was otherwise fine.
     });
 
-    currentUrl = new URL(location, currentUrl).toString();
+    const nextUrl = new URL(location, currentUrl).toString();
+
+    // Browsers drop Authorization on a cross-origin redirect, and for the same
+    // reason: the host answering this hop was chosen by the previous one, not
+    // by the caller, so it has no claim on credentials meant for the caller's
+    // destination.
+    if (crossOrigin(currentUrl, nextUrl)) {
+      requestInit = withoutCredentials(requestInit);
+    }
+
+    currentUrl = nextUrl;
   }
 
   throw new Error('Too many redirects');

--- a/lib/oauth/token-refresh-service.ts
+++ b/lib/oauth/token-refresh-service.ts
@@ -4,6 +4,7 @@ import { db } from '@/db';
 import { mcpServerOAuthTokensTable, mcpServersTable, profilesTable, projectsTable } from '@/db/schema';
 import { decryptField, encryptField } from '@/lib/encryption';
 import { getOAuthConfig } from '@/lib/oauth/oauth-config-store';
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 import { log } from '@/lib/observability/logger';
 import {
   recordTokenRefresh,
@@ -362,7 +363,8 @@ export async function refreshOAuthToken(serverUuid: string, userId: string): Pro
       log.oauth('token_refresh_using_basic_auth', { serverUuid });
     }
 
-    const tokenResponse = await fetch(oauthConfig.token_endpoint, {
+    // The same stored token_endpoint the callback route fetches.
+    const tokenResponse = await safeFetch(oauthConfig.token_endpoint, {
       method: 'POST',
       headers,
       body: tokenParams,

--- a/tests/integration/context7.test.ts
+++ b/tests/integration/context7.test.ts
@@ -42,10 +42,13 @@ describe('Context7 MCP Server Tests', () => {
       expect(result.message).toContain('MCP server connection verified');
       
       // Verify correct headers were sent
+      // These calls now go through safeFetch, which validates the destination
+      // and hands fetch the parsed URL with redirects taken off automatic.
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://mcp.context7.com/mcp',
+        new URL('https://mcp.context7.com/mcp'),
         expect.objectContaining({
           method: 'POST',
+          redirect: 'manual',
           headers: expect.objectContaining({
             'Accept': 'application/json, text/event-stream',
             'Content-Type': 'application/json',
@@ -100,9 +103,10 @@ describe('Context7 MCP Server Tests', () => {
 
       // Should try HEAD request for SSE (not special handling)
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://mcp.context7.com/mcp',
+        new URL('https://mcp.context7.com/mcp'),
         expect.objectContaining({
-          method: 'HEAD'
+          method: 'HEAD',
+          redirect: 'manual',
         })
       );
     });

--- a/tests/security/safe-fetch-redirect-credentials.test.ts
+++ b/tests/security/safe-fetch-redirect-credentials.test.ts
@@ -82,3 +82,44 @@ describe('safeFetch does not carry credentials across origins', () => {
     expect(headers.get('authorization')).toBeNull();
   });
 });
+
+/**
+ * 307 and 308 replay the request, body included. A URLSearchParams body — what
+ * the OAuth token exchange sends — is consumed by the first request, so the
+ * replay went out empty.
+ */
+describe('safeFetch can replay the body a 307 preserves', () => {
+  it('sends the same body on the second hop', async () => {
+    fetchMock
+      .mockResolvedValueOnce({
+        status: 307,
+        headers: new Headers({ location: 'https://issuer.example.com/v2/token' }),
+        body: null,
+      })
+      .mockResolvedValueOnce({ status: 200, headers: new Headers(), body: null });
+
+    await safeFetch('https://issuer.example.com/token', {
+      method: 'POST',
+      body: new URLSearchParams({ grant_type: 'authorization_code', code: 'abc' }),
+    });
+
+    const first = fetchMock.mock.calls[0][1].body;
+    const second = fetchMock.mock.calls[1][1].body;
+
+    expect(typeof second).toBe('string');
+    expect(second).toBe(first);
+    expect(second).toContain('grant_type=authorization_code');
+  });
+
+  it('sets the form content type when the caller did not', async () => {
+    fetchMock.mockResolvedValueOnce({ status: 200, headers: new Headers(), body: null });
+
+    await safeFetch('https://issuer.example.com/token', {
+      method: 'POST',
+      body: new URLSearchParams({ code: 'abc' }),
+    });
+
+    const headers = new Headers(fetchMock.mock.calls[0][1].headers);
+    expect(headers.get('content-type')).toBe('application/x-www-form-urlencoded;charset=UTF-8');
+  });
+});

--- a/tests/security/safe-fetch-redirect-credentials.test.ts
+++ b/tests/security/safe-fetch-redirect-credentials.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const { safeFetch } = await import('@/lib/oauth/ssrf-protection');
+
+/** A 302 to `location`, then a 200. */
+function redirectOnceTo(location: string) {
+  fetchMock
+    .mockResolvedValueOnce({
+      status: 302,
+      headers: new Headers({ location }),
+      body: null,
+    })
+    .mockResolvedValueOnce({ status: 200, headers: new Headers(), body: null });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * safeFetch follows redirects itself so it can revalidate each hop, and it
+ * reused the caller's headers on every one. The callers here send credentials:
+ * `Authorization: Basic <client id and secret>` to an OAuth token endpoint, and
+ * `X-Collector-Key` to a cluster collector. A redirect to a different origin
+ * therefore handed those to whoever answered it — and the destination is chosen
+ * by the very server the credentials authenticate against.
+ *
+ * Browsers drop `Authorization` on a cross-origin redirect for exactly this
+ * reason; this is the same rule.
+ */
+describe('safeFetch does not carry credentials across origins', () => {
+  it('drops Authorization when the redirect changes origin', async () => {
+    redirectOnceTo('https://elsewhere.example.net/token');
+
+    await safeFetch('https://issuer.example.com/token', {
+      method: 'POST',
+      headers: { Authorization: 'Basic c2VjcmV0', 'Content-Type': 'application/json' },
+    });
+
+    const second = fetchMock.mock.calls[1][1];
+    const headers = new Headers(second.headers);
+    expect(headers.get('authorization')).toBeNull();
+    // A header that carries no credential is not the point and stays.
+    expect(headers.get('content-type')).toBe('application/json');
+  });
+
+  it('drops other credential headers too', async () => {
+    redirectOnceTo('https://elsewhere.example.net/agents');
+
+    await safeFetch('https://collector.example.com/agents', {
+      headers: { 'X-Collector-Key': 'secret', Cookie: 'session=1' },
+    });
+
+    const headers = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(headers.get('x-collector-key')).toBeNull();
+    expect(headers.get('cookie')).toBeNull();
+  });
+
+  it('keeps them on a same-origin redirect', async () => {
+    redirectOnceTo('https://issuer.example.com/token/v2');
+
+    await safeFetch('https://issuer.example.com/token', {
+      method: 'POST',
+      headers: { Authorization: 'Basic c2VjcmV0' },
+    });
+
+    const headers = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(headers.get('authorization')).toBe('Basic c2VjcmV0');
+  });
+
+  it('treats a scheme or port change as a different origin', async () => {
+    redirectOnceTo('https://issuer.example.com:8443/token');
+
+    await safeFetch('https://issuer.example.com/token', {
+      headers: { Authorization: 'Basic c2VjcmV0' },
+    });
+
+    const headers = new Headers(fetchMock.mock.calls[1][1].headers);
+    expect(headers.get('authorization')).toBeNull();
+  });
+});

--- a/tests/security/safe-fetch-redirects.test.ts
+++ b/tests/security/safe-fetch-redirects.test.ts
@@ -132,7 +132,10 @@ describe('safeFetch redirect handling', () => {
 
     for (const call of fetchSpy.mock.calls) {
       const init = call[1] as RequestInit;
-      expect((init.headers as Record<string, string>).Accept).toBe('application/json');
+      // Read through Headers: a cross-origin hop rebuilds the container while
+      // dropping credential headers, so the shape differs between hops even
+      // though a non-credential header like Accept survives both.
+      expect(new Headers(init.headers).get('accept')).toBe('application/json');
       // Redirects must be handled by us, not by fetch.
       expect(init.redirect).toBe('manual');
     }

--- a/tests/security/ssrf-primitive-applied.test.ts
+++ b/tests/security/ssrf-primitive-applied.test.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
@@ -10,34 +11,69 @@ import { describe, expect, it } from 'vitest';
  * These are the sites that reach the network with a URL read from the database
  * or from a response header, rather than one written in the source.
  */
-const SITES = [
-  'app/api/oauth/callback/route.ts',
-  'app/api/clusters/[clusterId]/agents/route.ts',
-  'lib/oauth/rfc9728-discovery.ts',
-];
-
 function stripComments(src: string): string {
   return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
 }
 
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return /\.tsx?$/.test(full) ? [full] : [];
+  });
+}
+
+/**
+ * Values that name a network destination and are read from storage or from a
+ * response, rather than written in the source. A bare `fetch` in the same file
+ * as one of these is the shape this rule is about.
+ */
+const STORED_DESTINATIONS =
+  /\b(collector_url|token_endpoint|callback_url|metadataUrl|authorization_server|server\.url|remoteUrl|validated\.url|callbackUrl)\b/;
+
+/**
+ * The one site that cannot be fixed by applying safeFetch, listed here rather
+ * than left to slip through a pattern that happens not to match it.
+ *
+ * app/api/mcp/oauth/callback forwards to oauthSession.callback_url, and its
+ * guard *requires* the hostname to be localhost — which is the vulnerability,
+ * because the fetch runs on the production host. safeFetch would refuse the
+ * call outright and break the flow. Closing it properly means restricting the
+ * forward to the port the app allocated for that session, and
+ * mcp_oauth_sessions records no port. See the PR description.
+ */
+const KNOWN_UNFIXED = ['app/api/mcp/oauth/callback/route.ts'];
+
 describe('every server-side fetch of a stored url goes through safeFetch', () => {
-  for (const site of SITES) {
-    it(`${site} uses safeFetch`, () => {
-      const src = stripComments(fs.readFileSync(site, 'utf8'));
+  /**
+   * Discovered, not listed. My first version of this test enumerated the files
+   * I had just fixed, so it passed while the sibling route
+   * app/api/clusters/[clusterId]/agents/[agentId]/route.ts — the same
+   * collector_url, one directory down — still used a bare fetch. A test that
+   * only knows the files you already thought of cannot tell you about the one
+   * you missed.
+   */
+  it('no file naming a stored destination still calls fetch directly', () => {
+    const offenders = ['app', 'lib']
+      .flatMap((dir) => walk(dir))
+      .filter((file) => !KNOWN_UNFIXED.includes(file))
+      .filter((file) => {
+        const src = stripComments(fs.readFileSync(file, 'utf8'));
 
-      expect(src).toMatch(/safeFetch\s*\(/);
-    });
+        // The destination has to be in the call's own argument. Matching the
+        // file as a whole flagged lib/mcp/package-detector.ts, which fetches
+        // registry.npmjs.org and api.github.com — constant hosts — and merely
+        // mentions one of these names elsewhere.
+        for (const match of src.matchAll(/(?<![.\w])fetch\s*\(/g)) {
+          const argument = src.slice(match.index ?? 0, (match.index ?? 0) + 160);
+          if (STORED_DESTINATIONS.test(argument)) return true;
+        }
 
-    it(`${site} makes no bare fetch call`, () => {
-      const src = stripComments(fs.readFileSync(site, 'utf8'));
+        return false;
+      });
 
-      // `await fetch(` / `= fetch(` — a call to the global, as opposed to
-      // safeFetch. Matching the bare identifier keeps this readable.
-      const bare = src.match(/(?<![.\w])fetch\s*\(/g) ?? [];
-
-      expect(bare).toEqual([]);
-    });
-  }
+    expect(offenders).toEqual([]);
+  });
 });
 
 /**

--- a/tests/security/ssrf-primitive-applied.test.ts
+++ b/tests/security/ssrf-primitive-applied.test.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * lib/oauth/ssrf-protection.ts already had the right primitive — validateUrlForSSRF
+ * plus safeFetch, which revalidates every redirect hop. It simply was not applied
+ * everywhere a URL that a user can influence gets fetched by the server.
+ *
+ * These are the sites that reach the network with a URL read from the database
+ * or from a response header, rather than one written in the source.
+ */
+const SITES = [
+  'app/api/oauth/callback/route.ts',
+  'app/api/clusters/[clusterId]/agents/route.ts',
+  'lib/oauth/rfc9728-discovery.ts',
+];
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
+describe('every server-side fetch of a stored url goes through safeFetch', () => {
+  for (const site of SITES) {
+    it(`${site} uses safeFetch`, () => {
+      const src = stripComments(fs.readFileSync(site, 'utf8'));
+
+      expect(src).toMatch(/safeFetch\s*\(/);
+    });
+
+    it(`${site} makes no bare fetch call`, () => {
+      const src = stripComments(fs.readFileSync(site, 'utf8'));
+
+      // `await fetch(` / `= fetch(` — a call to the global, as opposed to
+      // safeFetch. Matching the bare identifier keeps this readable.
+      const bare = src.match(/(?<![.\w])fetch\s*\(/g) ?? [];
+
+      expect(bare).toEqual([]);
+    });
+  }
+});
+
+/**
+ * handleMcpRemoteOAuth spawns `npx -y mcp-remote <url>` against a URL taken
+ * from the server's own args, and the process manager reflects the child's
+ * stdout and stderr back to the caller on failure. Its sibling
+ * handleStreamableHttpOAuth validates; this one did not.
+ */
+describe('the mcp-remote path validates before it spawns', () => {
+  it('validates the remote url', () => {
+    const src = stripComments(
+      fs.readFileSync('app/actions/trigger-mcp-oauth.ts', 'utf8')
+    );
+    const handler = src.slice(
+      src.indexOf('async function handleMcpRemoteOAuth'),
+      src.indexOf('async function handleStreamableHttpOAuth')
+    );
+
+    expect(handler).toMatch(/validateUrlForSSRF\s*\(/);
+  });
+});

--- a/tests/security/ssrf-primitive-applied.test.ts
+++ b/tests/security/ssrf-primitive-applied.test.ts
@@ -83,15 +83,21 @@ describe('every server-side fetch of a stored url goes through safeFetch', () =>
  * handleStreamableHttpOAuth validates; this one did not.
  */
 describe('the mcp-remote path validates before it spawns', () => {
-  it('validates the remote url', () => {
-    const src = stripComments(
-      fs.readFileSync('app/actions/trigger-mcp-oauth.ts', 'utf8')
-    );
+  it('validates the remote url, and does so before the process is launched', () => {
+    // Asserting only that the call exists would pass if it moved below the
+    // spawn, which is where it would stop protecting anything.
+    const src = stripComments(fs.readFileSync('app/actions/trigger-mcp-oauth.ts', 'utf8'));
     const handler = src.slice(
       src.indexOf('async function handleMcpRemoteOAuth'),
       src.indexOf('async function handleStreamableHttpOAuth')
     );
 
-    expect(handler).toMatch(/validateUrlForSSRF\s*\(/);
+    const validatedAt = handler.search(/validateUrlForSSRF\s*\(/);
+    const spawnedAt = handler.search(/oauthProcessManager\.triggerOAuth\s*\(/);
+
+    expect(validatedAt).toBeGreaterThanOrEqual(0);
+    expect(spawnedAt).toBeGreaterThanOrEqual(0);
+    expect(validatedAt).toBeLessThan(spawnedAt);
   });
 });
+


### PR DESCRIPTION
## The finding

`lib/oauth/ssrf-protection.ts` already had the right tool — `safeFetch`, which validates **every redirect hop** rather than only the first, and downgrades the method on a 301/302/303 as RFC 9110 requires. It simply was not applied to four places that reach the network with a URL the caller can influence.

| Site | What was fetched |
|---|---|
| `app/api/oauth/callback` | `token_endpoint`, straight from the stored OAuth config, bare `fetch`, response reflected back |
| `lib/oauth/rfc9728-discovery` | a metadata URL built from the **`WWW-Authenticate` header** of a server the user configured |
| `app/api/clusters/[clusterId]/agents` | `collector_url`, checked against a denylist once at creation and never resolved |
| `app/actions/trigger-mcp-oauth` (`handleMcpRemoteOAuth`) | spawns `npx -y mcp-remote <url>` against a URL from the server's own args |

Two are worth calling out.

**The discovery hop is what made the existing guard bypassable.** `handleStreamableHttpOAuth` validates `server.url` correctly — but on a 401 it hands off to `discoverOAuthFromResponse`, which used the raw global `fetch` against a host named in the *response header*. Passing the first check only required the configured server to be genuinely public; its headers were always the attacker's to write.

**The `mcp-remote` path is worse than a blind probe.** `lib/mcp/oauth-process-manager.ts` captures the child's raw stdout and stderr and returns them on failure, so an internal service's banner comes back with the error.

## The fix

All four go through the existing primitive. Nothing new was invented; `safeFetch` and `validateUrlForSSRF` are the same functions `trigger-mcp-oauth` was already using sixty lines away.

A test freezes the rule **per site** rather than per fix — each listed file must use `safeFetch` and must contain no bare `fetch(` — so the next raw fetch of a stored URL is caught rather than found by the next scan.

## Not fixed here, and not for lack of looking

`app/api/mcp/oauth/callback` forwards to `oauthSession.callback_url`, and its SSRF guard **requires** the hostname to be `localhost`/`127.0.0.1`/`::1`. That is the vulnerability, not a defence: the fetch runs on the production host, so satisfying the check is what reaches the app host's own loopback on any port from 1024 up.

I traced whether the callback URL is app-generated, which would have made this a non-issue. It is not: `StreamableHTTPWrapper.extractOAuthCallbackUrl` reads it from the `redirect_uri` the **remote MCP server** hands back, and that server is user-configured.

Closing it properly means restricting the forward to the port the app itself allocated for that session — and `mcp_oauth_sessions` records `callback_url` but no port. That is a schema change on the OAuth path, so I have left it for @ckaraca rather than landing it unattended, the same call I made on #217.

## Verification

- `tsc --noEmit`: clean for `app/` and `lib/`
- `eslint`: 0 errors on every touched file
- Full suite: **191 failures, identical to `main`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790901659&installation_model_id=430597&pr_number=221&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F221&signature=2d5f72ee00468607070c579b1ec2c06f9cfaeebae459a4090012f350cf59eb90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Harden server-side network requests by consistently applying SSRF protection and securing redirect handling for credentials and request bodies.

Bug Fixes:
- Route server-controlled and stored URLs through SSRF-safe fetching across OAuth, MCP, cluster collector, health-check, and connection-test flows.
- Prevent credentials from being forwarded across cross-origin redirects and preserve URL-encoded request bodies across replayable redirects.
- Validate MCP remote URLs before launching the remote OAuth process.

Enhancements:
- Extend redirect handling to strip credential-like headers on origin changes while retaining them for same-origin redirects.
- Apply consistent manual redirect validation and improve request-body replay behavior.

Tests:
- Add security coverage for redirect credential stripping, request-body replay, and enforcement that stored URL fetches use the SSRF primitive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added protected outbound requests across MCP connections, agent proxies, health checks, OAuth flows, and metadata discovery.
  * Added validation for remote URLs before starting MCP OAuth flows.
  * Improved protection against server-side request forgery and unsafe redirects by removing sensitive headers across origins.
  * Improved redirect handling for form submissions and request bodies.

* **Tests**
  * Added security coverage for unsafe outbound requests, remote URL validation, redirect credential handling, and request replay.
  * Updated integration tests for protected request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->