### PR TITLE
infra: bound the uv cache, and check the disk more than once a day

### DIFF
--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -185,28 +185,48 @@ fi
 #
 # Run as the directory's owner rather than as root — root would leave
 # root-owned entries behind that the app user could not later evict.
+# What happened to the uv cache, so the exit status can say so. A retention job
+# that reports success while skipping the thing it exists to do is worse than no
+# job: monitoring cannot tell it apart from a working one.
+UV_RESULT="absent"
+
 if [ -d "$UV_CACHE_DIR" ]; then
   CACHE_OWNER="$(stat -c '%U' "$UV_CACHE_DIR")"
-  OWNER_HOME="$(getent passwd "$CACHE_OWNER" | cut -d: -f6)"
+  # `|| true` because getent exits non-zero for an unknown user, and with
+  # `set -e` that would kill the whole script here — taking the docker prune
+  # and the disk check down with it over an ownership entry this job could
+  # simply have reported and worked around.
+  OWNER_HOME="$(getent passwd "$CACHE_OWNER" | cut -d: -f6 || true)"
 
   # Resolve uv by absolute path rather than through PATH. `sudo -u` runs with a
   # minimal environment that does not include ~/.local/bin, which is where uv
   # installs itself — so a PATH lookup reports "not installed" on a host where
-  # it plainly is, and the job silently skips the thing it exists to do. That
-  # is worse than not having the job: the timer still exits 0.
+  # it plainly is.
   UV_BIN=""
-  for candidate in "${OWNER_HOME}/.local/bin/uv" /usr/local/bin/uv /usr/bin/uv; do
-    if [ -x "$candidate" ]; then UV_BIN="$candidate"; break; fi
+  for candidate in "${OWNER_HOME:+${OWNER_HOME}/.local/bin/uv}" /usr/local/bin/uv /usr/bin/uv; do
+    if [ -n "$candidate" ] && [ -x "$candidate" ]; then UV_BIN="$candidate"; break; fi
   done
+
+  if [ -z "$OWNER_HOME" ]; then
+    log "WARNING: no passwd entry for ${CACHE_OWNER} (owner of ${UV_CACHE_DIR})"
+  fi
 
   if [ -n "$UV_BIN" ]; then
     log "uv cache (${UV_CACHE_DIR}, owner ${CACHE_OWNER}) — removing unreferenced entries"
-    run sudo -u "$CACHE_OWNER" env UV_CACHE_DIR="$UV_CACHE_DIR" "$UV_BIN" cache prune
+    # Not left to `set -e`: a failing prune must not skip the disk check, which
+    # is the part that says how bad things are.
+    if run sudo -u "$CACHE_OWNER" env UV_CACHE_DIR="$UV_CACHE_DIR" "$UV_BIN" cache prune; then
+      UV_RESULT="pruned"
+    else
+      UV_RESULT="failed"
+      log "WARNING: uv cache prune failed"
+    fi
   else
+    UV_RESULT="no-uv"
     log "WARNING: uv not found for ${CACHE_OWNER} — the uv cache is NOT being pruned"
   fi
 else
-  log "no uv cache at ${UV_CACHE_DIR} — skipping"
+  log "no uv cache at ${UV_CACHE_DIR} — nothing to prune"
 fi
 
 # Restore any tag the prune stripped off an image it otherwise kept (see the
@@ -259,6 +279,8 @@ fi
 
 # A prune that leaves the disk critically full is not a success; say so loudly
 # so the timer's exit status carries the signal.
+UNHEALTHY=0
+
 USED_PCT=$(df --output=pcent / | tail -1 | tr -dc '0-9')
 # 85% on this disk is ~80G free, which sounds comfortable and is not: the fill
 # that caused the outage moved faster than that between two runs. Warning at 75
@@ -267,6 +289,20 @@ if [ "$USED_PCT" -ge 75 ]; then
   echo "WARNING: / still ${USED_PCT}% full after pruning — investigate before it reaches Postgres" >&2
   echo "         largest consumers:" >&2
   du -xh --max-depth=2 /var /home 2>/dev/null | sort -rh | head -5 >&2
-  exit 1
+  UNHEALTHY=1
+else
+  log "ok — / is ${USED_PCT}% full"
 fi
-log "ok — / is ${USED_PCT}% full"
+
+# A cache that exists and was not pruned is a failure even when the disk still
+# looks fine — it is how the disk stops looking fine. Only "pruned" and
+# "absent" are success; a dry run reports whatever it would have done.
+case "$UV_RESULT" in
+  pruned|absent) ;;
+  *)
+    echo "WARNING: the uv cache was not pruned (${UV_RESULT}) — this job is not doing its main task" >&2
+    [ "$DRY_RUN" -eq 1 ] || UNHEALTHY=1
+    ;;
+esac
+
+exit "$UNHEALTHY"

