### PR TITLE
fix: do not abort the sandbox on a directory that may not exist

### DIFF
--- a/lib/mcp/client-wrapper.ts
+++ b/lib/mcp/client-wrapper.ts
@@ -262,8 +262,15 @@ export function createBubblewrapConfig(
     '--ro-bind-try', '/usr/local/lib/python3', '/usr/local/lib/python3',
     '--ro-bind-try', '/usr/local/lib/python3.12', '/usr/local/lib/python3.12',
     
-    // User's local bin directory
-    '--ro-bind', paths.localBin, paths.localBin,
+    // User's local bin directory.
+    //
+    // Tolerant, like the optional paths above and below it. This is a host
+    // convention ($HOME/.local/bin) and it does not exist in the container
+    // image, where the tools live in /usr/local/bin. bwrap aborts outright if a
+    // --ro-bind source is missing, taking the child with it — which reached the
+    // user as "MCP error -32000: Connection closed" and stopped every sandboxed
+    // STDIO server from starting after the containerised cutover.
+    '--ro-bind-try', paths.localBin, paths.localBin,
     
     // Pipx venvs directory (needed for uvx and other pipx-installed tools)
     '--ro-bind-try', `${paths.userHome}/.local/share/pipx`, `${paths.userHome}/.local/share/pipx`,

--- a/tests/security/mcp-sandbox.test.ts
+++ b/tests/security/mcp-sandbox.test.ts
@@ -10,7 +10,7 @@
  * that could expose sensitive files like ~/.ssh, ~/.bash_history, etc.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { afterEach,beforeEach, describe, expect, it } from 'vitest';
 
 import { McpServerType } from '@/db/schema';
 import { createBubblewrapConfig } from '@/lib/mcp/client-wrapper';
@@ -280,5 +280,41 @@ describe('Sandbox Regression Prevention', () => {
     // If these conditions are not met, the sandbox is bypassed!
 
     expect(true).toBe(true);
+  });
+});
+
+/**
+ * bwrap aborts if a `--ro-bind` source does not exist, and the child dies with
+ * it — surfacing to the user as "MCP error -32000: Connection closed".
+ *
+ * `paths.localBin` is `$HOME/.local/bin`, a host convention. It does not exist
+ * in the container image, so every sandboxed STDIO server failed to start after
+ * the containerised cutover. The neighbouring optional paths already use the
+ * tolerant form; this one did not.
+ */
+describe('the sandbox does not abort on a directory that may not exist', () => {
+  it('binds the local bin directory tolerantly', async () => {
+    const { createBubblewrapConfig } = await import('@/lib/mcp/client-wrapper');
+
+    const config = createBubblewrapConfig({
+      name: 'probe',
+      type: 'STDIO' as never,
+      command: 'npx',
+      args: ['some-server'],
+    } as never);
+
+    const args: string[] = (config as { args?: string[] }).args ?? [];
+    // A bind is `<flag> <source> <dest>`, and source and dest are the same
+    // path here — so only look at entries that are actually a flag.
+    const localBinFlags = args
+      .map((arg, i) => ({ arg, next: args[i + 1] }))
+      .filter(({ arg, next }) => arg.startsWith('--') && next?.endsWith('/.local/bin'))
+      .map(({ arg }) => arg);
+
+    expect(localBinFlags.length).toBeGreaterThan(0);
+    expect(localBinFlags).not.toContain('--ro-bind');
+    for (const flag of localBinFlags) {
+      expect(flag).toMatch(/-try$/);
+    }
   });
 });

