### PR TITLE
chore(deps): schedule dependency updates, and bound fflate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+# Dependabot configuration.
+#
+# Security updates are enabled at the repository level and do not need an entry
+# here — they fire on advisories regardless. What this file adds is the routine
+# half: without it, nothing looks at dependencies until an advisory is
+# published, which is how twenty alerts came to sit unattended.
+#
+# The pnpm ecosystem is "npm" to Dependabot; it reads pnpm-lock.yaml.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/Istanbul
+    # Enough to keep moving, few enough to actually review. Security PRs are
+    # not counted against this limit.
+    open-pull-requests-limit: 5
+    groups:
+      # One PR for the routine noise, so the interesting ones stand out.
+      patch-and-minor:
+        patterns: ["*"]
+        update-types: [minor, patch]
+    ignore:
+      # Majors are a deliberate migration, not a weekly chore. A major with an
+      # advisory still arrives, because security updates ignore this list.
+      - dependency-name: "*"
+        update-types: [version-update:semver-major]
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    labels: [dependencies]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: chore(actions)
+    labels: [dependencies]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: chore(docker)
+    labels: [dependencies]

--- a/infra/scripts/prune-build-artifacts.sh
+++ b/infra/scripts/prune-build-artifacts.sh
@@ -89,7 +89,6 @@ log() { printf '[prune %s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 #   "someone holds the lock". So an unwritable lock path would have skipped the
 #   prune silently and for ever, which is the exact failure this file exists to
 #   argue against.
-LOCK_HELD_BY_US=0
 if ! command -v flock >/dev/null 2>&1; then
   log "note: flock not available — running without deploy serialisation"
 elif ! { exec 9>"$LOCK_FILE"; } 2>/dev/null; then
@@ -100,8 +99,6 @@ elif ! { exec 9>"$LOCK_FILE"; } 2>/dev/null; then
 elif ! flock -n 9; then
   echo "[prune] a deploy holds ${LOCK_FILE} — skipping this run"
   exit 0
-else
-  LOCK_HELD_BY_US=1
 fi
 LOCK_UNAVAILABLE="${LOCK_UNAVAILABLE:-0}"
 free_gb() { df -BG --output=avail / | tail -1 | tr -dc '0-9'; }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,7 @@ overrides:
   express-rate-limit@>=8.2.0 <8.2.2: '>=8.2.2'
   underscore@<1.13.8: '>=1.13.8'
   '@xmldom/xmldom@<0.8.15': '>=0.8.15 <0.9.0'
+  fflate@>=0.8.0 <0.8.3: '>=0.8.3 <0.9.0'
   browserslist@<=4.28.6: '>=4.28.7 <5.0.0'
   '@humanfs/node@<0.16.8': '>=0.16.8 <0.17.0'
   postcss-selector-parser@>=6.1.0 <6.1.3: '>=6.1.3 <7.0.0'
@@ -4673,8 +4674,8 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
-  fflate@0.8.2:
-    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -10450,7 +10451,7 @@ snapshots:
   '@vitest/ui@4.1.8(vitest@4.1.8)':
     dependencies:
       '@vitest/utils': 4.1.8
-      fflate: 0.8.2
+      fflate: 0.8.3
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
@@ -11748,7 +11749,7 @@ snapshots:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
 
-  fflate@0.8.2: {}
+  fflate@0.8.3: {}
 
   file-entry-cache@8.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,6 +86,11 @@ overrides:
   # Surfaced by `pnpm audit` after the bumps above pulled newer transitives.
   # Every target is bounded to its own major — the xmldom entry above is what
   # happens when one is not.
+  # GHSA-px8p-9vwx-vf98: unzipSync loops forever on a malformed ZIP64 archive.
+  # Reached only through @vitest/ui, so it is a test-time dependency and not
+  # something an attacker can hand input to — updated because it costs nothing,
+  # not because it is exposed.
+  'fflate@>=0.8.0 <0.8.3': '>=0.8.3 <0.9.0'
   'browserslist@<=4.28.6': '>=4.28.7 <5.0.0'
   '@humanfs/node@<0.16.8': '>=0.16.8 <0.17.0'
   'postcss-selector-parser@>=6.1.0 <6.1.3': '>=6.1.3 <7.0.0'


### PR DESCRIPTION
**Automated security updates are now enabled on this repo** (they were off — which is why twenty alerts sat unattended long enough to need a manual sweep) and **unpaused on `pluggedin-mcp`**.

That covers advisories. This PR covers the other half: without a schedule, nothing looks at dependencies until something is already vulnerable.

| ecosystem | cadence | notes |
|---|---|---|
| npm (reads `pnpm-lock.yaml`) | weekly, Mon 06:00 Europe/Istanbul | minor + patch grouped into one PR; max 5 open |
| github-actions | monthly | |
| docker | monthly | |

**Majors are ignored on purpose.** A major is a deliberate migration, not a weekly chore. A major carrying an advisory still arrives regardless — security updates do not consult the `ignore` list.

## Also: fflate

[GHSA-px8p-9vwx-vf98](https://github.com/advisories/GHSA-px8p-9vwx-vf98) landed while this was being written — `unzipSync` loops forever on a malformed ZIP64 archive.

Reached only through `@vitest/ui`, so it is a test-time dependency and nothing attacker-controlled goes near it. **Updated because it costs nothing, not because it was exposed.** Bounded to its own minor, like every entry added since the unbounded `@xmldom/xmldom` override walked onto a vulnerable major by itself.

## Verification

- `pnpm audit`: no known vulnerabilities.
- Suite: **192 failures, unchanged from baseline.**
- `dependabot.yml` parsed rather than eyeballed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791073951&installation_model_id=430597&pr_number=232&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F232&signature=08767aa1aaf2c4752053fa2e44da2da610d5b5746a711f3bb8937ea5ff37af91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Establish routine dependency update automation and constrain fflate to a patched compatible release range.

Enhancements:
- Add scheduled dependency maintenance for npm, GitHub Actions, and Docker updates, with grouped routine updates and major-version updates deferred for deliberate migrations.
- Bound the fflate dependency override to patched releases within its current major version.

Chores:
- Remove unused lock-state tracking from the build artifact pruning script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed ZIP64 archives for more reliable archive processing.
  - Updated the affected archive-processing dependency to a patched release range.

- **Chores**
  - Added automated dependency monitoring and update scheduling for npm packages, GitHub Actions, and Docker dependencies.
  - Grouped routine dependency updates and standardized their labeling and commit messages.
  - Simplified deployment artifact maintenance while preserving existing lock-handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->