### PR TITLE
security: apply the imported-server rules to importSharedServer too

### DIFF
--- a/app/actions/mcp-servers.ts
+++ b/app/actions/mcp-servers.ts
@@ -916,7 +916,12 @@ export async function importSharedServer(
       return { success: false, error: importedCommand.error };
     }
 
-    const importedEnv = validateImportedEnv(isTemplate ? serverData.env : undefined);
+    // Validated unconditionally rather than mirroring `isTemplate`. That flag
+    // is `!serverData.uuid`, but createShareableTemplate puts `uuid` on every
+    // template it builds — so it is false for a genuine share, and mirroring it
+    // meant this check never ran on anything. Checking what arrived is correct
+    // whatever the write path below decides to keep.
+    const importedEnv = validateImportedEnv(serverData.env);
     if (!importedEnv.valid) {
       return { success: false, error: importedEnv.error };
     }

--- a/app/actions/mcp-servers.ts
+++ b/app/actions/mcp-servers.ts
@@ -22,6 +22,8 @@ import {
   validateCommand,
   validateCommandArgs,
   validateHeaders,
+  validateImportedCommand,
+  validateImportedEnv,
   validateMcpUrl,
 } from '@/lib/security/validators';
 import { formatRateLimitError,rateLimitServerAction, ServerActionRateLimits } from '@/lib/server-action-rate-limiter';
@@ -906,9 +908,18 @@ export async function importSharedServer(
       sanitizedArgs = argsValidation.sanitizedArgs ?? serverData.args;
     }
 
-    // TODO: also apply validateImportedCommand / validateImportedEnv here once
-    // #220 lands them in lib/security/validators.ts — the same rules belong on
-    // this path, and it is the same class of import.
+    // A shared server is somebody else's definition, exactly as a collection's
+    // is — so the same two rules apply: the invocation shape is allowlisted,
+    // and the environment may not decide what the process loads.
+    const importedCommand = validateImportedCommand(serverData.command, serverData.args);
+    if (!importedCommand.valid) {
+      return { success: false, error: importedCommand.error };
+    }
+
+    const importedEnv = validateImportedEnv(isTemplate ? serverData.env : undefined);
+    if (!importedEnv.valid) {
+      return { success: false, error: importedEnv.error };
+    }
 
     let sanitizedHeaders: Record<string, string> | undefined;
     if (type === McpServerType.STREAMABLE_HTTP && serverData.streamableHTTPOptions?.headers) {

--- a/lib/security/validators.ts
+++ b/lib/security/validators.ts
@@ -521,6 +521,12 @@ export function validateImportedCommand(
     }
   }
 
+  // An interpreter with nothing to run opens a REPL and never exits, so every
+  // such import leaves a process behind on the host.
+  if (list.length === 0) {
+    return { valid: false, error: `An imported ${command} server must name a script to run` };
+  }
+
   return { valid: true };
 }
 
@@ -559,6 +565,14 @@ function validateImportedExecutorOptions(
         error: `An imported server must invoke ${command} as \`${command} ${required.join(' ')}\``,
       };
     }
+
+    if (positionals.length <= required.length) {
+      return { valid: false, error: `An imported ${command} server must name a package` };
+    }
+  } else if (
+    !list.some((arg) => typeof arg === 'string' && !arg.startsWith('-'))
+  ) {
+    return { valid: false, error: `An imported ${command} server must name a package` };
   }
 
   return { valid: true };

--- a/tests/security/import-server-ownership.test.ts
+++ b/tests/security/import-server-ownership.test.ts
@@ -180,4 +180,42 @@ describe('importSharedServer validates what it is about to run', () => {
     const written = insertValues.mock.calls[0][0] as any;
     expect(written.streamableHTTPOptions?.headers).toEqual({ 'X-Api-Key': 'value' });
   });
+
+  it.each([
+    ['node', ['-e', "require('child_process').execSync('id')"]],
+    ['node', ['--require', '/tmp/x.js']],
+    ['npx', ['--node-options=--require=/tmp/x.js', 'pkg']],
+    ['uv', ['run', 'arbitrary-thing']],
+    ['uv', ['tool', 'install', 'pkg']],
+    ['pnpm', ['exec', 'arbitrary-thing']],
+  ])('refuses %s given a shape that decides what loads', async (command, args) => {
+    // A shared server is somebody else's definition, exactly as a collection's
+    // is — #220 put these rules on that path and this is the same class.
+    const result = await importSharedServer(PROFILE, { type: 'STDIO', command, args }, 'srv');
+
+    expect(result.success).toBe(false);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it('refuses an env that decides what runs', async () => {
+    const result = await importSharedServer(
+      PROFILE,
+      { type: 'STDIO', command: 'npx', args: ['pkg'], env: { NODE_OPTIONS: '--require=/tmp/x.js' } },
+      'srv'
+    );
+
+    expect(result.success).toBe(false);
+    expect(insert).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['npx', ['-y', 'some-mcp-server']],
+    ['uvx', ['some-mcp-server']],
+    ['uv', ['tool', 'run', 'some-mcp-server']],
+    ['pnpm', ['dlx', 'some-mcp-server']],
+  ])('still imports the sanctioned %s shape', async (command, args) => {
+    const result = await importSharedServer(PROFILE, { type: 'STDIO', command, args }, 'srv');
+
+    expect(result.success).toBe(true);
+  });
 });