--- a/tests/security/mcp-sandbox.test.ts
+++ b/tests/security/mcp-sandbox.test.ts
@@ -293,28 +293,45 @@ describe('Sandbox Regression Prevention', () => {
  * tolerant form; this one did not.
  */
 describe('the sandbox does not abort on a directory that may not exist', () => {
-  it('binds the local bin directory tolerantly', async () => {
+  // createBubblewrapConfig returns null off Linux, so this needs the same
+  // platform setup the nested suites above use — without it the test fails on
+  // a macOS or Windows runner for a reason that has nothing to do with binds.
+  const originalPlatform = process.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  it('binds the local bin directory read-only and tolerantly', async () => {
     const { createBubblewrapConfig } = await import('@/lib/mcp/client-wrapper');
 
     const config = createBubblewrapConfig({
       name: 'probe',
-      type: 'STDIO' as never,
+      type: McpServerType.STDIO,
       command: 'npx',
       args: ['some-server'],
     } as never);
 
-    const args: string[] = (config as { args?: string[] }).args ?? [];
-    // A bind is `<flag> <source> <dest>`, and source and dest are the same
-    // path here — so only look at entries that are actually a flag.
+    const args: string[] = (config as { args?: string[] } | null)?.args ?? [];
+    expect(args.length).toBeGreaterThan(0);
+
+    // A bind is `<flag> <source> <dest>`, and source and dest are the same path
+    // here — so only look at entries that are actually a flag.
     const localBinFlags = args
       .map((arg, i) => ({ arg, next: args[i + 1] }))
       .filter(({ arg, next }) => arg.startsWith('--') && next?.endsWith('/.local/bin'))
       .map(({ arg }) => arg);
 
     expect(localBinFlags.length).toBeGreaterThan(0);
-    expect(localBinFlags).not.toContain('--ro-bind');
+    // Exactly --ro-bind-try. `--bind-try` would also survive a missing source,
+    // but it would make the mount writable — a regression this test has to
+    // fail on, not wave through.
     for (const flag of localBinFlags) {
-      expect(flag).toMatch(/-try$/);
+      expect(flag).toBe('--ro-bind-try');
     }
   });
 });


### PR DESCRIPTION
## The symptom

Tool discovery and the playground fail for every sandboxed STDIO server:

```
[MCP Playground] Applied bubblewrap sandbox to server: …
bwrap: Can't find source path /home/app/.local/bin: No such file or directory
[MCP] Failed to initialize server "…": MCP error -32000: Connection closed
```

## The cause

`bwrap` aborts outright if a `--ro-bind` source is missing, and the child dies with it. `paths.localBin` is `$HOME/.local/bin` — a **host convention**. It does not exist in the container image, where the tools live in `/usr/local/bin`.

The optional paths immediately either side of it already use the tolerant `--ro-bind-try`; this one did not. I checked every other strict bind against the running container: `/usr`, `/lib`, `/lib64`, `/bin`, `/sbin`, `/etc/resolv.conf`, `/etc/ssl`, `/etc/ca-certificates` and `/app/.cache/mcp-packages` are all present. This is the only one missing, so it is the only failure of this class.

## Reproduced before changing anything

In the running production container:

```
bwrap --ro-bind     /home/app/.local/bin …  ->  Can't find source path
bwrap --ro-bind-try /home/app/.local/bin …  ->  SANDBOX_OK
```

## This is not a regression from the recent security work

It sits on the path #209, #215 and #216 all touched, and it is the gap I twice recorded as "unverified live" — so it was the first thing I suspected. It is not:

- the strict bind was written in `81b88224`, **2025-07-05**
- `/home/app/.local/bin` is absent from **every** published image, including `sha-71a300f`, which was serving before yesterday's deploy, and `:latest`
- the sandbox capabilities have been in `docker-compose.yml` since the cutover, so bwrap really has been running and failing

So sandboxed STDIO servers have been broken since the containerised cutover. My changes did not cause it — but they did not catch it either, which is the more useful point: I flagged this path as unverified twice and did not push to have it exercised.

## Tests

Written failing first, and mutation-checked: restoring the strict bind fails it again. The assertion is on the flag rather than the path — my first version matched the bind's source argument and reported the path as if it were the flag.

## Verification

- `tsc --noEmit`: clean for `lib/`
- `eslint`: 0 errors on both touched files
- Full suite: **191 failures, identical to `main`**. The seven pre-existing failures in `tests/security/mcp-sandbox.test.ts` are unchanged — this adds the eighth test, which passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790981931&installation_model_id=430597&pr_number=224&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F224&signature=06a21b9f365d3c3265cbf5da689d88d0170f944cbcedb2d53f8b8de517634977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Allow sandboxed STDIO servers to start when the host-local bin directory is not present.

Bug Fixes:
- Prevent sandboxed STDIO servers from failing when the host-local bin directory is absent by using a tolerant read-only bind.
- Add regression coverage ensuring the optional local bin directory remains read-only and non-fatal when missing.

Tests:
- Add a sandbox regression test covering tolerant binding of the potentially missing local bin directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sandbox startup reliability when the user’s local bin directory is not present.
  * The sandbox now continues starting instead of failing when that optional directory is unavailable.
  * Existing local tools remain available when the directory exists.

* **Tests**
  * Added regression coverage for sandbox startup with a missing local bin directory.
  * Improved validation of sandbox startup arguments and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->