### PR TITLE
release: 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,100 @@ All notable changes to the Plugged.in platform will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0] - 2026-09-04
+
+A major by Semantic Versioning: two features were removed and the data model
+under Hubs changed. 72 commits since 3.3.0, and no release in between — which
+is why five published security advisories had to point at commit SHAs instead
+of a version. That is the gap this release closes.
+
+Entries between 2.16.0 and 3.3.0 are missing from this file; those releases were
+described in GitHub release notes only. This entry resumes the practice rather
+than reconstructing the gap.
+
+### Removed
+
+- **Workspaces as a separate axis.** Every Workspace is now its own Hub, one
+  Workspace per Hub, and the Workspace switcher is gone along with everything
+  that fed it. Existing Workspaces were promoted in place: no row of user data
+  moved, and `mcp_servers.slug` — the tool-name prefix in `{slug}__{tool}` — is
+  untouched, so saved instructions naming those tools still resolve.
+- **Discover / AI Social.** The feed and its surface are gone. The sharing
+  infrastructure underneath it stays: profiles, shared servers and shared
+  collections still work.
+
+### Added
+
+- **Hosted MCP connector at `/api/mcp`**, with an OAuth 2.1 authorization server
+  in front of it — PKCE, refresh-token rotation with reuse detection, and RFC
+  9728 discovery.
+- **Library tools over MCP**, behind a Hub boundary a caller cannot step
+  around.
+- **Docker + Traefik + SOPS deployment.** The stack runs in containers behind
+  Traefik with secrets decrypted to tmpfs at deploy time. `infra/scripts/deploy.sh`
+  is the entry point; running compose by hand skips decryption.
+- **Scheduled retention for Docker build artefacts**, four times a day, after a
+  4 GB-per-push image build filled the disk and took the site down.
+
+### Security
+
+Twenty security commits and five advisories, all published with the reporter
+credited (see the Acknowledgements section of SECURITY.md):
+
+- [GHSA-m623-vm42-63fg] (critical) — OS command injection through MCP server
+  `args`, reaching an unescaped shell in the pnpm/uv install path. Reported by
+  Syed Anas Mohiuddin.
+- [GHSA-qm2x-3m6j-c7fc] (high) — the same install-path injection reached through
+  discovery. Reported by EQSTLab.
+- [GHSA-m29x-gj35-9w8g] (high) — command injection in `testMcpConnection` via
+  ``exec(`which ${command}`)``. Reported by EQSTLab.
+- [GHSA-gmhc-h765-37cg] (high) — SSRF guard bypass. The guards matched hostname
+  text, which never matches the bracketed, hex-canonicalised form Node produces
+  for an IPv4-mapped address. Reported by tonghuaroot.
+- [GHSA-fv94-f4f5-vr99] (medium) — the REST unshare endpoint authenticated the
+  caller but never checked profile ownership, so any account could delete
+  another tenant's shares. Reported by 0xParth.
+
+Beyond the advisories, and found by an audit rather than reported:
+
+- Server actions no longer trust a caller-supplied identity; the set that did is
+  frozen by a test that discovers them rather than listing them.
+- `/api/search/users` no longer returns password hashes and 2FA secrets to
+  anonymous callers.
+- Spawned MCP servers no longer inherit the application's environment.
+- The SSRF primitive is applied everywhere a stored URL is fetched, and
+  `safeFetch` now resolves each redirect hop and connects to the address it
+  validated rather than re-resolving the name.
+- Email verification tokens are bound to the user they were issued for.
+- Shared-collection content is sanitised on write and on every read.
+- Imports validate what they are about to make runnable.
+
+### Fixed
+
+- **MCP discovery on STDIO servers.** The sandbox aborted on a bind for
+  `~/.local/bin`, a directory absent from every container image, so discovery
+  failed with `MCP error -32000: Connection closed`.
+- **Duplicate "Default Hub".** A race created two for 27 users. The race is
+  closed, and the duplicates are named apart rather than merged — merging would
+  have to rewrite slugs.
+- `deploy.sh` survives a second run and a failed decrypt.
+- Postgres and Redis are no longer published on `0.0.0.0` with a committed
+  password.
+- No SecurityError crash when Web Storage is blocked (Mobile Safari).
+
+### Dependencies
+
+`pnpm audit` reports no known vulnerabilities in this repository or in
+`pluggedin-mcp`. Automated security updates were **off** here and **paused**
+there, which is how twenty alerts went unattended; both are enabled now, and a
+`.github/dependabot.yml` schedules the routine half.
+
+[GHSA-m623-vm42-63fg]: https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-m623-vm42-63fg
+[GHSA-qm2x-3m6j-c7fc]: https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-qm2x-3m6j-c7fc
+[GHSA-m29x-gj35-9w8g]: https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-m29x-gj35-9w8g
+[GHSA-gmhc-h765-37cg]: https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-gmhc-h765-37cg
+[GHSA-fv94-f4f5-vr99]: https://github.com/VeriTeknik/pluggedin-app/security/advisories/GHSA-fv94-f4f5-vr99
+
 ## [2.16.0] - 2025-10-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Turn your AI conversations into permanent organizational memory**
 