--- a/tests/security/import-server-ownership.test.ts
+++ b/tests/security/import-server-ownership.test.ts
@@ -188,6 +188,12 @@ describe('importSharedServer validates what it is about to run', () => {
     ['uv', ['run', 'arbitrary-thing']],
     ['uv', ['tool', 'install', 'pkg']],
     ['pnpm', ['exec', 'arbitrary-thing']],
+    // No target at all: `node` with no script opens a REPL that never exits,
+    // leaving a process on the host for every such import.
+    ['node', []],
+    ['python3', []],
+    ['npx', []],
+    ['uv', ['tool', 'run']],
   ])('refuses %s given a shape that decides what loads', async (command, args) => {
     // A shared server is somebody else's definition, exactly as a collection's
     // is — #220 put these rules on that path and this is the same class.

--- a/tests/security/import-server-ownership.test.ts
+++ b/tests/security/import-server-ownership.test.ts
@@ -197,10 +197,20 @@ describe('importSharedServer validates what it is about to run', () => {
     expect(insert).not.toHaveBeenCalled();
   });
 
-  it('refuses an env that decides what runs', async () => {
+  it.each([
+    ['a template', { type: 'STDIO', command: 'npx', args: ['pkg'] }],
+    // createShareableTemplate stamps `uuid` on every template it builds, so a
+    // genuine share carries one — the env check has to run for it too.
+    ['a shared server carrying a uuid', {
+      uuid: 'server-uuid',
+      type: 'STDIO',
+      command: 'npx',
+      args: ['pkg'],
+    }],
+  ])('refuses an env that decides what runs, for %s', async (_label, base) => {
     const result = await importSharedServer(
       PROFILE,
-      { type: 'STDIO', command: 'npx', args: ['pkg'], env: { NODE_OPTIONS: '--require=/tmp/x.js' } },
+      { ...base, env: { NODE_OPTIONS: '--require=/tmp/x.js' } },
       'srv'
     );
 


### PR DESCRIPTION
Closes the TODO #218 left behind. Those rules lived in #220's changes to `lib/security/validators.ts`; both have landed, so this is the follow-up that PR promised.

## What

A **shared server** is somebody else's definition, exactly as a collection's is. So `importSharedServer` gets the same two rules #220 put on the collection path:

- the invocation shape is allowlisted — `npx -y <package>`, `uvx <package>`, `uv tool run <package>`, `pnpm dlx <package>`, or an interpreter pointed at a script with no options
- the environment may not decide what the process loads — no `NODE_OPTIONS`, `PYTHONSTARTUP`, `LD_PRELOAD` and the rest

## What this deliberately does *not* touch

**`bulkImportMcpServers`.** That path imports the JSON a user pastes for their **own** servers. Their own definition is not somebody else's, and running `node -e` in a server you wrote is the product working as intended — `validateCommandArgs` permits it on purpose, because args go to the process as argv and never through a shell.

That distinction is the entire basis of these rules. Extending them to a self-import would be applying the letter of the rule against its reason, and would break a legitimate workflow to no security benefit. Flagging it explicitly so it reads as a decision rather than an omission.

## Tests

Written failing first. Ten cases, pinned from both sides:

- six refused shapes: `node -e`, `node --require`, `npx --node-options=`, `uv run <thing>`, `uv tool install`, `pnpm exec <thing>`
- an environment setting `NODE_OPTIONS`
- the four sanctioned invocations, which must keep importing

## Verification

- `tsc --noEmit`: clean for `app/` and `lib/`
- `eslint`: 0 errors on both touched files
- Full suite: **191 failures, identical to `main`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790904949&installation_model_id=430597&pr_number=222&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F222&signature=0dd2ed86ad83508cc6356226d92d9cee2a1d27438cfa2bda96e5a01141f6a611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Enforce imported-server command and environment security rules when importing shared servers.

Bug Fixes:
- Apply imported-command and imported-environment security validation to shared server imports.
- Reject imported interpreter and package-runner invocations that omit a script or package or use unsafe loading options.

Enhancements:
- Keep self-owned bulk imports outside the imported-server restrictions while enforcing the rules for shared definitions.

Tests:
- Add coverage for unsafe shared-server command shapes, environment-based loading, and all sanctioned invocation forms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security Enhancements**
  - Improved validation when importing shared servers.
  - Blocks unsafe command and argument combinations.
  - Rejects environment variables that could control execution.
  - Continues to support approved package-runner configurations.

- **Bug Fixes**
  - Prevents invalid or potentially dangerous server configurations from being imported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->