--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -52,6 +52,11 @@ SYSTEM_KEEP="${SYSTEM_KEEP:-72h}"
 # Short for CI output: every one of those images exists in GHCR as well.
 RUNNER_KEEP="${RUNNER_KEEP:-24h}"
 
+# The MCP package manager's uv cache. Default mirrors
+# PackageManagerConfig.UV_CACHE_DIR in lib/mcp/package-manager/config.ts, which
+# is PACKAGE_STORE_DIR/uv-cache; override it here the same way the app does.
+UV_CACHE_DIR="${MCP_UV_CACHE_DIR:-/var/mcp-packages/uv-cache}"
+
 log() { printf '[prune %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 free_gb() { df -BG --output=avail / | tail -1 | tr -dc '0-9'; }
 
@@ -83,7 +88,11 @@ Description=Daily prune of Docker build artefacts
 [Timer]
 # 04:20 rather than on the hour: nothing else on this host runs then, and the
 # Ofelia jobs cluster at :00.
-OnCalendar=*-*-* 04:20:00
+# Every six hours, not nightly. On 2026-09-02 the 04:20 run reported 168G free
+# and the disk was full by 23:42 — a daily cadence cannot catch a fill that
+# takes nineteen hours, and the cost of running this more often is a few
+# seconds of docker and uv bookkeeping.
+OnCalendar=*-*-* 00,06,12,18:20:00
 Persistent=true
 RandomizedDelaySec=600
 
@@ -158,6 +167,48 @@ else
   log "no ${RUNNER_USER} user — skipping the rootless daemon"
 fi
 
+# ─── The uv cache ──────────────────────────────────────────────────────────
+#
+# This is what actually filled the disk. On 2026-09-02 the timer ran at 04:21,
+# reclaimed 2G of images and reported the disk 68% full with 168G free; by 23:42
+# it was 100% full, Postgres was PANICking on every checkpoint, and Traefik had
+# pulled the app out of the load balancer — the outage the header warns about,
+# arriving from a direction it did not cover. `uv cache prune` then reclaimed
+# 289 GiB.
+#
+# Docker retention was working the whole time: images were 16G of a 532G disk.
+# The MCP package manager's uv cache had simply never been bounded.
+#
+# `prune`, not `clean`: prune removes only entries no longer referenced by an
+# installed environment, so a cached wheel an MCP server still depends on stays.
+# clean would empty it and make the next server start re-download everything.
+#
+# Run as the directory's owner rather than as root — root would leave
+# root-owned entries behind that the app user could not later evict.
+if [ -d "$UV_CACHE_DIR" ]; then
+  CACHE_OWNER="$(stat -c '%U' "$UV_CACHE_DIR")"
+  OWNER_HOME="$(getent passwd "$CACHE_OWNER" | cut -d: -f6)"
+
+  # Resolve uv by absolute path rather than through PATH. `sudo -u` runs with a
+  # minimal environment that does not include ~/.local/bin, which is where uv
+  # installs itself — so a PATH lookup reports "not installed" on a host where
+  # it plainly is, and the job silently skips the thing it exists to do. That
+  # is worse than not having the job: the timer still exits 0.
+  UV_BIN=""
+  for candidate in "${OWNER_HOME}/.local/bin/uv" /usr/local/bin/uv /usr/bin/uv; do
+    if [ -x "$candidate" ]; then UV_BIN="$candidate"; break; fi
+  done
+
+  if [ -n "$UV_BIN" ]; then
+    log "uv cache (${UV_CACHE_DIR}, owner ${CACHE_OWNER}) — removing unreferenced entries"
+    run sudo -u "$CACHE_OWNER" env UV_CACHE_DIR="$UV_CACHE_DIR" "$UV_BIN" cache prune
+  else
+    log "WARNING: uv not found for ${CACHE_OWNER} — the uv cache is NOT being pruned"
+  fi
+else
+  log "no uv cache at ${UV_CACHE_DIR} — skipping"
+fi
+
 # Restore any tag the prune stripped off an image it otherwise kept (see the
 # header). RESTORE is the operative word: the mapping is captured before
 # pruning and put back exactly as it was.
@@ -209,8 +260,13 @@ fi
 # A prune that leaves the disk critically full is not a success; say so loudly
 # so the timer's exit status carries the signal.
 USED_PCT=$(df --output=pcent / | tail -1 | tr -dc '0-9')
-if [ "$USED_PCT" -ge 85 ]; then
+# 85% on this disk is ~80G free, which sounds comfortable and is not: the fill
+# that caused the outage moved faster than that between two runs. Warning at 75
+# leaves a margin worth acting on rather than one worth noting.
+if [ "$USED_PCT" -ge 75 ]; then
   echo "WARNING: / still ${USED_PCT}% full after pruning — investigate before it reaches Postgres" >&2
+  echo "         largest consumers:" >&2
+  du -xh --max-depth=2 /var /home 2>/dev/null | sort -rh | head -5 >&2
   exit 1
 fi
 log "ok — / is ${USED_PCT}% full"

--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -288,7 +288,11 @@ USED_PCT=$(df --output=pcent / | tail -1 | tr -dc '0-9')
 if [ "$USED_PCT" -ge 75 ]; then
   echo "WARNING: / still ${USED_PCT}% full after pruning — investigate before it reaches Postgres" >&2
   echo "         largest consumers:" >&2
-  du -xh --max-depth=2 /var /home 2>/dev/null | sort -rh | head -5 >&2
+  # `|| true` for the same reason as the systemctl pipeline in --install-timer,
+  # and I reintroduced the bug this file already documents: `head` closes the
+  # pipe, sort takes SIGPIPE, and under pipefail that exit 141 aborts the script
+  # — here, right before the exit status that carries the warning.
+  du -xh --max-depth=2 /var /home 2>/dev/null | sort -rh | head -5 >&2 || true
   UNHEALTHY=1
 else
   log "ok — / is ${USED_PCT}% full"


### PR DESCRIPTION
## What happened

The disk filled and took production down.

- **04:20** — the prune timer ran, reclaimed 2G of images, reported `/ is 68% full`, 168G free
- **23:42** — 100% full. Postgres began PANICking on every checkpoint: `could not write to file "pg_logical/replorigin_checkpoint.tmp": No space left on device`, crash-looping through `terminated by signal 6: Aborted`
- the app's health check returned 503 (`database: false`), **Traefik pulled it out of the load balancer**, and the site served **404**
- `uv cache prune` reclaimed **289 GiB** and everything recovered

This is precisely the outage this script's header predicted — *"If it ever fills, Postgres goes down with it — the failure is not 'CI gets slow', it is an outage"* — arriving from a direction it did not cover.

**Docker retention was working the whole time.** Images were 16G of a 532G disk. The MCP package manager's uv cache had simply never been bounded.

## The changes

**The uv cache is pruned.** As the directory's owner rather than as root, so no root-owned entries are left that the app user could not later evict. `prune` and not `clean` — prune drops only entries no installed environment still references, so a wheel an MCP server depends on survives and the next start does not re-download everything.

**uv is resolved by absolute path.** My first version looked it up through `PATH`, and `sudo -u` runs with a minimal environment that excludes `~/.local/bin`, which is where uv installs itself. The dry run said *"uv not on pluggedin's PATH — skipping"* on a host where uv is plainly present. It would have skipped the cache and still exited 0 — a retention job that silently does nothing is worse than no job, because it also removes the suspicion that anything is wrong.

**The timer runs every six hours instead of nightly, and the warning threshold drops from 85% to 75%.** A daily check cannot catch a fill that takes nineteen hours. And 85% of this disk is ~80G, which sounds comfortable and is not — the fill that caused this moved further than that between two runs. The warning now also prints the largest consumers, so whoever reads it does not start from `du`.

## Verified

`bash -n` clean; dry run exercised on the production host and shown to resolve the real uv binary and the real cache directory:

```
[prune] uv cache (/var/mcp-packages/uv-cache, owner pluggedin) — removing unreferenced entries
    would run: sudo -u pluggedin env UV_CACHE_DIR=… /home/pluggedin/.local/bin/uv cache prune
```

## Note on how this got here

I contributed to the fill: many pushes today, each triggering a ~2.45GB image build on this host. That was not the main consumer — 289 GiB of uv cache was — but it was not nothing, and I did not notice the disk while working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/226"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790986091&installation_model_id=430597&pr_number=226&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F226&signature=3523dae8d237d166df1f7c5f226627ed0e0598d32502f40bb6b3dda5a4ef6e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Bound the MCP uv cache and increase disk monitoring frequency to reduce the risk of production outages caused by filesystem exhaustion.

New Features:
- Add pruning of the MCP package manager’s uv cache while preserving entries referenced by installed environments.
- Run artifact cleanup and disk checks every six hours and report the largest disk consumers when usage is high.

Bug Fixes:
- Prevent unbounded uv cache growth from filling the production disk and taking the application offline.
- Ensure uv cache cleanup runs under the cache owner and resolves uv reliably without depending on the sudo user’s PATH.

Enhancements:
- Treat skipped or failed uv cache pruning and high disk usage as unhealthy job outcomes, while continuing to perform disk checks after cleanup failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved automated build-artifact cleanup to manage the MCP cache more reliably.
  - Cache-pruning failures are now reported and reflected in the final health status without preventing disk checks.
  - Cleanup now runs every six hours instead of daily.
  - Added clearer warnings when the cache tool is unavailable or pruning fails.
  - Disk-usage warnings now appear at 75% capacity instead of 85%.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->