### PR TITLE
fix(infra): protect the tag that is actually deployed, not a hardcoded one

### DIFF
--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -20,8 +20,18 @@ set -euo pipefail
 # Overridable so the locking itself can be exercised without root or a real
 # deploy; production uses the default.
 LOCK_FILE="${PLUGGEDIN_LOCK_FILE:-/var/lock/pluggedin-deploy.lock}"
-if exec 9>"$LOCK_FILE" 2>/dev/null && command -v flock >/dev/null 2>&1; then
-  flock -w 600 9 || { echo "could not acquire ${LOCK_FILE} within 600s" >&2; exit 1; }
+#
+# The braces matter: `exec 9>"$FILE" 2>/dev/null` would redirect stderr for the
+# whole deploy, silencing every error this script reports. Scoped to the exec.
+if command -v flock >/dev/null 2>&1; then
+  if { exec 9>"$LOCK_FILE"; } 2>/dev/null; then
+    flock -w 600 9 || { echo "could not acquire ${LOCK_FILE} within 600s" >&2; exit 1; }
+  else
+    # A deploy is operator-initiated and watched, so this warns rather than
+    # refusing. The retention job is the unattended one and treats the same
+    # condition as a failed run.
+    echo "WARNING: cannot open ${LOCK_FILE} — deploying WITHOUT retention-job serialisation" >&2
+  fi
 fi
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/infra/scripts/deploy.sh
+++ b/infra/scripts/deploy.sh
@@ -13,6 +13,17 @@
 
 set -euo pipefail
 
+# Held for the whole deploy so the retention job cannot prune underneath it —
+# see the same lock in infra/scripts/prune-build-artifacts.sh. Deploys wait
+# rather than skip: the prune is short, and a deploy the operator asked for
+# should happen.
+# Overridable so the locking itself can be exercised without root or a real
+# deploy; production uses the default.
+LOCK_FILE="${PLUGGEDIN_LOCK_FILE:-/var/lock/pluggedin-deploy.lock}"
+if exec 9>"$LOCK_FILE" 2>/dev/null && command -v flock >/dev/null 2>&1; then
+  flock -w 600 9 || { echo "could not acquire ${LOCK_FILE} within 600s" >&2; exit 1; }
+fi
+
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INFRA_DIR="${REPO_ROOT}/infra"
 # /run/sops is the production location: /run is tmpfs, so the decrypted

--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -48,14 +48,6 @@ set -euo pipefail
 # deploy; production uses the default.
 LOCK_FILE="${PLUGGEDIN_LOCK_FILE:-/var/lock/pluggedin-deploy.lock}"
 
-# A retention run that cannot get the lock is skipped, not queued: a deploy is
-# in progress, and the timer comes round again in six hours. Exit 0 — a skipped
-# run is not a failure.
-exec 9>"$LOCK_FILE" 2>/dev/null || true
-if command -v flock >/dev/null 2>&1 && ! flock -n 9; then
-  echo "[prune] a deploy holds ${LOCK_FILE} — skipping this run"
-  exit 0
-fi
 
 DRY_RUN=0
 INSTALL_TIMER=0
