### PR TITLE
docs(security): credit the five reporters, by name and by advisory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,6 +17,7 @@ Plugged.in takes security seriously as a collaborative platform for the Model Co
 9. [Security Best Practices](#security-best-practices)
 10. [Environment Security](#environment-security)
 11. [Supported Versions](#supported-versions)
+12. [Acknowledgements](#acknowledgements)
 
 ## Reporting Security Vulnerabilities
 
@@ -648,9 +649,38 @@ const RATE_LIMITS = {
    - Add API key rotation mechanism
    - Enhanced API usage analytics and monitoring
 
+## Acknowledgements
+
+Every fix below came from someone who looked at this code carefully and told us
+privately before telling anyone else. Thank you — the reports were specific
+enough to reproduce from, which is the difference between a report and a lead.
+
+| Reported by | Issue | Advisory | Fixed in |
+|---|---|---|---|
+| Syed Anas Mohiuddin ([@SyedAnas01](https://github.com/SyedAnas01)) | OS command injection through MCP server `args`, reaching an unescaped shell in the pnpm/uv install path | [GHSA-m623-vm42-63fg](https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-m623-vm42-63fg) | `ebadd474` (#204) |
+| [EQSTLab](https://github.com/EQSTLab) | The same install-path injection, reached through discovery on a server the caller owns | [GHSA-qm2x-3m6j-c7fc](https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-qm2x-3m6j-c7fc) | `ebadd474` (#204) |
+| [EQSTLab](https://github.com/EQSTLab) | Command injection in `testMcpConnection` via `` exec(`which ${command}`) `` | [GHSA-m29x-gj35-9w8g](https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-m29x-gj35-9w8g) | `c3aece0f` (#208) |
+| [@tonghuaroot](https://github.com/tonghuaroot) | SSRF guard bypass via IPv4-mapped IPv6 hosts — the guards matched hostname text, which never matches the bracketed, hex-canonicalised form Node produces | [GHSA-gmhc-h765-37cg](https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-gmhc-h765-37cg) | `0f34f682` (#228) |
+| [@0xParth](https://github.com/0xParth) | Broken access control: the REST unshare endpoint authenticated the caller but never checked profile ownership, so any account could delete another tenant's shares | [GHSA-fv94-f4f5-vr99](https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-fv94-f4f5-vr99) | `0f34f682` (#228) |
+
+Two of these reports were worth more than the bug they named.
+
+`@tonghuaroot`'s SSRF report identified the *class* of mistake, not just the
+instance: blocking hosts by matching the text of a hostname cannot be made
+reliable, because one address has many spellings. Fixing only the reported
+IPv4-mapped form would have left `http://[::1]/` working, since a URL hostname
+carries brackets and never equalled `::1` either. The guards now parse the
+address instead of reading it.
+
+`@0xParth` asked us to audit the sibling REST endpoints rather than only patch
+the one that was broken, and pointed at the real defect: the equivalent server
+action had always checked ownership. One rule with two implementations, one of
+them wrong. The check now lives in a single place.
+
 ---
 
-**Last Updated**: January 15, 2025 (Critical vulnerability fixes - XSS, SSRF, URL validation, Admin Email Security, Enhanced Sanitization, Translation Retry Logic, Environment Validation)
+**Last Updated**: September 3, 2026 (Five reported advisories fixed and credited — see Acknowledgements)
+**Previously Updated**: January 15, 2025 (Critical vulnerability fixes - XSS, SSRF, URL validation, Admin Email Security, Enhanced Sanitization, Translation Retry Logic, Environment Validation)
 **Security Improvements**: Secure tokens, admin roles, audit logging, rate limiting, XSS protection, centralized sanitization, robust error handling, environment validation
 **Next Review**: April 2025
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,9 @@ Plugged.in takes security seriously as a collaborative platform for the Model Co
 9. [Security Best Practices](#security-best-practices)
 10. [Environment Security](#environment-security)
 11. [Supported Versions](#supported-versions)
-12. [Acknowledgements](#acknowledgements)
+12. [Security Contact](#security-contact)
+13. [Recent Security Enhancements](#recent-security-enhancements-january-2025---admin-email-system)
+14. [Acknowledgements](#acknowledgements)
 
 ## Reporting Security Vulnerabilities
 
@@ -578,7 +580,7 @@ WHERE user_id IN (SELECT id FROM users WHERE is_admin = true);
 - Review and update security documentation
 - Conduct admin security training
 
-### 📊 Additional Security Enhancements (January 2025 - Latest Updates)
+### 📊 Additional Security Enhancements (January 2025)
 
 #### 6. Centralized HTML Sanitization
 - **Implementation**: Created `lib/sanitization.ts` for consistent security
@@ -682,6 +684,6 @@ them wrong. The check now lives in a single place.
 **Last Updated**: September 3, 2026 (Five reported advisories fixed and credited — see Acknowledgements)
 **Previously Updated**: January 15, 2025 (Critical vulnerability fixes - XSS, SSRF, URL validation, Admin Email Security, Enhanced Sanitization, Translation Retry Logic, Environment Validation)
 **Security Improvements**: Secure tokens, admin roles, audit logging, rate limiting, XSS protection, centralized sanitization, robust error handling, environment validation
-**Next Review**: April 2025
+**Next Review**: December 2026
 
 For questions about this security policy or to report vulnerabilities, please contact our security team or create a GitHub Security Advisory. 


### PR DESCRIPTION
Five people reported vulnerabilities privately. All five are fixed. None of them appeared anywhere in this repository.

This adds an **Acknowledgements** section to `SECURITY.md` naming each reporter, the issue, the advisory, and the commit that closed it.

| Reported by | Advisory | Fixed in |
|---|---|---|
| Syed Anas Mohiuddin ([@SyedAnas01](https://github.com/SyedAnas01)) | GHSA-m623-vm42-63fg | `ebadd474` (#204) |
| [EQSTLab](https://github.com/EQSTLab) | GHSA-qm2x-3m6j-c7fc | `ebadd474` (#204) |
| [EQSTLab](https://github.com/EQSTLab) | GHSA-m29x-gj35-9w8g | `c3aece0f` (#208) |
| [@tonghuaroot](https://github.com/tonghuaroot) | GHSA-gmhc-h765-37cg | `0f34f682` (#228) |
| [@0xParth](https://github.com/0xParth) | GHSA-fv94-f4f5-vr99 | `0f34f682` (#228) |

**Commits verified, not inferred.** The two older fixes landed on 2026-09-01, close enough to the report dates that guessing would have been easy and wrong. I checked the diffs: `ebadd474` is the commit that replaced `execAsync` with `execFileAsync` in the pnpm and uv handlers, and `c3aece0f` is the one that removed `` exec(`which ${command}`) `` from `testMcpConnection`.

**Names, not just handles.** Syed Anas Mohiuddin's report closed with a request to be credited by name if it led to a fix. The table carries names wherever they were given.

**Two reports get their own paragraph**, because what they contributed was bigger than the bug they named — `@tonghuaroot` identified the class of mistake rather than the instance, and `@0xParth` asked for an audit of the sibling endpoints and pointed at the real defect. Both changed the shape of the fix, and the section says so.

Also: the `Last Updated` line said *January 15, 2025* after a year of security work. It now reads today, with the old line kept below rather than discarded.

Advisories are published separately, with `patched_versions` pointing at these same commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791043406&installation_model_id=430597&pr_number=229&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F229&signature=258f97e391b5888d7ddb9dfee1f3da5b2752f4c51abc62a85697b9e304d99b5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Update the security policy to acknowledge five vulnerability reporters and document the advisories and fixes associated with their reports.

Enhancements:
- Document and credit five private vulnerability reporters, their security advisories, and the commits that fixed the issues.
- Add context for the broader security improvements prompted by the SSRF and access-control reports.

Documentation:
- Update SECURITY.md navigation and revision metadata, clarify the security enhancements section date, and add an acknowledgements section covering five fixed vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added acknowledgements for five reported security vulnerabilities, including command injection, SSRF, and broken access control.
  * Documented security enhancements for SSRF address parsing and centralized ownership checks.
  * Updated the security policy table of contents and metadata, including the latest update and next review dates.
  * Renamed the January 2025 security enhancement heading for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->