-[![Version](https://img.shields.io/badge/version-3.0.0-blue?style=for-the-badge)](https://github.com/VeriTeknik/pluggedin-app/releases)
+[![Version](https://img.shields.io/badge/version-4.0.0-blue?style=for-the-badge)](https://github.com/VeriTeknik/pluggedin-app/releases)
 [![GitHub Stars](https://img.shields.io/github/stars/VeriTeknik/pluggedin-app?style=for-the-badge)](https://github.com/VeriTeknik/pluggedin-app/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)](LICENSE)
 [![Docker](https://img.shields.io/badge/docker-ready-blue?style=for-the-badge&logo=docker)](https://hub.docker.com/r/veriteknik/pluggedin)

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 ---
 🧩 **Now Multi‑Arch Ready!**
 Plugged.in Docker images support both `amd64` and `arm64` architectures via a unified manifest.
-🧠 **v3.0.0 — Embedded RAG Vector Engine:**
-RAG now runs fully in-process using zvec (RocksDB + HNSW). No external services needed — document processing, chunking, and semantic search are all built-in.
+🧭 **v4.0.0 — Hubs, a hosted MCP connector, and a security pass:**
+Workspaces are Hubs now, one Workspace per Hub. `/api/mcp` serves a hosted connector behind an OAuth 2.1 server. Five reported advisories fixed and credited.
 ---
 </div>
 
@@ -557,38 +557,45 @@ Built on top of these amazing projects:
 
 ## 📝 Release Notes
 
-**Latest Release: v3.0.0** — Embedded RAG Vector Engine
+**Latest Release: v4.0.0** — Hubs, a hosted MCP connector, and a security pass
 
-### 🎯 What's New in v3.0.0
+### 🎯 What's New in v4.0.0
 
-This is a **major architectural shift** that eliminates the external FastAPI/Milvus dependency for RAG.
+Major by Semantic Versioning: two features were removed and the data model under
+Hubs changed.
 
-**🧠 Embedded RAG Vector Engine** (Breaking Change)
-- **In-process vector search** via zvec (RocksDB + HNSW) — zero external dependencies
-- **Shared vector infrastructure** (`lib/vectors/`) with domain-based collections
-- **Server-side PDF extraction** using unpdf — no external service needed
-- **Smart text chunking** with configurable overlap and separators
-- **Model-to-dimension validation** — detects misconfigured embedding models at startup
-- **Re-index menu option** in library UI for recovering from vector corruption
-- **Relevance-ordered results** with query term highlighting
+**🧭 Workspaces are Hubs** (Breaking Change)
+- Every Workspace is its own Hub, one Workspace per Hub; the Workspace switcher is gone
+- Existing Workspaces were promoted in place — no row of user data moved
+- `mcp_servers.slug` is untouched, so saved instructions naming `{slug}__{tool}` still resolve
 
-**🔒 Security Hardening**
-- **Filter injection prevention**: Field-name allowlist + per-type value validation (UUID/alphanumeric regex)
-- **Path traversal protection**: External `ZVEC_DATA_PATH` blocked unless explicitly opted in
-- **Corruption recovery**: Collections backed up to `.bak` before recreation with stats logging
-- **Idempotent document processing**: Prevents orphaned rows on retry
+**🔌 Hosted MCP connector**
+- `/api/mcp` serves the connector, with an OAuth 2.1 authorization server in front of it
+- PKCE, refresh-token rotation with reuse detection, RFC 9728 discovery
+- Library tools exposed over MCP, behind a Hub boundary a caller cannot step around
 
-**🗑️ Dead Code Removal**
-- Removed ~750 lines of upload polling infrastructure (no longer needed with synchronous processing)
-- Removed `UploadProgressContext`, `UploadProgressToast`, upload-status API route
+**🔒 Security**
+- Five advisories fixed and published, each credited to its reporter — see
+  [Acknowledgements](SECURITY.md#acknowledgements)
+- Command injection in the pnpm/uv install path and in `testMcpConnection`
+- SSRF guards now classify the parsed address rather than matching hostname text,
+  and `safeFetch` connects to the address it validated instead of re-resolving
+- Server actions no longer trust a caller-supplied identity
+
+**🐳 Deployment**
+- Docker + Traefik + SOPS; secrets are decrypted to tmpfs at deploy time
+- `infra/scripts/deploy.sh` is the entry point — running compose by hand skips decryption
+- Scheduled retention for build artefacts, after a 4 GB-per-push image build filled the disk
+
+**🗑️ Removed**
+- Discover / AI Social. The sharing infrastructure underneath it stays
 
 **⚠️ Migration Notes**
-- Docker image changed to `pgvector/pgvector:pg18` — back up your database before upgrading
-- New env vars: `ZVEC_DATA_PATH`, `EMBEDDING_MODEL`, `RAG_SEARCH_TOP_K`, `RAG_CACHE_TTL_MS`
-- Removed env var: `RAG_API_URL`
-- Run `pnpm db:migrate` after upgrading (3 new migrations)
+- Run `pnpm db:migrate` after upgrading
+- Users who hit the duplicate-Hub race will see the second one renamed to
+  "Default Hub 2"; nothing is merged and nothing is deleted
 
-View the full changelog at [GitHub Releases](https://github.com/VeriTeknik/pluggedin-app/releases/tag/v3.0.0)
+View the full changelog at [GitHub Releases](https://github.com/VeriTeknik/pluggedin-app/releases/tag/v4.0.0)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ Hubs changed.
 - Users who hit the duplicate-Hub race will see the second one renamed to
   "Default Hub 2"; nothing is merged and nothing is deleted
 
-View the full changelog at [GitHub Releases](https://github.com/VeriTeknik/pluggedin-app/releases/tag/v4.0.0)
+View the full changelog at [GitHub Releases](https://github.com/VeriTeknik/pluggedin-app/releases/latest)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluggedin-app",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "private": true,
   "type": "module",
   "engines": {


### PR DESCRIPTION
Cuts the first release since **3.3.0, 72 commits ago**.

That gap is the reason for doing it now: five security advisories were published this week, and every one had to say *"fixed in commit `<sha>`, unreleased at time of disclosure"* — a self-hoster reading them had no version to move to.

## Why major, not 3.4.0

This project's CHANGELOG states it follows Semantic Versioning. Two features were **removed** and the data model under Hubs **changed**:

- **Workspaces stopped being a separate axis.** Every Workspace is now its own Hub, one per Hub, and the switcher is gone along with everything that fed it.
- **Discover / AI Social was removed entirely.** The sharing infrastructure underneath it stays.

Either alone is a breaking change. A minor would understate both. Say so if you would rather it were 3.4.0 — the tag has not been created yet, and this is a judgement rather than a fact.

## What is in it

| | |
|---|---|
| Removed | Workspace axis; Discover / AI Social |
| Added | hosted MCP connector at `/api/mcp` with an OAuth 2.1 server; library tools behind a Hub boundary; Docker + Traefik + SOPS deployment; scheduled artefact retention |
| Security | 20 `security:` commits and 5 published advisories, each credited to its reporter |
| Fixed | STDIO MCP discovery (`MCP error -32000`); duplicate "Default Hub" for 27 users; Postgres/Redis no longer on `0.0.0.0` with a committed password |

## The CHANGELOG

The entry is the **first since 2.16.0** — the 3.x releases were described in GitHub release notes only. It resumes the practice rather than reconstructing the gap, and says so in the entry itself instead of pretending the file was maintained.

## Verified, not written from memory

Every factual claim was checked:

```
5 advisory IDs        -> all published, severities as stated
20 security commits   -> 20
72 commits            -> 72
.github/dependabot.yml, SECURITY.md Acknowledgements, drizzle/0104  -> present
```

Suite: **192 failures, unchanged from baseline.**

After merge: tag `v4.0.0` and publish the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791108762&installation_model_id=430597&pr_number=240&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F240&signature=0db8c7fabd1d0713e1606d63803809f89d7a1d6584ecc5533feb8b89492150f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Release version 4.0.0 with the Hub data-model transition, hosted MCP support, deployment improvements, and comprehensive security fixes.

New Features:
- Add a hosted MCP connector at `/api/mcp` with OAuth 2.1 and Hub-scoped library tools.
- Add containerized Docker, Traefik, and SOPS deployment with scheduled build-artifact retention.

Bug Fixes:
- Fix STDIO MCP discovery failures and duplicate Default Hub creation.
- Harden command execution, SSRF protection, identity handling, data exposure, token validation, shared content handling, and deployment/runtime security issues.

Enhancements:
- Promote Workspaces into individual Hubs and remove the Workspace switching model.
- Remove the Discover / AI Social surface while retaining underlying sharing capabilities.
- Publish the 4.0.0 release metadata and document its migration and security changes.

CI:
- Enable automated dependency security updates through Dependabot.

Deployment:
- Harden deployment secrets and internal database service exposure.

Documentation:
- Update the changelog, README release notes, and security acknowledgements for version 4.0.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added hosted MCP/OAuth support, library tools, containerized deployment, and scheduled Docker artifact retention.

- **Changes**
  - Removed separate Workspaces and Discover/AI Social experiences.
  - Updated the package version to 4.0.0.

- **Documentation**
  - Added the 4.0.0 changelog, including security advisories, audit fixes, MCP updates, and advisory links.
  - Updated the README to link to the latest GitHub release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->