@@ -81,6 +73,37 @@ RUNNER_KEEP="${RUNNER_KEEP:-24h}"
 UV_CACHE_DIR="${MCP_UV_CACHE_DIR:-/var/mcp-packages/uv-cache}"
 
 log() { printf '[prune %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+
+# A retention run that cannot get the lock is skipped, not queued: a deploy is
+# in progress, and the timer comes round again in six hours. Exit 0 — a skipped
+# run is not a failure.
+#
+# Two things this has to get right, both found in review after being got wrong:
+#
+#   `exec 9>"$FILE" 2>/dev/null` redirects stderr for the REST OF THE SCRIPT,
+#   not just for the exec — redirections apply to the shell, and a bare exec is
+#   how you set them. Braces scope it to the exec alone.
+#
+#   A failed exec leaves fd 9 unopened, and `flock -n 9` then fails with "Bad
+#   file descriptor" — indistinguishable, to a test on its exit status, from
+#   "someone holds the lock". So an unwritable lock path would have skipped the
+#   prune silently and for ever, which is the exact failure this file exists to
+#   argue against.
+LOCK_HELD_BY_US=0
+if ! command -v flock >/dev/null 2>&1; then
+  log "note: flock not available — running without deploy serialisation"
+elif ! { exec 9>"$LOCK_FILE"; } 2>/dev/null; then
+  # Not fatal: a cleanup that never runs is what filled the disk once already.
+  # Loud, and carried into the exit status further down.
+  log "WARNING: cannot open ${LOCK_FILE} — running WITHOUT deploy serialisation"
+  LOCK_UNAVAILABLE=1
+elif ! flock -n 9; then
+  echo "[prune] a deploy holds ${LOCK_FILE} — skipping this run"
+  exit 0
+else
+  LOCK_HELD_BY_US=1
+fi
+LOCK_UNAVAILABLE="${LOCK_UNAVAILABLE:-0}"
 free_gb() { df -BG --output=avail / | tail -1 | tr -dc '0-9'; }
 
 if [ "$INSTALL_TIMER" -eq 1 ]; then
@@ -331,6 +354,12 @@ fi
 # A prune that leaves the disk critically full is not a success; say so loudly
 # so the timer's exit status carries the signal.
 UNHEALTHY=0
+
+# Running unserialised is a real risk to the deployed tag, so it must not be
+# reported as a clean run.
+if [ "$LOCK_UNAVAILABLE" -eq 1 ]; then
+  UNHEALTHY=1
+fi
 
 USED_PCT=$(df --output=pcent / | tail -1 | tr -dc '0-9')
 # 85% on this disk is ~80G free, which sounds comfortable and is not: the fill

--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -34,6 +34,29 @@
 #   afterwards — read from the running container, not hardcoded.
 set -euo pipefail
 
+# Deploys and the retention job must not overlap. The retention job reads which
+# tags to protect, prunes, then puts back any tag the prune stripped. A deploy
+# landing inside that window swaps the running container, so the job protects
+# the tag that was deployed a minute ago and the new one is left exposed —
+# raised in review on PR #231.
+#
+# Serialising is the fix rather than re-reading the container mid-run: this
+# script is explicitly forbidden from re-pointing a tag at whatever happens to
+# be running (see the restore block below), because during a rollback that
+# would rewrite deployment state to agree with the rollback.
+# Overridable so the locking itself can be exercised without root or a real
+# deploy; production uses the default.
+LOCK_FILE="${PLUGGEDIN_LOCK_FILE:-/var/lock/pluggedin-deploy.lock}"
+
+# A retention run that cannot get the lock is skipped, not queued: a deploy is
+# in progress, and the timer comes round again in six hours. Exit 0 — a skipped
+# run is not a failure.
+exec 9>"$LOCK_FILE" 2>/dev/null || true
+if command -v flock >/dev/null 2>&1 && ! flock -n 9; then
+  echo "[prune] a deploy holds ${LOCK_FILE} — skipping this run"
+  exit 0
+fi
+
 DRY_RUN=0
 INSTALL_TIMER=0
 for arg in "$@"; do

--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -26,12 +26,12 @@
 #
 #   TAGS ARE A DIFFERENT MATTER, and this bit is genuinely surprising: prune
 #   can drop a TAG from an image it is otherwise protecting. Observed here — a
-#   run removed `:live` while keeping the image, because the container holds it
-#   by ID and no longer needs the name. The stack still ran, but
-#   `IMAGE_TAG=live docker compose up` would then find nothing locally and try
-#   to pull a tag that does not exist in the registry, so the next deploy
-#   breaks rather than the current one. The script re-asserts the tags compose
-#   depends on afterwards.
+#   run removed the deployed tag while keeping the image, because the container
+#   holds it by ID and no longer needs the name. The stack still ran, but the
+#   next `docker compose up` would find nothing locally and try to pull a tag
+#   that does not exist in the registry, so the next deploy breaks rather than
+#   the current one. The script re-asserts the tags compose depends on
+#   afterwards — read from the running container, not hardcoded.
 set -euo pipefail
 
 DRY_RUN=0
@@ -125,9 +125,36 @@ fi
 BEFORE=$(free_gb)
 log "disk before: ${BEFORE}G free"
 
-# Record what the compose-referenced tags point at BEFORE pruning, so a tag the
-# prune strips can be put back on the same image rather than on a guess.
-COMPOSE_TAGS=(live)
+# Which tags matter is derived, not assumed. This was hardcoded to `live`,
+# which no longer appears anywhere: compose reads `${IMAGE_TAG:-latest}` and
+# deploys run without setting it, so the deployed tag is `latest`. Both halves
+# of the tag protection were therefore guarding a name nothing used — the
+# restore could not restore the tag a deploy needs, and the registry check
+# warned three times a day about the absence of a tag that was never meant to
+# exist, while never once looking at the one that does.
+#
+# The running container is the authority: it is by definition the tag a
+# rollback or redeploy has to find. `latest` is included as a floor because it
+# is compose's default and would be used by a deploy run with no IMAGE_TAG.
+# Order matters and must not be sorted: the running container's tag comes
+# first, because the registry check below asks about the DEPLOYED tag and a
+# sorted list would silently answer about a different one. (`latest` sorts
+# before `sha-abc1234`, so sorting made the check report on the wrong tag while
+# looking correct.)
+COMPOSE_TAGS=()
+RUNNING_TAG="$(docker inspect pluggedin-app --format '{{.Config.Image}}' 2>/dev/null \
+  | sed -n 's|^ghcr\.io/veriteknik/pluggedin-app:||p' || true)"
+# Written as ifs rather than `[ … ] && …`. Under `set -e` that form is exempt
+# only because the test is not the command after the final `&&` — a rule this
+# file has already been bitten by once, and not one worth relying on twice.
+if [ -n "$RUNNING_TAG" ]; then
+  COMPOSE_TAGS+=("$RUNNING_TAG")
+fi
+# compose's default, used by any deploy that does not set IMAGE_TAG.
+if [ "$RUNNING_TAG" != "latest" ]; then
+  COMPOSE_TAGS+=(latest)
+fi
+log "protecting tags: ${COMPOSE_TAGS[*]}"
 TAG_SNAPSHOT=()
 for tag in "${COMPOSE_TAGS[@]}"; do
   ref="ghcr.io/veriteknik/pluggedin-app:${tag}"
@@ -266,14 +293,15 @@ log "disk after: ${AFTER}G free (reclaimed $((AFTER - BEFORE))G)"
 # so treating a non-zero exit as proof of absence produces a warning that is
 # permanently wrong and quickly ignored. Root runs this timer and has no
 # registry credentials, which is exactly the case that would misreport.
-if REG_OUT=$(docker manifest inspect "ghcr.io/veriteknik/pluggedin-app:live" 2>&1); then
-  log "ok — :live is present in GHCR"
+DEPLOYED_TAG="${COMPOSE_TAGS[0]:-latest}"
+if REG_OUT=$(docker manifest inspect "ghcr.io/veriteknik/pluggedin-app:${DEPLOYED_TAG}" 2>&1); then
+  log "ok — :${DEPLOYED_TAG} is present in GHCR"
 else
   case "$REG_OUT" in
     *denied*|*unauthorized*|*authentication*|*"no basic auth"*)
