### PR TITLE
security: validate the image a replicated agent deploys

### DIFF
--- a/app/api/agents/[id]/replicate/route.ts
+++ b/app/api/agents/[id]/replicate/route.ts
@@ -9,7 +9,7 @@ import {
   apiKeysTable,
   modelRouterServicesTable,
 } from '@/db/schema';
-import { buildAgentEnv } from '@/lib/agent-helpers';
+import { buildAgentEnv, validateContainerImage, validateResourceLimits } from '@/lib/agent-helpers';
 import { validateAgentName } from '@/lib/agent-name-policy';
 import { generateModelRouterToken } from '@/lib/model-router/token';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
@@ -289,6 +289,20 @@ export async function POST(
         overrides?.image || (sourceMetadata.image as string) || 'ghcr.io/veriteknik/compass-agent:latest';
       const resources =
         overrides?.resources || (sourceMetadata.resources as Record<string, string>);
+
+      // Both come from a caller-supplied `overrides` and reach the same
+      // deployAgent() sink that app/api/agents/route.ts guards. Without these,
+      // anyone holding an API key and one agent could put an arbitrary image
+      // into the shared cluster namespace.
+      const imageError = validateContainerImage(image);
+      if (imageError) {
+        return NextResponse.json({ error: imageError }, { status: 400 });
+      }
+
+      const resourceError = validateResourceLimits(resources);
+      if (resourceError) {
+        return NextResponse.json({ error: resourceError }, { status: 400 });
+      }
 
       // Note: dnsName in DB is just subdomain (e.g., "dev1"), but K8s Ingress needs full FQDN
       const fullDnsName = `${dnsName}.is.plugged.in`;

--- a/app/api/agents/[id]/replicate/route.ts
+++ b/app/api/agents/[id]/replicate/route.ts
@@ -172,6 +172,30 @@ export async function POST(
 
     // Clone metadata, applying overrides
     const sourceMetadata = (sourceAgent.metadata as Record<string, unknown>) || {};
+
+    // Resolved and validated before anything is written. Either value may come
+    // from the caller's `overrides`, falling back to the source agent's stored
+    // metadata, and both reach the same deployAgent() sink that
+    // app/api/agents/route.ts guards. Validating here rather than at the deploy
+    // keeps a rejected image from leaving a replica row behind and reserving
+    // its DNS name.
+    const image =
+      overrides?.image || (sourceMetadata.image as string) || 'ghcr.io/veriteknik/compass-agent:latest';
+    const resources =
+      overrides?.resources || (sourceMetadata.resources as Record<string, string>);
+
+    if (deploy) {
+      const imageError = validateContainerImage(image);
+      if (imageError) {
+        return NextResponse.json({ error: imageError }, { status: 400 });
+      }
+
+      const resourceError = validateResourceLimits(resources);
+      if (resourceError) {
+        return NextResponse.json({ error: resourceError }, { status: 400 });
+      }
+    }
+
     const newMetadata = {
       ...sourceMetadata,
       replicated_from: {
@@ -285,28 +309,6 @@ export async function POST(
 
     // Optionally deploy to Kubernetes
     if (deploy) {
-      const image =
-        overrides?.image || (sourceMetadata.image as string) || 'ghcr.io/veriteknik/compass-agent:latest';
-      const resources =
-        overrides?.resources || (sourceMetadata.resources as Record<string, string>);
-
-      // Either value may come from the caller's `overrides`, falling back to
-      // the source agent's stored metadata — and both reach the same
-      // deployAgent() sink that app/api/agents/route.ts guards. Validating
-      // regardless of which one supplied it is the point: the override path is
-      // how an API-key holder could put an arbitrary image into the shared
-      // cluster namespace, and stored metadata predating this check is no more
-      // trustworthy.
-      const imageError = validateContainerImage(image);
-      if (imageError) {
-        return NextResponse.json({ error: imageError }, { status: 400 });
-      }
-
-      const resourceError = validateResourceLimits(resources);
-      if (resourceError) {
-        return NextResponse.json({ error: resourceError }, { status: 400 });
-      }
-
       // Note: dnsName in DB is just subdomain (e.g., "dev1"), but K8s Ingress needs full FQDN
       const fullDnsName = `${dnsName}.is.plugged.in`;
 

--- a/app/api/agents/[id]/replicate/route.ts
+++ b/app/api/agents/[id]/replicate/route.ts
@@ -290,10 +290,13 @@ export async function POST(
       const resources =
         overrides?.resources || (sourceMetadata.resources as Record<string, string>);
 
-      // Both come from a caller-supplied `overrides` and reach the same
-      // deployAgent() sink that app/api/agents/route.ts guards. Without these,
-      // anyone holding an API key and one agent could put an arbitrary image
-      // into the shared cluster namespace.
+      // Either value may come from the caller's `overrides`, falling back to
+      // the source agent's stored metadata — and both reach the same
+      // deployAgent() sink that app/api/agents/route.ts guards. Validating
+      // regardless of which one supplied it is the point: the override path is
+      // how an API-key holder could put an arbitrary image into the shared
+      // cluster namespace, and stored metadata predating this check is no more
+      // trustworthy.
       const imageError = validateContainerImage(image);
       if (imageError) {
         return NextResponse.json({ error: imageError }, { status: 400 });

--- a/tests/security/agent-deploy-image-validation.test.ts
+++ b/tests/security/agent-deploy-image-validation.test.ts
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { validateContainerImage, validateResourceLimits } from '@/lib/agent-helpers';
+
+function stripComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+}
+
+function walk(dir: string): string[] {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) return walk(full);
+    return /\.tsx?$/.test(full) ? [full] : [];
+  });
+}
+
+/**
+ * lib/agent-helpers.ts carries both validators with their reasons written on
+ * them: "Only allow images from trusted registries to prevent malicious code
+ * execution", "Prevents resource exhaustion by enforcing maximum limits".
+ *
+ * app/api/agents/route.ts calls both before deploying. The replicate endpoint
+ * reached the same deployAgent() sink with a caller-supplied `overrides.image`
+ * and called neither — so anyone holding an API key and one agent could deploy
+ * an arbitrary image into the shared cluster namespace.
+ *
+ * Discovered rather than listed, for the same reason as the SSRF check: a list
+ * only knows the endpoints already thought of.
+ */
+describe('every path that deploys an agent validates what it deploys', () => {
+  it('no deployAgent call site skips the validators', () => {
+    const offenders = walk('app')
+      .concat(walk('lib'))
+      .filter((file) => {
+        const src = stripComments(fs.readFileSync(file, 'utf8'));
+        if (!/\.deployAgent\s*\(/.test(src)) return false;
+        return !/validateContainerImage\s*\(/.test(src) || !/validateResourceLimits\s*\(/.test(src);
+      });
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('the image validator is what stands between a caller and the cluster', () => {
+  it.each([
+    'evil.example.com/malicious:latest',
+    'docker.io/attacker/backdoor:1',
+    'ghcr.io/../../escape:latest',
+  ])('refuses %s', (image) => {
+    expect(validateContainerImage(image)).not.toBeNull();
+  });
+
+  it('allows a bare name, which is Docker Hub\'s curated library namespace', () => {
+    // Deliberate, and commented as such in the validator: a name with no slash
+    // resolves to library/<name>, which an attacker cannot publish into. Pinned
+    // so the intent is not mistaken for an oversight later.
+    expect(validateContainerImage('nginx:1.27')).toBeNull();
+  });
+
+  it('accepts the project registry', () => {
+    expect(validateContainerImage('ghcr.io/veriteknik/compass-agent:latest')).toBeNull();
+  });
+
+  it('refuses resource limits beyond the ceiling', () => {
+    expect(validateResourceLimits({ cpu_limit: '999', memory_limit: '999Gi' })).not.toBeNull();
+  });
+});

--- a/tests/security/agent-deploy-image-validation.test.ts
+++ b/tests/security/agent-deploy-image-validation.test.ts
@@ -31,13 +31,23 @@ function walk(dir: string): string[] {
  * only knows the endpoints already thought of.
  */
 describe('every path that deploys an agent validates what it deploys', () => {
-  it('no deployAgent call site skips the validators', () => {
+  it('no deployAgent call site is reached without the validators running first', () => {
+    // Presence in the same file is not a guard: the call could sit above the
+    // validation, or behind a branch that skips it. Positions are compared, so
+    // moving either validator below the deploy fails this.
     const offenders = walk('app')
       .concat(walk('lib'))
-      .filter((file) => {
+      .flatMap((file) => {
         const src = stripComments(fs.readFileSync(file, 'utf8'));
-        if (!/\.deployAgent\s*\(/.test(src)) return false;
-        return !/validateContainerImage\s*\(/.test(src) || !/validateResourceLimits\s*\(/.test(src);
+
+        return [...src.matchAll(/\.deployAgent\s*\(/g)].flatMap((deploy) => {
+          const before = src.slice(0, deploy.index ?? 0);
+          const validated =
+            /validateContainerImage\s*\(/.test(before) &&
+            /validateResourceLimits\s*\(/.test(before);
+
+          return validated ? [] : [file];
+        });
       });
 
     expect(offenders).toEqual([]);

--- a/tests/security/agent-deploy-image-validation.test.ts
+++ b/tests/security/agent-deploy-image-validation.test.ts
@@ -31,17 +31,28 @@ function walk(dir: string): string[] {
  * only knows the endpoints already thought of.
  */
 describe('every path that deploys an agent validates what it deploys', () => {
+  /** The body of the function containing `at`, by scanning back to its header. */
+  function enclosingFunction(src: string, at: number): string {
+    const header = /(?:export\s+)?(?:async\s+)?function\s+\w+\s*\(/g;
+    let start = 0;
+    for (const match of src.matchAll(header)) {
+      if ((match.index ?? 0) > at) break;
+      start = match.index ?? 0;
+    }
+    return src.slice(start, at);
+  }
+
   it('no deployAgent call site is reached without the validators running first', () => {
     // Presence in the same file is not a guard: the call could sit above the
-    // validation, or behind a branch that skips it. Positions are compared, so
-    // moving either validator below the deploy fails this.
+    // validation, or in a different function entirely. The window is the
+    // enclosing function, up to the call.
     const offenders = walk('app')
       .concat(walk('lib'))
       .flatMap((file) => {
         const src = stripComments(fs.readFileSync(file, 'utf8'));
 
         return [...src.matchAll(/\.deployAgent\s*\(/g)].flatMap((deploy) => {
-          const before = src.slice(0, deploy.index ?? 0);
+          const before = enclosingFunction(src, deploy.index ?? 0);
           const validated =
             /validateContainerImage\s*\(/.test(before) &&
             /validateResourceLimits\s*\(/.test(before);
@@ -51,6 +62,21 @@ describe('every path that deploys an agent validates what it deploys', () => {
       });
 
     expect(offenders).toEqual([]);
+  });
+
+  it('validates before it writes the replica row', () => {
+    // A rejected image used to return 400 after the agent row existed, leaving
+    // an orphan and its reserved DNS name behind.
+    const src = stripComments(
+      fs.readFileSync('app/api/agents/[id]/replicate/route.ts', 'utf8')
+    );
+
+    expect(src.search(/validateContainerImage\s*\(/)).toBeLessThan(
+      src.search(/insert\(agentsTable\)/)
+    );
+    expect(src.search(/validateResourceLimits\s*\(/)).toBeLessThan(
+      src.search(/insert\(agentsTable\)/)
+    );
   });
 });
 


### PR DESCRIPTION
## The finding

`lib/agent-helpers.ts` carries both validators with their reasons written on them — *"Only allow images from trusted registries to prevent malicious code execution"*, *"Prevents resource exhaustion by enforcing maximum limits"* — and `app/api/agents/route.ts` calls both before deploying.

`POST /api/agents/{id}/replicate` reached the **same `deployAgent()` sink** with a caller-supplied `overrides.image` and `overrides.resources`, and called neither.

Anyone holding an API key and one agent — agents are self-service, so a low bar — could put an arbitrary image into the shared `agents` namespace as a live Deployment, Service and Ingress.

This is the last of the CRITICAL findings from the scan.

## The fix

Both validators, before the deploy, returning 400 on refusal — the same control its sibling endpoint already enforces. Nothing new invented.

The test is a **discovery, not a list**: no file calling `deployAgent` may skip either validator. That is the shape that caught the sibling cluster route in #221 after a listed test had missed it, and I would rather not repeat the lesson.

## One thing pinned rather than changed

`validateContainerImage` accepts a bare name like `nginx:1.27`. That looked wrong to me and my first version of the test asserted it should be refused — it is in fact deliberate, and commented as such: a reference with no slash resolves into Docker Hub's curated `library/` namespace, which an attacker cannot publish into. There is now a test asserting the acceptance, so the intent is not mistaken for an oversight by the next person to look.

## Verification

- `tsc --noEmit`: clean for `app/` and `lib/`
- `eslint`: 0 errors on both touched files
- Full suite: **191 failures, identical to `main`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790905513&installation_model_id=430597&pr_number=223&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F223&signature=0e4db7525d8077effb77dc4a815465ac31f69ff8220d1f545c603dbf420c5b03"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Secure agent replication by validating deployment images and resource limits before creating or deploying replicas.

Bug Fixes:
- Validate replicated agent images against trusted registry rules before deployment.
- Enforce resource limits for replicated agent deployments to prevent excessive resource usage.
- Reject invalid replication requests before creating the replica record or reserving its DNS name.

Tests:
- Add discovery-based coverage ensuring every agent deployment path runs both validators before calling the deployment sink.
- Add validation coverage for untrusted images, approved images, Docker Hub bare names, and excessive resource limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Agent replication now validates container images and resource limits before creating deployment records.
  * Invalid deployment settings return a clear HTTP 400 response, preventing unsafe deployments.

* **Tests**
  * Added security coverage for malicious, unsupported, and project-registry image references.
  * Added validation tests for excessive resource settings across agent deployment paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->