### PR TITLE
security: close the four findings that survived manual verification

### DIFF
--- a/app/actions/profiles.ts
+++ b/app/actions/profiles.ts
@@ -181,6 +181,20 @@ export async function setProfileActive(
   const validatedProfileUuid = uuidSchema.parse(profileUuid);
   
   return withProjectAuth(validatedProjectUuid, async (session, project) => {
+    // Owning the project is not enough. The foreign key on
+    // active_profile_uuid points at profiles.uuid and accepts any row, so
+    // without this a caller could aim their own Hub at another tenant's
+    // profile — and registry-servers.ts resolves the working profile as
+    // `activeProject.active_profile_uuid`, so the aim is what gets acted on.
+    const target = await db.query.profilesTable.findFirst({
+      where: eq(profilesTable.uuid, validatedProfileUuid),
+      columns: { uuid: true, project_uuid: true },
+    });
+
+    if (!target || target.project_uuid !== validatedProjectUuid) {
+      throw new Error('Profile does not belong to this project');
+    }
+
     const updatedProject = await db
       .update(projectsTable)
       .set({ active_profile_uuid: validatedProfileUuid })

--- a/lib/agents/opencode-manifests.ts
+++ b/lib/agents/opencode-manifests.ts
@@ -593,20 +593,6 @@ function buildMiddlewaresManifest(config: OpenCodeAgentConfig): object[] {
       apiVersion: 'traefik.io/v1alpha1',
       kind: 'Middleware',
       metadata: {
-        name: `${config.name}-strip-terminal`,
-        namespace: config.namespace,
-        labels: { app: config.name, 'pap-agent': 'true' },
-      },
-      spec: {
-        stripPrefix: {
-          prefixes: ['/terminal'],
-        },
-      },
-    },
-    {
-      apiVersion: 'traefik.io/v1alpha1',
-      kind: 'Middleware',
-      metadata: {
         name: `${config.name}-strip-code`,
         namespace: config.namespace,
         labels: { app: config.name, 'pap-agent': 'true' },
@@ -685,12 +671,17 @@ function buildIngressRouteManifest(config: OpenCodeAgentConfig): object {
         services: [{ name: config.name, port: 4000 }],
         middlewares: [{ name: `${config.name}-strip-opencode` }],
       },
-      {
-        match: `Host(\`${config.dnsName}\`) && PathPrefix(\`/terminal\`)`,
-        kind: 'Rule',
-        services: [{ name: config.name, port: 7681 }],
-        middlewares: [{ name: `${config.name}-strip-terminal` }],
-      },
+      // No public /terminal route. The ttyd container runs `ttyd -W -p 7681 sh`
+      // — writable, a shell — and this route carried a stripPrefix middleware
+      // and nothing else, so reaching the host was reaching a root shell in the
+      // pod, with its workspace and its service-account token.
+      //
+      // ttyd is still in the Deployment and still reachable with
+      // `kubectl port-forward`, which requires cluster credentials. `uiPassword`
+      // exists in the config and lands in the Secret, but nothing wires it to
+      // Traefik, so there is no authenticated route to publish instead. Adding
+      // one is a change worth making deliberately, not a way to keep an
+      // unauthenticated shell on the internet in the meantime.
       {
         // /api routes go to openchamber (not agent-api) for frontend to work
         // openchamber handles auth and proxies to opencode-serve

--- a/lib/mcp/client-wrapper.ts
+++ b/lib/mcp/client-wrapper.ts
@@ -182,6 +182,22 @@ async function isCommandAvailable(command: string): Promise<boolean> {
 }
 
 // Add this function to handle bubblewrap configuration
+/**
+ * Does this server need the raw Docker socket, and therefore no sandbox?
+ *
+ * Only the `docker` binary itself. This used to also return true for any `uvx`
+ * server with "docker" as a *substring* of any argument, which meant
+ * `docker-utils`, `mcp-docker-helper` or `--from x-docker-y` ran with no
+ * bubblewrap or firejail at all — the whole isolation, disabled by a package
+ * name. A uvx package is not Docker; it runs under uv like every other one.
+ *
+ * A server that genuinely wraps Docker opts out explicitly with
+ * `applySandboxing: false`, which createMcpClientAndTransport already honours.
+ */
+export function requiresDockerSocket(command: string, _args: string[]): boolean {
+  return command === 'docker';
+}
+
 export function createBubblewrapConfig(
   serverConfig: McpServer
 ): FirejailConfig | null {
@@ -595,14 +611,9 @@ async function createMcpClientAndTransport(serverConfig: McpServer, skipCommandT
         }
       }
 
-      // Check if this is a Docker-based server that needs direct socket access
-      const isDockerServer = 
-        transformedCommand === 'docker' || 
-        (transformedCommand === 'uvx' && 
-         transformedArgs.some(arg => arg.toLowerCase().includes('docker')));
-      
-      if (isDockerServer) {
-      }
+      // Skipping the sandbox is a decision, so it is made by one named
+      // function with tests rather than inline.
+      const isDockerServer = requiresDockerSocket(transformedCommand, transformedArgs);
 
       // Apply sandboxing by default for all STDIO servers (unless explicitly disabled)
       let sandboxConfig: FirejailConfig | null = null;

--- a/lib/oauth/dynamic-client-registration.ts
+++ b/lib/oauth/dynamic-client-registration.ts
@@ -6,6 +6,7 @@
  */
 
 import { clearOAuthConfigCache } from '@/lib/oauth/oauth-config-store';
+import { safeFetch } from '@/lib/oauth/ssrf-protection';
 import { log } from '@/lib/observability/logger';
 import { recordClientRegistration } from '@/lib/observability/oauth-metrics';
 
@@ -62,7 +63,12 @@ export async function registerOAuthClient(
   });
 
   try {
-    const response = await fetch(registrationEndpoint, {
+    // safeFetch, not fetch: registrationEndpoint is not ours. It arrives from
+    // the remote server's own OAuth metadata document, so a host we merely
+    // reached can name any address it likes — including 169.254.169.254 or
+    // loopback. safeFetch validates the URL, resolves it, refuses a non-global
+    // address and pins the connection to the address it checked.
+    const response = await safeFetch(registrationEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/tests/security/agent-terminal-not-public.test.ts
+++ b/tests/security/agent-terminal-not-public.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The agent pod's web terminal must not be published without authentication.
+ *
+ * buildIngressRouteManifest routed `PathPrefix('/terminal')` on the agent's
+ * public DNS name straight to ttyd on port 7681, with a `stripPrefix`
+ * middleware and nothing else. The container runs `ttyd -W -p 7681 sh` — `-W`
+ * is writable, `sh` is a shell — so anyone who reached
+ * `https://<agent>.<domain>/terminal` got an interactive shell inside the pod,
+ * with its mounted workspace and its service-account token.
+ *
+ * No agent has ever been deployed (0 rows in `agents` and `clusters` in
+ * production), so this was latent rather than live — it would have become live
+ * with the first deployment.
+ *
+ * Found by the 2026-09-06 re-scan.
+ *
+ * ttyd stays in the pod: it is still reachable with `kubectl port-forward`,
+ * which requires cluster credentials. What is removed is the public route.
+ * `uiPassword` exists in the config and is written into the Secret, but nothing
+ * wires it to Traefik, so there is no authenticated route to fall back to.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { buildOpenCodeManifests, type OpenCodeAgentConfig } from '@/lib/agents/opencode-manifests';
+
+const config = {
+  name: 'agent-1',
+  namespace: 'agents',
+  dnsName: 'agent-1.example.com',
+  uiPassword: 'pw',
+  defaultModel: 'claude-sonnet-4',
+  agentUuid: 'uuid-1',
+  modelRouterUrl: 'https://router.example.com',
+  modelRouterToken: 'tok',
+  papApiKey: 'pap',
+  pluggedinApiKey: 'plug',
+} as unknown as OpenCodeAgentConfig;
+
+/** Every route in the manifest, flattened. */
+function routes(): Array<{ match: string; services: Array<{ port: number }>; middlewares?: unknown[] }> {
+  const manifests = buildOpenCodeManifests(config);
+  const ingress = manifests.ingressRoute as { spec?: { routes?: unknown[] } };
+  return (ingress.spec?.routes ?? []) as Array<{
+    match: string;
+    services: Array<{ port: number }>;
+    middlewares?: unknown[];
+  }>;
+}
+
+describe('agent ingress', () => {
+  it('builds routes at all', () => {
+    expect(routes().length).toBeGreaterThan(0);
+  });
+
+  it('publishes no route to the ttyd port', () => {
+    const terminalRoutes = routes().filter((r) => r.services?.some((s) => s.port === 7681));
+
+    expect(terminalRoutes).toEqual([]);
+  });
+
+  it('publishes no /terminal path', () => {
+    const terminalRoutes = routes().filter((r) => /\/terminal/.test(r.match ?? ''));
+
+    expect(terminalRoutes).toEqual([]);
+  });
+
+  it('still keeps ttyd in the pod for port-forward access', () => {
+    const manifests = buildOpenCodeManifests(config);
+    const deployment = manifests.deployment as {
+      spec?: { template?: { spec?: { containers?: Array<{ name: string }> } } };
+    };
+    const names = (deployment.spec?.template?.spec?.containers ?? []).map((c) => c.name);
+
+    expect(names).toContain('ttyd');
+  });
+});

--- a/tests/security/docker-sandbox-gate.test.ts
+++ b/tests/security/docker-sandbox-gate.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Skipping the sandbox must require actually being Docker.
+ *
+ * `createMcpClientAndTransport` decided a server needed raw Docker socket
+ * access — and therefore no bubblewrap/firejail — like this:
+ *
+ *   transformedCommand === 'docker' ||
+ *   (transformedCommand === 'uvx' &&
+ *    transformedArgs.some(arg => arg.toLowerCase().includes('docker')))
+ *
+ * A substring. Any uvx server with "docker" anywhere in its arguments —
+ * `docker-utils`, `mydocker`, `--from some-docker-helper` — ran completely
+ * unsandboxed, with the full filesystem the sandbox exists to withhold. The
+ * flag was set by a branch whose own body was empty, so its only effect was to
+ * disable the sandbox.
+ *
+ * Found by the 2026-09-06 re-scan and confirmed by reading the gate.
+ *
+ * A uvx package is not Docker. If one genuinely wraps Docker it opts out
+ * explicitly with `applySandboxing: false`, which the caller already supports.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { requiresDockerSocket } from '@/lib/mcp/client-wrapper';
+
+describe('requiresDockerSocket', () => {
+  it('is true for the docker command itself', () => {
+    expect(requiresDockerSocket('docker', ['run', 'x'])).toBe(true);
+  });
+
+  it.each([
+    ['docker-utils', ['docker-utils']],
+    ['a package merely containing the word', ['mcp-docker-helper']],
+    ['a flag value', ['--from', 'some-docker-thing', 'pkg']],
+    ['different case', ['DOCKER-tools']],
+    ['a path', ['/opt/docker/whatever']],
+  ])('is false for a uvx server whose args merely mention docker: %s', (_label, args) => {
+    expect(requiresDockerSocket('uvx', args)).toBe(false);
+  });
+
+  it('is false for an ordinary uvx server', () => {
+    expect(requiresDockerSocket('uvx', ['some-package'])).toBe(false);
+  });
+
+  it('is false for npx regardless of arguments', () => {
+    expect(requiresDockerSocket('npx', ['-y', 'docker'])).toBe(false);
+  });
+
+  it('does not treat a command that merely starts with docker as docker', () => {
+    // `docker-compose` is a different binary and does not imply the daemon
+    // socket is required by this server.
+    expect(requiresDockerSocket('docker-compose', ['up'])).toBe(false);
+  });
+});

--- a/tests/security/oauth-registration-ssrf.test.ts
+++ b/tests/security/oauth-registration-ssrf.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Dynamic client registration must not be an SSRF hole.
+ *
+ * `registerOAuthClient` POSTed to `registrationEndpoint` with plain `fetch`.
+ * That endpoint is not ours: it comes from the remote server's own OAuth
+ * metadata document, fetched during discovery. `trigger-mcp-oauth.ts`
+ * validates `server.url` with validateUrlForSSRF and then hands the
+ * *metadata's* `registration_endpoint` straight through unvalidated.
+ *
+ * So: register an MCP server on a host you control — public, passes the URL
+ * check — and answer discovery with
+ * `{"registration_endpoint": "http://169.254.169.254/latest/meta-data/"}`.
+ * The app POSTs there, server-side.
+ *
+ * Reported in the August scan as "OAuth metadata discovery and dynamic client
+ * registration bypass this file's own SSRF guard" and never fixed; re-found on
+ * 2026-09-06 and confirmed by reading the call.
+ *
+ * safeFetch is the fix: it validates, resolves, refuses non-global addresses
+ * and pins the connection to the address it checked.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const lookup = vi.fn();
+vi.mock('node:dns/promises', () => ({ default: { lookup: (...a: unknown[]) => lookup(...a) } }));
+vi.mock('@/lib/oauth/oauth-config-store', () => ({ clearOAuthConfigCache: vi.fn() }));
+vi.mock('@/lib/observability/logger', () => ({ log: { oauth: vi.fn(), error: vi.fn(), warn: vi.fn() } }));
+vi.mock('@/lib/observability/oauth-metrics', () => ({ recordClientRegistration: vi.fn() }));
+
+const pinnedFetch = vi.fn();
+vi.mock('@/lib/security/pinned-fetch', () => ({
+  pinnedFetch: (...a: unknown[]) => pinnedFetch(...a),
+  pinnedLookup: vi.fn(),
+}));
+
+const { registerOAuthClient } = await import('@/lib/oauth/dynamic-client-registration');
+
+describe('registerOAuthClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pinnedFetch.mockResolvedValue(
+      new Response(JSON.stringify({ client_id: 'x' }), { status: 201 })
+    );
+  });
+
+  it.each([
+    ['cloud metadata', 'http://169.254.169.254/latest/meta-data/'],
+    ['loopback', 'http://127.0.0.1:8080/register'],
+    ['RFC 1918', 'http://10.0.0.5/register'],
+    ['IPv6 loopback', 'http://[::1]/register'],
+    ['IPv4-mapped loopback', 'http://[::ffff:7f00:1]/register'],
+  ])('refuses a registration endpoint pointing at %s', async (_label, endpoint) => {
+    await expect(
+      registerOAuthClient(endpoint, 'https://plugged.in/api/oauth/callback')
+    ).rejects.toThrow();
+
+    expect(pinnedFetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses a public name that resolves inward', async () => {
+    lookup.mockResolvedValue([{ address: '127.0.0.1', family: 4 }]);
+
+    await expect(
+      registerOAuthClient('https://evil.example/register', 'https://plugged.in/api/oauth/callback')
+    ).rejects.toThrow(/private or reserved/i);
+  });
+
+  it('still registers against a genuinely public endpoint', async () => {
+    lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+
+    const result = await registerOAuthClient(
+      'https://auth.example.com/register',
+      'https://plugged.in/api/oauth/callback'
+    );
+
+    expect(result.client_id).toBe('x');
+    expect(pinnedFetch).toHaveBeenCalled();
+  });
+});

--- a/tests/security/set-profile-active-ownership.test.ts
+++ b/tests/security/set-profile-active-ownership.test.ts
@@ -1,0 +1,74 @@
+/**
+ * A Hub's active profile must belong to that Hub.
+ *
+ * `setProfileActive(projectUuid, profileUuid)` ran under `withProjectAuth`, so
+ * the caller had to own the *project*. Nothing checked the *profile*. The
+ * foreign key points at `profiles.uuid` and accepts any row, so a caller could
+ * set their own Hub's `active_profile_uuid` to another tenant's profile.
+ *
+ * That is not cosmetic: `app/actions/registry-servers.ts` resolves the working
+ * profile as `activeProject.active_profile_uuid` and acts on it. Pointing your
+ * own Hub at someone else's profile shifts which profile your authenticated
+ * calls operate on.
+ *
+ * Found by the 2026-09-06 re-scan; confirmed by reading the action and the
+ * consumer.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const findFirst = vi.fn();
+const setSpy = vi.fn();
+
+vi.mock('@/lib/auth-helpers', () => ({
+  withProjectAuth: (_p: string, fn: (s: unknown, project: unknown) => unknown) =>
+    fn({ user: { id: 'owner' } }, { uuid: 'project-1', user_id: 'owner' }),
+  withProfileAuth: (_p: string, fn: (s: unknown) => unknown) => fn({ user: { id: 'owner' } }),
+  withAuth: (fn: (s: unknown) => unknown) => fn({ user: { id: 'owner' } }),
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+// profiles.ts pulls in lib/auth transitively, which builds the Auth.js Drizzle
+// adapter at module scope against the mocked db.
+vi.mock('@/lib/auth', () => ({ getAuthSession: vi.fn(), authOptions: {} }));
+vi.mock('@/db', () => ({
+  db: {
+    query: { profilesTable: { findFirst: (...a: unknown[]) => findFirst(...a) } },
+    update: () => ({
+      set: (v: unknown) => {
+        setSpy(v);
+        return { where: () => ({ returning: async () => [{ uuid: 'project-1' }] }) };
+      },
+    }),
+  },
+}));
+
+const { setProfileActive } = await import('@/app/actions/profiles');
+
+const PROJECT = '11111111-1111-1111-1111-111111111111';
+const OWN_PROFILE = '22222222-2222-2222-2222-222222222222';
+const OTHER_PROFILE = '33333333-3333-3333-3333-333333333333';
+
+describe('setProfileActive', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('refuses a profile that belongs to another project', async () => {
+    findFirst.mockResolvedValue({ uuid: OTHER_PROFILE, project_uuid: 'someone-elses-project' });
+
+    await expect(setProfileActive(PROJECT, OTHER_PROFILE)).rejects.toThrow();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('refuses a profile that does not exist', async () => {
+    findFirst.mockResolvedValue(undefined);
+
+    await expect(setProfileActive(PROJECT, OTHER_PROFILE)).rejects.toThrow();
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows a profile that belongs to the project', async () => {
+    findFirst.mockResolvedValue({ uuid: OWN_PROFILE, project_uuid: PROJECT });
+
+    await setProfileActive(PROJECT, OWN_PROFILE);
+
+    expect(setSpy).toHaveBeenCalledWith({ active_profile_uuid: OWN_PROFILE });
+  });
+});


### PR DESCRIPTION
The 2026-09-06 re-scan produced 33 "confirmed" CRITICALs. **26 of them were already fixed** — the referee run was unreliable and I verified every one by hand. These are the four that were real.

Each commit is one finding, each with a test written before the fix.

## 1. Skipping the sandbox required only the word "docker"

```ts
transformedCommand === 'docker' ||
(transformedCommand === 'uvx' &&
 transformedArgs.some(arg => arg.toLowerCase().includes('docker')))
```

A **substring**, over user-supplied arguments. `docker-utils`, `mcp-docker-helper`, `--from some-docker-thing`, a path containing `/docker/` — any of them ran with no bubblewrap and no firejail.

The branch it fed was `if (isDockerServer) { }` — an empty block. Its only effect was to disable isolation.

Now `command === 'docker'`, extracted as `requiresDockerSocket` so the rule is one named function with tests. A server that genuinely wraps Docker opts out with `applySandboxing: false`, which the caller already honours.

## 2. Dynamic client registration was an SSRF hole — on the OAuth path

`registerOAuthClient` POSTed to `registrationEndpoint` with plain `fetch`. That endpoint comes from **the remote server's own metadata document**. `trigger-mcp-oauth.ts` validates `server.url` and then passes the metadata's `registration_endpoint` straight through.

Register an MCP server on a host you control, answer discovery with `{"registration_endpoint": "http://169.254.169.254/latest/meta-data/"}`, and the app POSTs there.

The August scan reported this and it was never fixed. It matters more now, because this is the path a public `/api/mcp` connector runs on.

## 3. A Hub's active profile could point at another tenant

`setProfileActive` ran under `withProjectAuth` — you had to own the *project*. Nothing checked the *profile*, and the FK accepts any `profiles.uuid`.

`registry-servers.ts` resolves the working profile as `activeProject.active_profile_uuid`, so aiming your own Hub at someone else's profile shifts which profile your authenticated calls act on. **Verified before fixing**: the update went through.

## 4. Every agent pod published an unauthenticated shell

`PathPrefix('/terminal')` → ttyd on 7681, `stripPrefix` middleware and nothing else. The container runs `ttyd -W -p 7681 sh`.

**Latent, not live** — production has 0 `agents` and 0 `clusters`, so no manifest has ever been built. It would have gone live with the first deployment.

Route removed; ttyd stays in the Deployment for `kubectl port-forward`, which needs cluster credentials. `uiPassword` exists but nothing wires it to Traefik, so there is no authenticated route to publish instead — that is a change worth making deliberately.

## Left alone deliberately

`app/api/mcp/oauth/callback` uses plain `fetch`, but it has an explicit allowlist forcing the host to loopback. `safeFetch` would be **wrong** there — it refuses private addresses, and reaching localhost is the entire purpose of that proxy. The residual is reaching localhost ports above 1024; narrowing that is a separate change.

## Verification

- Every test written before its fix and watched fail. 23 new cases across four suites.
- Full suite: **189 failures, 0 new** against a 189 baseline.
- `next build` exit 0, `tsc` clean, `eslint` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791305052&installation_model_id=430597&pr_number=243&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F243&signature=41f6303819c2407548971abd73df92710076dbc6d690bd64c700e02da2637c16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Close four verified security vulnerabilities affecting sandbox isolation, OAuth registration, profile tenancy, and agent shell exposure.

Bug Fixes:
- Prevent OAuth dynamic client registration from making server-side requests to private, loopback, or otherwise non-public addresses.
- Restrict sandbox bypasses to the actual Docker command instead of arguments that merely contain “docker”.
- Ensure active profiles belong to the project selecting them.
- Remove the unauthenticated public agent terminal route while retaining port-forward access for authorized operators.

Tests:
- Add security regression coverage for Docker sandbox decisions, OAuth registration SSRF protection, profile ownership, and agent terminal exposure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Prevented selecting profiles belonging to another project or nonexistent profiles.
  - Removed public access to the agent terminal endpoint; terminal access remains available through authenticated cluster port forwarding.
  - Strengthened OAuth client registration to block unsafe destinations, including private and loopback addresses.
  - Restricted Docker sandbox bypass behavior to the exact Docker command, avoiding unintended access for unrelated commands.
- **Tests**
  - Added coverage for profile ownership, terminal exposure, OAuth destination validation, and Docker access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->