### PR TITLE
fix: create a user's default hub once, under a lock

### DIFF
--- a/app/actions/projects.ts
+++ b/app/actions/projects.ts
@@ -5,6 +5,7 @@ import { eq } from 'drizzle-orm';
 import { db } from '@/db';
 import { profilesTable, projectsTable } from '@/db/schema';
 import { withAuth, withProjectAuth } from '@/lib/auth-helpers';
+import { createDefaultProject } from '@/lib/default-project-creation';
 
 export async function createProject(name: string) {
   return withAuth(async (session) => {
@@ -66,69 +67,12 @@ export async function getProjects() {
         .where(eq(projectsTable.user_id, session.user.id));
 
       if (projects.length === 0) {
-        // User has no projects, create a default one
+        // Delegate rather than inline: createDefaultProject takes a lock on the
+        // user row and re-checks, so two concurrent page loads for a brand-new
+        // user cannot both create a hub. This block used to do its own
+        // check-then-create, which is how 27 users ended up with two.
         try {
-          
-          // Direct DB transaction method instead of using createProject function
-          // This avoids dependency loops and ensures project creation works correctly
-          const defaultProject = await db.transaction(async (tx) => {
-            // Insert the project
-            const [project] = await tx
-              .insert(projectsTable)
-              .values({
-                name: 'Default Hub',
-                active_profile_uuid: null,
-                user_id: session.user.id,
-              })
-              .returning();
-
-            // Create the profile with the project UUID
-            const [profile] = await tx
-              .insert(profilesTable)
-              .values({
-                name: 'Default Workspace',
-                project_uuid: project.uuid,
-              })
-              .returning();
-
-            // Update the project with the profile UUID
-            const [updatedProject] = await tx
-              .update(projectsTable)
-              .set({ active_profile_uuid: profile.uuid })
-              .where(eq(projectsTable.uuid, project.uuid))
-              .returning();
-
-            // Add sample MCP servers within the same transaction
-            try {
-              const { SAMPLE_MCP_SERVERS } = await import('@/lib/sample-mcp-servers');
-              const { mcpServersTable, McpServerType } = await import('@/db/schema');
-
-              const serversToAdd = SAMPLE_MCP_SERVERS.map(server => ({
-                profile_uuid: profile.uuid,
-                name: server.name,
-                slug: server.slug,
-                description: server.description,
-                type: server.type,
-                command: server.type === McpServerType.STDIO ? server.command : undefined,
-                args: server.type === McpServerType.STDIO ? server.args : undefined,
-                env: server.type === McpServerType.STDIO ? server.env : undefined,
-                url: server.type === McpServerType.STREAMABLE_HTTP ? server.url : undefined,
-                headers: server.type === McpServerType.STREAMABLE_HTTP ? server.headers : undefined,
-                notes: server.notes,
-                created_at: new Date(),
-                updated_at: new Date()
-              }));
-
-              await tx.insert(mcpServersTable).values(serversToAdd);
-              console.log(`✅ Added ${SAMPLE_MCP_SERVERS.length} sample MCP servers for profile ${profile.uuid}`);
-            } catch (error) {
-              console.error('Failed to add sample MCP servers:', error);
-              // Don't fail the signup process if sample servers can't be added
-            }
-
-            return updatedProject;
-          });
-          
+          const defaultProject = await createDefaultProject(session.user.id);
           projects = [defaultProject];
         } catch (error) {
           console.error('Error creating default project:', error);

--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -3,7 +3,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { db } from '@/db';
-import { profilesTable, projectsTable, users, verificationTokens } from '@/db/schema';
+import { users, verificationTokens } from '@/db/schema';
+import { createDefaultProject } from '@/lib/default-project-creation';
 
 const verifyEmailSchema = z.object({
   token: z.string(),
@@ -144,63 +145,13 @@ export async function POST(req: NextRequest) {
         )
       );
 
-    // Create a default project for the newly verified user
+    // Create a default project for the newly verified user.
+    //
+    // Delegated rather than inlined: createDefaultProject locks the user row
+    // and returns any existing project, so a user who already has one from
+    // registration or a first page load does not get a second.
     try {
-      // Manually insert a default project for this user
-      await db.transaction(async (tx) => {
-        // Insert the project
-        const [project] = await tx
-          .insert(projectsTable)
-          .values({
-            name: 'Default Hub',
-            active_profile_uuid: null,
-            user_id: user.id,
-          })
-          .returning();
-
-        // Create the default profile
-        const [profile] = await tx
-          .insert(profilesTable)
-          .values({
-            name: 'Default Workspace',
-            project_uuid: project.uuid,
-          })
-          .returning();
-
-        // Update the project with the profile UUID
-        await tx
-          .update(projectsTable)
-          .set({ active_profile_uuid: profile.uuid })
-          .where(eq(projectsTable.uuid, project.uuid));
-
-        // Add sample MCP servers within the same transaction
-        try {
-          const { SAMPLE_MCP_SERVERS } = await import('@/lib/sample-mcp-servers');
-          const { mcpServersTable, McpServerType } = await import('@/db/schema');
-
-          const serversToAdd = SAMPLE_MCP_SERVERS.map(server => ({
-            profile_uuid: profile.uuid,
-            name: server.name,
-            slug: server.slug,
-            description: server.description,
-            type: server.type,
-            command: server.type === McpServerType.STDIO ? server.command : undefined,
-            args: server.type === McpServerType.STDIO ? server.args : undefined,
-            env: server.type === McpServerType.STDIO ? server.env : undefined,
-            url: server.type === McpServerType.STREAMABLE_HTTP ? server.url : undefined,
-            headers: server.type === McpServerType.STREAMABLE_HTTP ? server.headers : undefined,
-            notes: server.notes,
-            created_at: new Date(),
-            updated_at: new Date()
-          }));
-
-          await tx.insert(mcpServersTable).values(serversToAdd);
-          console.log(`✅ Added ${SAMPLE_MCP_SERVERS.length} sample MCP servers for profile ${profile.uuid}`);
-        } catch (error) {
-          console.error('Failed to add sample MCP servers:', error);
-          // Don't fail the verification process if sample servers can't be added
-        }
-      });
+      await createDefaultProject(user.id);
     } catch (projectError) {
       console.error('Error creating default project:', projectError);
       // We won't fail the verification process if project creation fails

--- a/lib/default-project-creation.ts
+++ b/lib/default-project-creation.ts
@@ -1,22 +1,49 @@
 import { eq } from 'drizzle-orm';
 
 import { db } from '@/db';
-import { profilesTable, projectsTable } from '@/db/schema';
+import { profilesTable, projectsTable, users } from '@/db/schema';
 
 import { addSampleMcpServersForNewUser } from './sample-mcp-servers';
 
 /**
- * Creates a default project and workspace for a new user
+ * Creates a default project and workspace for a new user, once.
  *
- * This is used in both:
+ * The only place that creates a 'Default Hub'. It used to be three — this
+ * helper, the verify-email route and getProjects — and the one guard among
+ * them was a check-then-create that two concurrent requests both pass. In
+ * production that left 27 users with a duplicate pair, created 0.0-0.1 seconds
+ * apart, all of them OAuth sign-ups where a fresh session fires several
+ * requests at once.
+ *
+ * The lock is on the user row, which is what the two callers have in common;
+ * checking for an existing project without it does not help, because both
+ * transactions read before either writes. app/api/auth/register/route.ts
+ * already uses the same pattern against the same class of race.
+ *
+ * Callers:
  * - OAuth sign-in flow (lib/auth.ts)
  * - Email registration flow (app/api/auth/register/route.ts)
+ * - Email verification (app/api/auth/verify-email/route.ts)
+ * - First page load with no project (app/actions/projects.ts)
  *
  * @param userId - The user ID to create the project for
- * @returns The created project with active profile UUID
+ * @returns The user's default project, existing or newly created
  */
 export async function createDefaultProject(userId: string) {
   const result = await db.transaction(async (tx) => {
+    // Serialise concurrent callers for this user before looking.
+    await tx.select({ id: users.id }).from(users).where(eq(users.id, userId)).for('update');
+
+    const [existing] = await tx
+      .select()
+      .from(projectsTable)
+      .where(eq(projectsTable.user_id, userId))
+      .limit(1);
+
+    if (existing) {
+      return { project: existing, profileUuid: null as string | null };
+    }
+
     // Create the project
     const [project] = await tx
       .insert(projectsTable)
@@ -50,9 +77,13 @@ export async function createDefaultProject(userId: string) {
   });
 
   // Add sample MCP servers for the new user (outside transaction)
-  // This allows the project creation to succeed even if server addition fails
+  // This allows the project creation to succeed even if server addition fails.
+  // Skipped when the project already existed — the samples were added the first
+  // time, and adding them again is what a second call used to do.
   try {
-    await addSampleMcpServersForNewUser(result.profileUuid);
+    if (result.profileUuid) {
+      await addSampleMcpServersForNewUser(result.profileUuid);
+    }
   } catch (error) {
     console.error('Failed to add sample MCP servers for new user:', error);
     // Don't fail the project creation if sample servers can't be added

--- a/tests/security/default-project-behaviour.test.ts
+++ b/tests/security/default-project-behaviour.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const forUpdate = vi.fn(async () => [{ id: 'u1' }]);
+const existingProjects = vi.fn(async () => [] as unknown[]);
+const insertValues = vi.fn();
+const returning = vi.fn();
+const addSamples = vi.fn(async () => undefined);
+
+/** A `tx` that answers the two selects the helper makes, in order. */
+function makeTx() {
+  let selectCall = 0;
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => {
+          selectCall += 1;
+          // first select is the FOR UPDATE lock, second is the existence check
+          return selectCall === 1
+            ? { for: forUpdate }
+            : { limit: existingProjects };
+        },
+      }),
+    }),
+    insert: () => ({ values: (v: unknown) => (insertValues(v), { returning }) }),
+    update: () => ({ set: () => ({ where: () => ({ returning }) }) }),
+  };
+}
+
+vi.mock('@/db', () => ({
+  db: { transaction: async (fn: (tx: unknown) => unknown) => fn(makeTx()) },
+}));
+vi.mock('@/lib/sample-mcp-servers', () => ({ addSampleMcpServersForNewUser: addSamples }));
+
+const { createDefaultProject } = await import('@/lib/default-project-creation');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  returning.mockResolvedValue([{ uuid: 'new-project', user_id: 'u1' }]);
+  existingProjects.mockResolvedValue([]);
+});
+
+/**
+ * Two concurrent callers for a brand-new user both used to reach the insert.
+ * The lock is what stops that; the existence check is what makes the second
+ * caller return the first one's work instead of duplicating it.
+ */
+describe('createDefaultProject creates at most one project per user', () => {
+  it('takes the lock before it looks', async () => {
+    await createDefaultProject('u1');
+
+    expect(forUpdate).toHaveBeenCalled();
+  });
+
+  it('inserts nothing when the user already has a project', async () => {
+    const already = { uuid: 'already-there', user_id: 'u1' };
+    existingProjects.mockResolvedValue([already]);
+
+    const result = await createDefaultProject('u1');
+
+    expect(insertValues).not.toHaveBeenCalled();
+    expect(result).toEqual(already);
+  });
+
+  it('does not add the sample servers a second time', async () => {
+    existingProjects.mockResolvedValue([{ uuid: 'already-there', user_id: 'u1' }]);
+
+    await createDefaultProject('u1');
+
+    expect(addSamples).not.toHaveBeenCalled();
+  });
+
+  it('still creates one for a user who has none', async () => {
+    const result = await createDefaultProject('u1');
+
+    expect(insertValues).toHaveBeenCalled();
+    expect(result).toEqual({ uuid: 'new-project', user_id: 'u1' });
+    expect(addSamples).toHaveBeenCalled();
+  });
+});

--- a/tests/security/default-project-once.test.ts
+++ b/tests/security/default-project-once.test.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * A user ended up with two 'Default Hub' projects because three separate places
+ * created one, and the only guarded site used a check-then-create that two
+ * concurrent requests both pass.
+ *
+ * In production 27 users have a duplicate pair, created 0.0-0.1 seconds apart —
+ * all of them OAuth sign-ups, where a fresh session fires several requests at
+ * once. 23 of the 27 have MCP servers under both copies.
+ */
+describe('the default project is created in one place, under a lock', () => {
+  const helper = fs.readFileSync('lib/default-project-creation.ts', 'utf8');
+
+  it('serialises concurrent callers on the user row', () => {
+    // Without a lock two transactions both see no project and both insert.
+    // The registration route already uses this pattern for the same reason.
+    expect(helper).toMatch(/\.for\(\s*['"]update['"]\s*\)/);
+  });
+
+  it('returns the existing project instead of creating a second', () => {
+    expect(helper).toMatch(/existing/i);
+  });
+
+  it('is the only place that creates a Default Hub', () => {
+    const others = ['app/actions/projects.ts', 'app/api/auth/verify-email/route.ts']
+      .filter((file) => /name:\s*['"]Default Hub['"]/.test(fs.readFileSync(file, 'utf8')));
+
+    expect(others).toEqual([]);
+  });
+
+  it('the callers import and call the helper', () => {
+    // Grepping for the name alone is not enough: my first version passed while
+    // verify-email called it without importing it, and only tsc caught that.
+    for (const file of ['app/actions/projects.ts', 'app/api/auth/verify-email/route.ts']) {
+      const src = fs.readFileSync(file, 'utf8');
+      expect(src).toMatch(/import\s*\{[^}]*createDefaultProject[^}]*\}\s*from/);
+      expect(src).toMatch(/createDefaultProject\s*\(/);
+    }
+  });
+});

--- a/tests/security/default-project-once.test.ts
+++ b/tests/security/default-project-once.test.ts
@@ -20,9 +20,11 @@ describe('the default project is created in one place, under a lock', () => {
     expect(helper).toMatch(/\.for\(\s*['"]update['"]\s*\)/);
   });
 
-  it('returns the existing project instead of creating a second', () => {
-    expect(helper).toMatch(/existing/i);
-  });
+  // "returns the existing project instead of creating a second" used to live
+  // here as a grep for the word "existing", which the comments satisfy on their
+  // own — a mutation that always inserts passed it. That behaviour is asserted
+  // properly in default-project-behaviour.test.ts, against a mocked
+  // transaction, and that one does fail under the mutation.
 
   it('is the only place that creates a Default Hub', () => {
     const others = ['app/actions/projects.ts', 'app/api/auth/verify-email/route.ts']


### PR DESCRIPTION
## What is happening

27 users have two `Default Hub` projects. From production:

- the pairs are created **0.0–0.1 seconds apart**
- **all 27 are OAuth sign-ups** — 21 Google, 6 GitHub
- **none has a verified email**
- 23 of the 27 have MCP servers under **both** copies (125 servers in the older, 73 in the newer)

## Why

Three places created a `Default Hub`: this helper, `verify-email`, and `getProjects`. Only `getProjects` guarded, with `if (projects.length === 0)` — a check-then-create that two concurrent requests both pass. A fresh OAuth session fires several requests at once, which is exactly the window, and it matches the 0.0–0.1s spacing.

**The originally reported cause was different and does not hold.** The finding said registration and email verification both create one. None of the 27 has a verified email, so none of them went through that path. I repeated that explanation before checking, and it was wrong.

## The fix

`createDefaultProject` is the only place that creates one now, and it takes a lock on the user row before looking. The lock is the part that matters — re-checking without it changes nothing, because both transactions read before either writes. `app/api/auth/register/route.ts` already uses this pattern against the same class of race.

When a project already exists it is returned as-is, and the sample MCP servers are not added again.

## What this deliberately does not do

**It does not touch the 27 existing pairs.** Both hubs are reachable through `components/project-switcher.tsx`, so this is visible clutter rather than lost data. Merging them means deciding which copy's profile keeps the 199 servers spread across them, on live accounts — a product decision that does not have to be made to stop the bleeding. Happy to do it as a follow-up with a rule you pick.

## Tests

Written failing first. One of them, in its first version, **passed while `verify-email` called the helper without importing it** — `tsc` caught what the test missed. It now checks the import as well as the call, and is mutation-checked: deleting the import fails it.

## Verification

- `tsc --noEmit`: clean for `app/` and `lib/`
- `eslint`: 0 errors on every touched file
- Full suite: **191 failures, identical to `main`**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790982677&installation_model_id=430597&pr_number=225&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F225&signature=9ecdcea5a4b1d5c65d8031ab04d77b2bed942ee79b222dd68addca9b9d274656"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Ensure each user receives at most one default hub, even when onboarding requests run concurrently.

Bug Fixes:
- Prevent duplicate default projects when concurrent requests create a user's initial hub.
- Avoid re-adding sample MCP servers when an existing default project is reused.

Enhancements:
- Centralize default project creation across authentication and project-loading flows with user-row locking and existence checks.
- Add coverage for one-time creation, locking, reuse of existing projects, and centralized callers.

Tests:
- Add security tests verifying default project creation is serialized and occurs through a single helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate default projects when multiple setup requests occur simultaneously.
  - Existing projects are now reused without duplicating profiles or sample integrations.
  - Default project setup is applied consistently during initial loading and email verification.
  - Improved reliability when initializing new accounts while preserving existing error handling.

- **Tests**
  - Added coverage for concurrent setup requests and consistent default-project behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->