-      log "note: cannot check GHCR for :live (no registry credentials) — not asserting either way" ;;
+      log "note: cannot check GHCR for :${DEPLOYED_TAG} (no registry credentials) — not asserting either way" ;;
     *)
-      log "WARNING: :live is not in GHCR — the local image is the only copy" ;;
+      log "WARNING: :${DEPLOYED_TAG} is not in GHCR — the local image is the only copy" ;;
   esac
 fi
 


### PR DESCRIPTION
The retention job guarded `:live`. **Nothing uses that name** — compose reads `${IMAGE_TAG:-latest}` and deploys run without setting it, so the deployed tag is `latest`.

So both halves of the tag protection were pointed at a name that does not exist:

- **The restore could not restore anything.** The script's stated purpose is that a prune stripping the tag "breaks the next deploy rather than the current one". That is exactly the case it was not covering.
- **The registry check has been warning four times a day, truthfully and uselessly.** `WARNING: :live is not in GHCR` — correct, and about a tag nobody wants. Meanwhile it never once asked about `latest`. An always-on warning is one nobody reads, and this one was concealing the absence of the check that matters.

```
before:  WARNING: :live is not in GHCR — the local image is the only copy
after:   protecting tags: latest
         ok — :latest is present in GHCR
```

The tag now comes from the running container — by definition what a redeploy has to find — with `latest` as a floor for a deploy that sets no `IMAGE_TAG`.

## Two bugs in my own fix, found by testing it

**Ordering is load-bearing.** My first version piped through `sort -u`. With a deployed tag of `sha-abc1234`, `latest` sorts first, so the registry check reported on the wrong tag while looking entirely correct. The running tag is kept first and the list is not sorted.

**`[ … ] && …` under `set -e`.** That form is exempt only because the test is not the command following the final `&&`. This file's header already documents being bitten by a `set -e` trap once; these are `if` blocks rather than a second bet on that rule.

## Verified

Exercised in all three states with a stand-in `docker` on PATH:

| state | result |
|---|---|
| deployed tag `latest` | `protecting tags: latest`, `ok — :latest is present in GHCR`, exit 0 |
| deployed tag absent from GHCR | warns about **that** tag, not another |
| no running container | falls back to `latest`, exit 0 |

Remember to re-run `sudo bash infra/scripts/prune-build-artifacts.sh --install-timer` after merge — the timer runs the installed copy, not the checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791054292&installation_model_id=430597&pr_number=231&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F231&signature=529a7ab09fdd9e6d05e6c4e4950d6f6d28bedc5dd0d3b7e7832ae9fc07f59b96"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Protect deployed image tags and serialize deploys with retention pruning to keep redeploys recoverable.

Bug Fixes:
- Protect the actually deployed image tag, with a fallback to `latest`, during artifact pruning and registry verification.
- Prevent deploys and retention jobs from overlapping so tag protection remains consistent throughout each operation.

Enhancements:
- Report lock acquisition failures and skipped or unserialised retention runs clearly instead of silently treating them as successful.

Tests:
- Verify tag protection and registry checks for deployed, missing, and absent-container states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved deployment validation to consistently recognize the tag used by the running container.
  - Added support for Compose’s default `latest` tag during registry checks.
  - Updated snapshot workflows and deployment documentation to reflect current tag handling.
  - Strengthened safeguards against concurrent deployments and artifact cleanup.
  - Deployments wait for an available lock, while cleanup exits successfully when another deployment is active.
  - Added warnings and unhealthy status when cleanup cannot access its lock.
  - Preserved deployment diagnostics when lock handling encounters issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->