### PR TITLE
security: prevent credential disclosure through sharing and client responses

### DIFF
--- a/app/(sidebar-layout)/(container)/agents/[id]/page.tsx
+++ b/app/(sidebar-layout)/(container)/agents/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Activity, AlertTriangle, ArrowLeft, CheckCircle2, Clock, Cpu, Download, FileText, HardDrive, Heart, Key, Pause, Play, RefreshCw, RotateCw, Server, Shield, Terminal, Trash2, XCircle } from 'lucide-react';
+import { Activity, AlertTriangle, ArrowLeft, CheckCircle2, Clock, Cpu, Download, FileText, HardDrive, Heart, Pause, Play, RefreshCw, RotateCw, Server, Shield, Terminal, Trash2, XCircle } from 'lucide-react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { useCallback, useState } from 'react';
@@ -1017,7 +1017,7 @@ export default function AgentDetailPage() {
                     </div>
                   </div>
 
-                  {agent.model_router_token && !agent.model_router_token_revoked && (
+                  {agent.has_model_router_token && !agent.model_router_token_revoked && (
                     <div className="flex items-center gap-2 p-3 bg-green-50 dark:bg-green-950/20 border border-green-200 dark:border-green-900 rounded-md">
                       <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-500" />
                       <p className="text-sm text-green-800 dark:text-green-400">

--- a/app/(sidebar-layout)/(container)/settings/components/settings-form.tsx
+++ b/app/(sidebar-layout)/(container)/settings/components/settings-form.tsx
@@ -38,7 +38,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/components/ui/use-toast';
-import { users } from '@/db/schema';
 import { useLanguage } from '@/hooks/use-language';
 import { localeNames,locales } from '@/i18n/config'; // Import locales and names
 import { safeLocalStorage, safeSessionStorage } from '@/lib/storage-utils';
@@ -48,7 +47,13 @@ import { AppearanceSection } from './appearance-section';
 import { CurrentProjectSection } from './current-project-section';
 import { LoginMethodsCard } from './login-methods-card';
 import { RemovePasswordDialog } from './remove-password-dialog';
-type User = typeof users.$inferSelect;
+type User = {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  hasPassword: boolean;
+};
 
 interface SettingsFormProps {
   user: User;
@@ -443,7 +448,7 @@ export function SettingsForm({ user, connectedAccounts }: SettingsFormProps) {
       {/* Login Methods Card - Unified view of all login methods */}
       <LoginMethodsCard
         userEmail={user.email || ''}
-        hasPassword={!!user.password}
+        hasPassword={!!user.hasPassword}
         connectedAccounts={connectedAccounts.map((acc) => ({
           id: acc.provider,
           provider: acc.provider,
@@ -452,7 +457,7 @@ export function SettingsForm({ user, connectedAccounts }: SettingsFormProps) {
         onDisconnect={handleRemoveAccount}
         onConnect={(provider) => signIn(provider)}
         canRemoveAccount={
-          connectedAccounts.length > 1 || (connectedAccounts.length === 1 && !!user.password)
+          connectedAccounts.length > 1 || (connectedAccounts.length === 1 && !!user.hasPassword)
         }
       />
 
@@ -461,7 +466,7 @@ export function SettingsForm({ user, connectedAccounts }: SettingsFormProps) {
         <CardHeader>
           <CardTitle>{t('settings.password.title')}</CardTitle>
           <CardDescription>
-            {!user.password
+            {!user.hasPassword
               ? t('settings.password.descriptionNoPassword')
               : connectedAccounts.length > 0
               ? t('settings.password.descriptionWithRemove')
@@ -469,7 +474,7 @@ export function SettingsForm({ user, connectedAccounts }: SettingsFormProps) {
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          {!user.password ? (
+          {!user.hasPassword ? (
             // No password set - Show "Set Password" form
             <>
               <p className="text-sm text-muted-foreground mb-4">

--- a/app/(sidebar-layout)/(container)/settings/page.tsx
+++ b/app/(sidebar-layout)/(container)/settings/page.tsx
@@ -48,7 +48,13 @@ export default async function SettingsPage() {
       <div className="max-w-2xl mx-auto space-y-6">
         <SettingsTitle />
         <SettingsForm
-          user={user}
+          user={{
+            id: user.id,
+            name: user.name,
+            email: user.email,
+            image: user.image,
+            hasPassword: !!user.password,
+          }}
           connectedAccounts={connectedAccounts}
         />
         <EmailPreferencesSection

--- a/app/actions/community-servers.ts
+++ b/app/actions/community-servers.ts
@@ -18,8 +18,8 @@ import {
 } from '@/db/schema';
 import { getAuthSession } from '@/lib/auth';
 import { PUBLIC_USER_COLUMNS } from '@/lib/public-user';
-import { sanitizeServerTemplate } from '@/lib/server-template';
 import { PluggedinRegistryClient } from '@/lib/registry/pluggedin-registry-client';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 
 import { verifyGitHubOwnership } from './registry-servers';
 
@@ -356,6 +356,10 @@ export async function claimCommunityServer(data: z.infer<typeof claimCommunitySe
       return { success: false, error: 'Community server not found' };
     }
 
+    if (communityServer.profile?.project?.user_id !== session.user.id) {
+      return { success: false, error: 'Unauthorized: you do not own this community server' };
+    }
+
     if (communityServer.is_claimed) {
       return { 
         success: false, 
@@ -367,19 +371,11 @@ export async function claimCommunityServer(data: z.infer<typeof claimCommunitySe
     // Get GitHub token - either from registry OAuth or NextAuth
     let githubToken: string | null = null;
     
-    // Check if we have a registry OAuth token passed
-    if (validated.registryToken && validated.registryToken !== 'nextauth') {
-      githubToken = validated.registryToken;
-    } else {
-      // Fall back to NextAuth token
-      const githubAccount = await db.query.accounts.findFirst({
-        where: and(
-          eq(accounts.userId, session.user.id),
-          eq(accounts.provider, 'github')
-        ),
-      });
-      githubToken = githubAccount?.access_token || null;
-    }
+    // A client-provided token is not proof of the signed-in user's identity.
+    const githubAccount = await db.query.accounts.findFirst({
+      where: and(eq(accounts.userId, session.user.id), eq(accounts.provider, 'github')),
+    });
+    githubToken = githubAccount?.access_token || null;
 
     if (!githubToken) {
       return {
@@ -406,7 +402,8 @@ export async function claimCommunityServer(data: z.infer<typeof claimCommunitySe
     }
     const [, owner, repo] = match;
 
-    // Extract package information from template
+    // Legacy shares must not publish stored credentials to the registry.
+    communityServer.template = sanitizeServerTemplate(communityServer.template);
     const packageInfo = extractPackageInfo(communityServer.template);
     
     // Extract environment variables documentation

--- a/app/actions/community-servers.ts
+++ b/app/actions/community-servers.ts
@@ -18,6 +18,7 @@ import {
 } from '@/db/schema';
 import { getAuthSession } from '@/lib/auth';
 import { PUBLIC_USER_COLUMNS } from '@/lib/public-user';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 import { PluggedinRegistryClient } from '@/lib/registry/pluggedin-registry-client';
 
 import { verifyGitHubOwnership } from './registry-servers';
@@ -97,7 +98,7 @@ export async function createCommunityServer(data: z.infer<typeof createCommunity
       profile_uuid: validated.profileUuid,
       title: validated.title,
       description: validated.description,
-      template: validated.template,
+      template: sanitizeServerTemplate(validated.template),
       is_public: true, // Always public for community servers
       requires_credentials: false,
     }).returning();
@@ -256,7 +257,7 @@ export async function getCommunityServer(uuid: string) {
       return { success: false, error: 'Server not found' };
     }
 
-    return { success: true, server };
+    return { success: true, server: sanitizeCommunityShare(server) };
   } catch (error) {
     console.error('Error getting community server:', error);
     return { 
@@ -611,7 +612,7 @@ export async function getClaimableCommunityServers() {
       orderBy: (table, { desc }) => desc(table.created_at),
     });
 
-    return { success: true, servers };
+    return { success: true, servers: servers.map(sanitizeCommunityShare) };
   } catch (error) {
     console.error('Error getting claimable servers:', error);
     return { 
@@ -620,4 +621,9 @@ export async function getClaimableCommunityServers() {
       servers: []
     };
   }
+}
+// A live local server is private configuration, not a public install recipe.
+function sanitizeCommunityShare<T extends { template: unknown; server?: unknown }>(share: T) {
+  const { server: _privateServer, ...publicShare } = share;
+  return { ...publicShare, template: sanitizeServerTemplate(share.template) };
 }

--- a/app/actions/registry-servers.ts
+++ b/app/actions/registry-servers.ts
@@ -1076,6 +1076,13 @@ export async function submitWizardToRegistry(wizardData: WizardSubmissionData) {
       return { success: false, error: 'Missing repository information' };
     }
 
+    const repository = extractGitHubInfo(wizardData.githubUrl);
+    if (repository.owner.toLowerCase() !== wizardData.owner.toLowerCase() ||
+        repository.repo.toLowerCase() !== wizardData.repo.toLowerCase()) {
+      return { success: false, error: 'Repository identity must match the GitHub URL' };
+    }
+    wizardData = { ...wizardData, owner: repository.owner, repo: repository.repo };
+
     // Check if this is a community server (not claimed)
     if (!wizardData.shouldClaim) {
       // Community servers are stored locally, no registry authentication needed

--- a/app/api/agents/[id]/export/route.ts
+++ b/app/api/agents/[id]/export/route.ts
@@ -9,6 +9,7 @@ import {
   agentsTable,
 } from '@/db/schema';
 import { redactSensitiveMetadata } from '@/lib/agent-helpers';
+import { toClientAgent } from '@/lib/agent-response';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
 import { serializeForJson } from '@/lib/serialize-for-json';
 import { kubernetesService } from '@/lib/services/kubernetes-service';
@@ -227,7 +228,8 @@ export async function POST(
     // SECURITY: Redact sensitive fields from agent metadata before export
     // This prevents accidental exposure of API keys, tokens, secrets, etc.
     const redactedAgent = {
-      ...agent,
+      ...toClientAgent(agent),
+      config_values: redactSensitiveMetadata(agent.config_values as Record<string, unknown>),
       metadata: redactSensitiveMetadata(agent.metadata as Record<string, unknown>),
     };
 

--- a/app/api/agents/[id]/replicate/route.ts
+++ b/app/api/agents/[id]/replicate/route.ts
@@ -11,6 +11,7 @@ import {
 } from '@/db/schema';
 import { buildAgentEnv, validateContainerImage, validateResourceLimits } from '@/lib/agent-helpers';
 import { validateAgentName } from '@/lib/agent-name-policy';
+import { toClientAgent } from '@/lib/agent-response';
 import { generateModelRouterToken } from '@/lib/model-router/token';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
 import { kubernetesService } from '@/lib/services/kubernetes-service';
@@ -398,7 +399,7 @@ export async function POST(
         name: sourceAgent.name,
         state: sourceAgent.state,
       },
-      new_agent: newAgent,
+      new_agent: toClientAgent(newAgent),
       deployment: deploymentResult,
     });
   } catch (error) {

--- a/app/api/agents/[id]/route.ts
+++ b/app/api/agents/[id]/route.ts
@@ -10,6 +10,7 @@ import {
   agentsTable,
   AgentState,
 } from '@/db/schema';
+import { toClientAgent } from '@/lib/agent-response';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
 import { serializeForJson } from '@/lib/serialize-for-json';
 import { kubernetesService } from '@/lib/services/kubernetes-service';
@@ -162,7 +163,7 @@ export async function GET(
     ]);
 
     return NextResponse.json(serializeForJson({
-      agent,
+      agent: toClientAgent(agent),
       recentHeartbeats,
       recentMetrics,
       lifecycleEvents,
@@ -458,7 +459,7 @@ export async function PATCH(
 
     return NextResponse.json({
       message: 'Agent updated successfully',
-      agent: serializeForJson(updatedAgent),
+      agent: serializeForJson(toClientAgent(updatedAgent)),
     });
   } catch (error) {
     console.error('Error updating agent:', error);

--- a/app/api/agents/[id]/shutdown/route.ts
+++ b/app/api/agents/[id]/shutdown/route.ts
@@ -7,6 +7,7 @@ import {
   agentsTable,
   AgentState,
 } from '@/db/schema';
+import { toClientAgent } from '@/lib/agent-response';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
 import { kubernetesService } from '@/lib/services/kubernetes-service';
 
@@ -221,7 +222,7 @@ export async function POST(
 
     return NextResponse.json({
       message: 'Agent shutdown initiated. Transitioning to DRAINING state.',
-      agent: updatedAgent,
+      agent: toClientAgent(updatedAgent),
       kubernetes: kubernetesResult,
       drain_timeout_seconds: drainTimeoutSeconds,
     });

--- a/app/api/agents/[id]/upgrade/route.ts
+++ b/app/api/agents/[id]/upgrade/route.ts
@@ -8,6 +8,7 @@ import {
   AgentState,
 } from '@/db/schema';
 import { validateContainerImage, validateResourceLimits } from '@/lib/agent-helpers';
+import { toClientAgent } from '@/lib/agent-response';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
 import { kubernetesService } from '@/lib/services/kubernetes-service';
 
@@ -294,7 +295,7 @@ export async function POST(
 
     return NextResponse.json({
       message: 'Agent upgrade initiated with rolling update strategy',
-      agent: updatedAgent,
+      agent: toClientAgent(updatedAgent),
       upgrade: {
         target_image: finalImage,
         strategy: 'RollingUpdate',

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -12,9 +12,10 @@ import {
   apiKeysTable,
   modelRouterServicesTable,
 } from '@/db/schema';
+import { parseConfigurable, validateConfigValues } from '@/lib/agent-config';
 import { buildAgentEnv, validateContainerImage, validateEnvKey, validateResourceLimits } from '@/lib/agent-helpers';
 import { validateAgentName } from '@/lib/agent-name-policy';
-import { parseConfigurable, validateConfigValues } from '@/lib/agent-config';
+import { toClientAgent } from '@/lib/agent-response';
 import { generateModelRouterToken } from '@/lib/model-router/token';
 import { EnhancedRateLimiters } from '@/lib/rate-limiter-redis';
 import { serializeForJson } from '@/lib/serialize-for-json';
@@ -707,7 +708,7 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json(serializeForJson({
-      agent: newAgent,
+      agent: toClientAgent(newAgent),
       template: template ? {
         uuid: template.uuid,
         namespace: template.namespace,

--- a/app/api/profile/[profileId]/shared-servers/route.ts
+++ b/app/api/profile/[profileId]/shared-servers/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db } from '@/db';
 import { sharedMcpServersTable } from '@/db/schema';
 import { getAuthSession } from '@/lib/auth';
+import { sanitizeServerTemplate } from '@/lib/server-template';
 
 /**
  * @swagger
@@ -104,7 +105,11 @@ export async function GET(
       (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
     );
     
-    return NextResponse.json(sortedServers);
+    return NextResponse.json(sortedServers.map(share => ({
+      ...share,
+      template: sanitizeServerTemplate(share.template),
+      server: sanitizeServerTemplate(share.server),
+    })));
   } catch (error) {
     console.error('Error fetching shared servers:', error);
     return NextResponse.json(

--- a/app/api/release-notes/rss/route.ts
+++ b/app/api/release-notes/rss/route.ts
@@ -2,6 +2,7 @@ import { Feed } from 'feed';
 import { NextResponse } from 'next/server';
 
 import { getReleaseNotes } from '@/app/actions/release-notes';
+import { sanitizeStrict } from '@/lib/sanitization';
 import type { ReleaseChange } from '@/types/release';
 
 export async function GET() {
@@ -22,7 +23,7 @@ export async function GET() {
 
     // Add items to feed
     notes.forEach((note) => {
-      const content = note.content.body || 
+      const content = sanitizeStrict(note.content.body || 
         Object.entries(note.content)
           .filter(([key, value]) => Array.isArray(value) && value.length > 0)
           .map(([key, changes]) => {
@@ -41,7 +42,7 @@ export async function GET() {
               </ul>
             `;
           })
-          .join('');
+          .join(''));
 
       feed.addItem({
         title: `${note.repository} ${note.version}`,

--- a/app/api/settings/avatar/route.ts
+++ b/app/api/settings/avatar/route.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm';
 import { mkdir, writeFile } from 'fs/promises';
 import { NextRequest, NextResponse } from 'next/server';
 import { join } from 'path';
+import sharp from 'sharp';
 
 import { db } from '@/db';
 import { users } from '@/db/schema';
@@ -36,14 +37,22 @@ export async function POST(req: NextRequest) {
       return new NextResponse('File size must be less than 1MB', { status: 400 });
     }
 
-    // Create unique filename
-    const ext = file.name.split('.').pop();
-    const filename = `${session.user.id}-${Date.now()}.${ext}`;
+    // Never serve the uploaded bytes or a client-selected extension. Decode a
+    // bounded raster and re-encode it without metadata on our own origin.
+    let buffer: Buffer;
+    try {
+      const bytes = Buffer.from(await file.arrayBuffer());
+      const image = sharp(bytes, { limitInputPixels: 16_000_000, animated: false });
+      const metadata = await image.metadata();
+      if (!['jpeg', 'png', 'webp', 'gif', 'avif'].includes(metadata.format || '')) {
+        return new NextResponse('File must be a raster image', { status: 400 });
+      }
+      buffer = await image.rotate().resize(512, 512, { fit: 'inside', withoutEnlargement: true }).webp().toBuffer();
+    } catch {
+      return new NextResponse('Invalid image', { status: 400 });
+    }
+    const filename = `${session.user.id}-${Date.now()}.webp`;
     const path = join(process.cwd(), 'public', 'avatars', filename);
-    
-    // Convert File to Buffer
-    const bytes = await file.arrayBuffer();
-    const buffer = Buffer.from(bytes);
 
     // Ensure avatars directory exists
     const avatarsDir = join(process.cwd(), 'public', 'avatars');

--- a/app/api/settings/avatar/route.ts
+++ b/app/api/settings/avatar/route.ts
@@ -44,7 +44,8 @@ export async function POST(req: NextRequest) {
       const bytes = Buffer.from(await file.arrayBuffer());
       const image = sharp(bytes, { limitInputPixels: 16_000_000, animated: false });
       const metadata = await image.metadata();
-      if (!['jpeg', 'png', 'webp', 'gif', 'avif'].includes(metadata.format || '')) {
+      // Sharp reports AVIF's container as heif, not avif.
+      if (!['jpeg', 'png', 'webp', 'gif', 'heif'].includes(metadata.format || '')) {
         return new NextResponse('File must be a raster image', { status: 400 });
       }
       buffer = await image.rotate().resize(512, 512, { fit: 'inside', withoutEnlargement: true }).webp().toBuffer();

--- a/lib/admin-notifications.ts
+++ b/lib/admin-notifications.ts
@@ -1,4 +1,5 @@
 import { sendEmail } from '@/lib/email';
+import { escapeHtml } from '@/lib/email-layout';
 
 export type AdminNotificationSeverity = 'INFO' | 'WARNING' | 'ALERT' | 'CRITICAL';
 
@@ -108,7 +109,7 @@ function generateAdminNotificationHtml(options: {
     <head>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>${title}</title>
+      <title>${escapeHtml(title)}</title>
     </head>
     <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f3f4f6; color: #1f2937;">
       <table role="presentation" cellspacing="0" cellpadding="0" width="100%" style="background-color: #f3f4f6; padding: 20px;">
@@ -128,11 +129,11 @@ function generateAdminNotificationHtml(options: {
               <tr>
                 <td style="padding: 24px;">
                   <h1 style="margin: 0 0 16px; color: #1f2937; font-size: 20px; font-weight: 600;">
-                    ${title}
+                    ${escapeHtml(title)}
                   </h1>
                   
                   <div style="color: #4b5563; font-size: 16px; line-height: 1.5; margin-bottom: 20px;">
-                    ${message}
+                    ${escapeHtml(message)}
                   </div>
                   
                   ${userDetails ? `
@@ -144,25 +145,25 @@ function generateAdminNotificationHtml(options: {
                         ${userDetails.name ? `
                           <tr>
                             <td style="padding: 4px 0; font-weight: 600; width: 100px;">Name:</td>
-                            <td style="padding: 4px 0;">${userDetails.name}</td>
+                            <td style="padding: 4px 0;">${escapeHtml(userDetails.name)}</td>
                           </tr>
                         ` : ''}
                         ${userDetails.email ? `
                           <tr>
                             <td style="padding: 4px 0; font-weight: 600;">Email:</td>
-                            <td style="padding: 4px 0;">${userDetails.email}</td>
+                            <td style="padding: 4px 0;">${escapeHtml(userDetails.email)}</td>
                           </tr>
                         ` : ''}
                         ${userDetails.id ? `
                           <tr>
                             <td style="padding: 4px 0; font-weight: 600;">User ID:</td>
-                            <td style="padding: 4px 0; font-family: monospace; font-size: 12px;">${userDetails.id}</td>
+                            <td style="padding: 4px 0; font-family: monospace; font-size: 12px;">${escapeHtml(userDetails.id)}</td>
                           </tr>
                         ` : ''}
                         ${userDetails.source ? `
                           <tr>
                             <td style="padding: 4px 0; font-weight: 600;">Source:</td>
-                            <td style="padding: 4px 0;">${userDetails.source}</td>
+                            <td style="padding: 4px 0;">${escapeHtml(userDetails.source)}</td>
                           </tr>
                         ` : ''}
                       </table>
@@ -175,7 +176,7 @@ function generateAdminNotificationHtml(options: {
                         Additional Information
                       </h3>
                       <pre style="margin: 0; font-family: monospace; font-size: 12px; color: #4b5563; white-space: pre-wrap; word-wrap: break-word;">
-${JSON.stringify(metadata, null, 2)}
+${escapeHtml(JSON.stringify(metadata, null, 2))}
                       </pre>
                     </div>
                   ` : ''}
@@ -192,7 +193,7 @@ ${JSON.stringify(metadata, null, 2)}
                   
                   <!-- Admin Dashboard Link -->
                   <div style="margin-top: 24px; text-align: center;">
-                    <a href="${appUrl}/admin" style="display: inline-block; padding: 12px 24px; background-color: #3b82f6; color: #ffffff; text-decoration: none; font-weight: 600; border-radius: 6px; font-size: 14px;">
+                    <a href="${escapeHtml(appUrl)}/admin" style="display: inline-block; padding: 12px 24px; background-color: #3b82f6; color: #ffffff; text-decoration: none; font-weight: 600; border-radius: 6px; font-size: 14px;">
                       View Admin Dashboard
                     </a>
                   </div>
@@ -203,7 +204,7 @@ ${JSON.stringify(metadata, null, 2)}
               <tr>
                 <td style="background-color: #f9fafb; padding: 16px 24px; text-align: center; border-top: 1px solid #e5e7eb;">
                   <p style="margin: 0; color: #6b7280; font-size: 12px;">
-                    This is an automated admin notification from ${appName}
+                    This is an automated admin notification from ${escapeHtml(appName)}
                   </p>
                 </td>
               </tr>

--- a/lib/agent-response.ts
+++ b/lib/agent-response.ts
@@ -12,9 +12,10 @@ const CLIENT_AGENT_FIELDS = [
 type ClientAgentField = typeof CLIENT_AGENT_FIELDS[number];
 
 /** Platform-issued credentials are injected into the pod, never returned to its owner. */
-export function toClientAgent<T extends object>(agent: T): Pick<T, Extract<keyof T, ClientAgentField>> {
-  return Object.fromEntries(
+export function toClientAgent<T extends object>(agent: T): Pick<T, Extract<keyof T, ClientAgentField>> & { has_model_router_token: boolean } {
+  const publicFields = Object.fromEntries(
     CLIENT_AGENT_FIELDS.filter((key) => Object.hasOwn(agent, key))
       .map((key) => [key, agent[key as keyof T]])
   ) as Pick<T, Extract<keyof T, ClientAgentField>>;
+  return { ...publicFields, has_model_router_token: Boolean((agent as { model_router_token?: unknown }).model_router_token) };
 }

--- a/lib/agent-response.ts
+++ b/lib/agent-response.ts
@@ -1,0 +1,5 @@
+/** Platform-issued credentials are injected into the pod, never returned to its owner. */
+export function toClientAgent<T extends { model_router_token?: unknown }>(agent: T): Omit<T, 'model_router_token'> {
+  const { model_router_token: _platformCredential, ...publicAgent } = agent;
+  return publicAgent;
+}

--- a/lib/agent-response.ts
+++ b/lib/agent-response.ts
@@ -1,5 +1,20 @@
+// Keep the client contract explicit: adding a database credential column must
+// never silently add it to every agent API response.
+const CLIENT_AGENT_FIELDS = [
+  'uuid', 'name', 'dns_name', 'profile_uuid', 'template_uuid', 'access_level',
+  'state', 'heartbeat_mode', 'deployment_status', 'kubernetes_namespace',
+  'kubernetes_deployment', 'model_router_service_uuid',
+  'model_router_token_issued_at', 'model_router_token_revoked',
+  'created_at', 'provisioned_at', 'activated_at', 'terminated_at',
+  'last_heartbeat_at', 'metadata', 'config_values',
+] as const;
+
+type ClientAgentField = typeof CLIENT_AGENT_FIELDS[number];
+
 /** Platform-issued credentials are injected into the pod, never returned to its owner. */
-export function toClientAgent<T extends { model_router_token?: unknown }>(agent: T): Omit<T, 'model_router_token'> {
-  const { model_router_token: _platformCredential, ...publicAgent } = agent;
-  return publicAgent;
+export function toClientAgent<T extends object>(agent: T): Pick<T, Extract<keyof T, ClientAgentField>> {
+  return Object.fromEntries(
+    CLIENT_AGENT_FIELDS.filter((key) => Object.hasOwn(agent, key))
+      .map((key) => [key, agent[key as keyof T]])
+  ) as Pick<T, Extract<keyof T, ClientAgentField>>;
 }

--- a/lib/pap-ui-utils.ts
+++ b/lib/pap-ui-utils.ts
@@ -33,7 +33,7 @@ export interface Agent {
   metadata?: Record<string, unknown>;
   // Model Router integration
   model_router_service_uuid?: string;
-  model_router_token?: string;
+  has_model_router_token?: boolean;
   model_router_token_issued_at?: string;
   model_router_token_revoked?: boolean;
 }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "remark-gfm": "^4.0.1",
     "sanitize-html": "^2.17.7",
     "server-only": "^0.0.1",
+    "sharp": "^0.35.3",
     "sonner": "^2.0.7",
     "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,6 +321,9 @@ importers:
       server-only:
         specifier: ^0.0.1
         version: 0.0.1
+      sharp:
+        specifier: ^0.35.3
+        version: 0.35.3(@types/node@24.10.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)

--- a/tests/security/admin-email-escaping.test.ts
+++ b/tests/security/admin-email-escaping.test.ts
@@ -1,0 +1,12 @@
+import { expect, it, vi } from 'vitest';
+const send = vi.hoisted(() => vi.fn(async (_message: { html: string }) => true));
+vi.mock('@/lib/email', () => ({ sendEmail: send }));
+import { notifyAdmins } from '@/lib/admin-notifications';
+it('escapes untrusted names, message text, and metadata in administrative email', async () => {
+ vi.stubEnv('ADMIN_NOTIFICATION_EMAILS', 'admin@example.com');
+ const payload = '<img src=x onerror=alert(1)>';
+ expect(await notifyAdmins({ subject: 'test', title: payload, message: payload, severity: 'ALERT', userDetails: { name: payload, email: payload, id: payload, source: payload }, metadata: { content: payload } })).toBe(true);
+ const html = send.mock.calls[0][0].html;
+ expect(html).not.toContain(payload);
+ expect(html).toContain('&lt;img');
+});

--- a/tests/security/agent-response-secrets.test.ts
+++ b/tests/security/agent-response-secrets.test.ts
@@ -1,6 +1,6 @@
 import { NextRequest } from 'next/server';
 import { expect, it, vi } from 'vitest';
-const agent = vi.hoisted(() => ({ uuid: 'agent', model_router_token: 'PLATFORM-SECRET', config_values: { api_key: 'CONFIG-SECRET' }, metadata: {}, access_level: 'PRIVATE' }));
+const agent = vi.hoisted(() => ({ uuid: 'agent', model_router_token: 'PLATFORM-SECRET', future_platform_credential: 'FUTURE-CREDENTIAL', config_values: { api_key: 'CONFIG-SECRET' }, metadata: {}, access_level: 'PRIVATE' }));
 vi.mock('@/app/api/auth', () => ({ authenticate: async () => ({ activeProfile: { uuid: 'profile' }, project: { user_id: 'owner' } }) }));
 vi.mock('@/lib/rate-limiter-redis', () => ({ EnhancedRateLimiters: { agentRead: async () => ({ allowed: true }), agentUpdate: async () => ({ allowed: true }), agentIntensive: async () => ({ allowed: true }) } }));
 vi.mock('@/lib/services/kubernetes-service', () => ({ kubernetesService: {} }));
@@ -19,5 +19,6 @@ it.each(['GET', 'PATCH', 'EXPORT'])('does not expose platform model credentials 
  const text = await response.text();
  expect(text).toContain('agent');
  expect(text).not.toContain('PLATFORM-SECRET');
+ expect(text).not.toContain('FUTURE-CREDENTIAL');
  if (method === 'EXPORT') expect(text).not.toContain('CONFIG-SECRET');
 });

--- a/tests/security/agent-response-secrets.test.ts
+++ b/tests/security/agent-response-secrets.test.ts
@@ -17,6 +17,7 @@ it.each(['GET', 'PATCH', 'EXPORT'])('does not expose platform model credentials 
  const response = method === 'GET' ? await GET(request, params) : method === 'PATCH' ? await PATCH(request, params) : await POST(request, params);
  expect(response.status).toBe(200);
  const text = await response.text();
+ expect(JSON.parse(text).agent.has_model_router_token).toBe(true);
  expect(text).toContain('agent');
  expect(text).not.toContain('PLATFORM-SECRET');
  expect(text).not.toContain('FUTURE-CREDENTIAL');

--- a/tests/security/agent-response-secrets.test.ts
+++ b/tests/security/agent-response-secrets.test.ts
@@ -1,0 +1,23 @@
+import { NextRequest } from 'next/server';
+import { expect, it, vi } from 'vitest';
+const agent = vi.hoisted(() => ({ uuid: 'agent', model_router_token: 'PLATFORM-SECRET', config_values: { api_key: 'CONFIG-SECRET' }, metadata: {}, access_level: 'PRIVATE' }));
+vi.mock('@/app/api/auth', () => ({ authenticate: async () => ({ activeProfile: { uuid: 'profile' }, project: { user_id: 'owner' } }) }));
+vi.mock('@/lib/rate-limiter-redis', () => ({ EnhancedRateLimiters: { agentRead: async () => ({ allowed: true }), agentUpdate: async () => ({ allowed: true }), agentIntensive: async () => ({ allowed: true }) } }));
+vi.mock('@/lib/services/kubernetes-service', () => ({ kubernetesService: {} }));
+vi.mock('@/db', async () => {
+ const { agentsTable } = await import('@/db/schema');
+ const db = { insert: () => ({ values: async () => undefined }), select: () => ({ from: (table: unknown) => ({ where: () => ({ limit: async () => table === agentsTable ? [agent] : [], orderBy: () => ({ limit: async () => [] }) }) }) }), update: () => ({ set: () => ({ where: () => ({ returning: async () => [agent] }) }) }), transaction: async (fn: any) => fn(db) };
+ return { db };
+});
+import { POST } from '@/app/api/agents/[id]/export/route';
+import { GET, PATCH } from '@/app/api/agents/[id]/route';
+it.each(['GET', 'PATCH', 'EXPORT'])('does not expose platform model credentials through %s', async (method) => {
+ const params = { params: Promise.resolve({ id: 'agent' }) };
+ const request = new NextRequest('https://plugged.in/api/agents/agent', { method: method === 'GET' ? 'GET' : 'POST', ...(method === 'GET' ? {} : { body: JSON.stringify({ metadata: { description: 'test' } }) }) });
+ const response = method === 'GET' ? await GET(request, params) : method === 'PATCH' ? await PATCH(request, params) : await POST(request, params);
+ expect(response.status).toBe(200);
+ const text = await response.text();
+ expect(text).toContain('agent');
+ expect(text).not.toContain('PLATFORM-SECRET');
+ if (method === 'EXPORT') expect(text).not.toContain('CONFIG-SECRET');
+});

--- a/tests/security/avatar-raster-upload.test.ts
+++ b/tests/security/avatar-raster-upload.test.ts
@@ -1,0 +1,28 @@
+import sharp from 'sharp';
+import { beforeEach, expect, it, vi } from 'vitest';
+const m = vi.hoisted(() => ({ write: vi.fn(), update: vi.fn() }));
+vi.mock('fs/promises', () => ({ default: { mkdir: vi.fn(), writeFile: m.write }, mkdir: vi.fn(), writeFile: m.write }));
+vi.mock('@/lib/auth', () => ({ getAuthSession: async () => ({ user: { id: 'owner' } }) }));
+vi.mock('@/lib/csrf-protection', () => ({ validateCSRF: async () => null }));
+vi.mock('@/db', () => ({ db: { update: () => ({ set: m.update }) } }));
+import type { NextRequest } from 'next/server';
+
+import { POST } from '@/app/api/settings/avatar/route';
+const request = (bytes: Uint8Array, name: string) => ({ formData: async () => ({ get: () => ({ name, type: 'image/png', size: bytes.length, arrayBuffer: async () => bytes }) }) }) as unknown as NextRequest;
+beforeEach(() => { vi.clearAllMocks(); m.update.mockReturnValue({ where: async () => undefined }); });
+it.each(['payload.html', 'payload.svg'])('rejects executable content disguised as %s', async (name) => {
+ const response = await POST(request(Buffer.from('<svg onload="alert(1)"></svg>'), name));
+ expect(response.status).toBe(400);
+ expect(m.write).not.toHaveBeenCalled();
+ expect(m.update).not.toHaveBeenCalled();
+});
+it('re-encodes a raster and derives its public extension on the server', async () => {
+ const png = await sharp({ create: { width: 2, height: 2, channels: 3, background: '#ffffff' } }).png().toBuffer();
+ const response = await POST(request(png, 'payload.html'));
+ expect(response.status).toBe(200);
+ const json = await response.json();
+ expect(json.image).toMatch(/\.webp$/);
+ const written = m.write.mock.calls.find(([file]) => String(file).endsWith('.webp'));
+ expect(written).toBeDefined();
+ expect((await sharp(written![1]).metadata()).format).toBe('webp');
+});

--- a/tests/security/avatar-raster-upload.test.ts
+++ b/tests/security/avatar-raster-upload.test.ts
@@ -16,8 +16,8 @@ it.each(['payload.html', 'payload.svg'])('rejects executable content disguised a
  expect(m.write).not.toHaveBeenCalled();
  expect(m.update).not.toHaveBeenCalled();
 });
-it('re-encodes a raster and derives its public extension on the server', async () => {
- const png = await sharp({ create: { width: 2, height: 2, channels: 3, background: '#ffffff' } }).png().toBuffer();
+it.each(['png', 'avif'] as const)('re-encodes a %s raster and derives its public extension on the server', async (format) => {
+ const png = await sharp({ create: { width: 2, height: 2, channels: 3, background: '#ffffff' } }).toFormat(format).toBuffer();
  const response = await POST(request(png, 'payload.html'));
  expect(response.status).toBe(200);
  const json = await response.json();

--- a/tests/security/community-claim-ownership.test.ts
+++ b/tests/security/community-claim-ownership.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+const m = vi.hoisted(() => ({ user: 'attacker', verify: vi.fn(), publish: vi.fn(), tx: vi.fn(), accounts: vi.fn() }));
+vi.mock('@/lib/auth', () => ({ getAuthSession: async () => ({ user: { id: m.user } }) }));
+vi.mock('@/app/actions/registry-servers', () => ({ verifyGitHubOwnership: m.verify }));
+vi.mock('@/lib/registry/pluggedin-registry-client', () => ({ PluggedinRegistryClient: class { publishServer = m.publish; } }));
+vi.mock('@/db', () => ({ db: {
+ query: { sharedMcpServersTable: { findFirst: async () => ({ is_public: true, profile: { project: { user_id: 'owner' } }, template: { command: 'npx', args: ['test'], env: { TOKEN: 'SECRET-LEGACY' } } }) }, accounts: { findFirst: m.accounts } },
+ transaction: m.tx,
+} }));
+import { claimCommunityServer } from '@/app/actions/community-servers';
+beforeEach(() => { vi.clearAllMocks(); m.verify.mockResolvedValue({ isOwner: true }); m.accounts.mockResolvedValue({ access_token: 'session-token' }); m.publish.mockRejectedValue(new Error('test stops publishing')); m.tx.mockResolvedValue({}); });
+it('rejects a foreign share before using credentials or publishing', async () => {
+ m.user = 'attacker';
+ const result = await claimCommunityServer({ communityServerUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', repositoryUrl: 'https://github.com/attacker/repo', registryToken: 'caller-token' });
+ expect(result.success).toBe(false);
+ expect(m.verify).not.toHaveBeenCalled(); expect(m.publish).not.toHaveBeenCalled(); expect(m.tx).not.toHaveBeenCalled();
+});
+it('uses the owner session token and sanitizes legacy secrets before publishing', async () => {
+ m.user = 'owner';
+ await claimCommunityServer({ communityServerUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', repositoryUrl: 'https://github.com/owner/repo', registryToken: 'caller-token' });
+ expect(m.verify).toHaveBeenCalledWith('session-token', 'https://github.com/owner/repo');
+ expect(m.publish).toHaveBeenCalled();
+ expect(JSON.stringify(m.publish.mock.calls[0][0])).not.toContain('SECRET-LEGACY');
+});

--- a/tests/security/community-template-redaction.test.ts
+++ b/tests/security/community-template-redaction.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+const m = vi.hoisted(() => ({ first: vi.fn(), many: vi.fn(), written: [] as any[] }));
+vi.mock('@/lib/auth', () => ({ getAuthSession: async () => ({ user: { id: 'owner' } }) }));
+vi.mock('@/app/actions/registry-servers', () => ({ verifyGitHubOwnership: vi.fn() }));
+vi.mock('@/lib/registry/pluggedin-registry-client', () => ({ PluggedinRegistryClient: class {} }));
+vi.mock('@/db', () => ({ db: {
+ query: { profilesTable: { findFirst: async () => ({ project: { user_id: 'owner' } }) }, mcpServersTable: { findFirst: async () => null }, registryServersTable: { findFirst: async () => null }, sharedMcpServersTable: { findFirst: m.first, findMany: m.many } },
+ insert: () => ({ values: (v: any) => { m.written.push(v); return { returning: async () => [{ uuid: 'new', ...v }] }; } }),
+} }));
+import { createCommunityServer, getClaimableCommunityServers,getCommunityServer } from '@/app/actions/community-servers';
+import { McpServerType } from '@/db/schema';
+const template = { name: 'test', type: McpServerType.STDIO, command: 'npx', args: ['server', '--token', 'SECRET-ARG'], env: { API_KEY: 'SECRET-ENV' }, streamableHTTPOptions: { headers: { Authorization: 'SECRET-HEADER' } } };
+beforeEach(() => { vi.clearAllMocks(); m.written.length = 0; m.many.mockResolvedValue([]); });
+it('redacts the public template on creation while preserving the private local configuration', async () => {
+ const result = await createCommunityServer({ title: 'Test', template, profileUuid: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' });
+ expect(result.success).toBe(true);
+ expect(JSON.stringify(m.written.find(v => v.template)?.template)).not.toContain('SECRET-');
+ expect(m.written.find(v => v.command)?.env.API_KEY).toBe('SECRET-ENV');
+});
+it.each(['single', 'list'])('redacts legacy public %s reads including the live server relation', async (kind) => {
+ const share = { uuid: 'share', is_public: true, template, server: { uuid: 'server', ...template } };
+ m.first.mockResolvedValue(share); m.many.mockResolvedValue([share]);
+ const result = kind === 'single' ? await getCommunityServer('share') : await getClaimableCommunityServers();
+ expect(result.success).toBe(true);
+ expect(JSON.stringify(result)).not.toContain('SECRET-');
+});

--- a/tests/security/registry-repository-binding.test.ts
+++ b/tests/security/registry-repository-binding.test.ts
@@ -1,0 +1,16 @@
+import { beforeEach, expect, it, vi } from 'vitest';
+const m = vi.hoisted(() => ({ token: vi.fn() }));
+vi.mock('@/lib/auth-helpers', () => ({ withAuth: async (fn: any) => fn({ user: { id: 'owner' } }), withProfileAuth: vi.fn() }));
+vi.mock('@/app/actions/registry-oauth-session', () => ({ getRegistryOAuthToken: m.token }));
+vi.mock('@/db', () => ({ db: {} }));
+import { submitWizardToRegistry } from '@/app/actions/registry-servers';
+beforeEach(() => { vi.clearAllMocks(); m.token.mockResolvedValue({ success: false }); });
+it('rejects repository identity different from the verified URL before requesting credentials', async () => {
+ const result = await submitWizardToRegistry({ githubUrl: 'https://github.com/owner/repo', owner: 'victim', repo: 'reputable', shouldClaim: true } as any);
+ expect(result).toMatchObject({ success: false, error: expect.stringMatching(/match|repository identity/i) });
+ expect(m.token).not.toHaveBeenCalled();
+});
+it('continues normal ownership verification for a matching repository', async () => {
+ await submitWizardToRegistry({ githubUrl: 'https://github.com/owner/repo', owner: 'owner', repo: 'repo', shouldClaim: true } as any);
+ expect(m.token).toHaveBeenCalledOnce();
+});

--- a/tests/security/release-rss-escaping.test.ts
+++ b/tests/security/release-rss-escaping.test.ts
@@ -1,0 +1,13 @@
+import { expect, it, vi } from 'vitest';
+const notes = vi.hoisted(() => [] as any[]);
+vi.mock('@/app/actions/release-notes', () => ({ getReleaseNotes: async () => ({ notes }) }));
+import { GET } from '@/app/api/release-notes/rss/route';
+it.each(['body', 'changes'])('removes executable markup from RSS %s', async (kind) => {
+ const payload = '<img src=x onerror=alert(1)>';
+ notes.splice(0, notes.length, { repository: 'pluggedin-app', version: 'v1', releaseDate: '2026-01-01', content: kind === 'body' ? { body: payload } : { added: [{ message: payload, commitUrl: 'javascript:alert(1)', contributors: [payload] }] } });
+ const response = await GET();
+ expect(response.status).toBe(200);
+ const text = await response.text();
+ expect(text).not.toContain(payload);
+ expect(text).not.toContain('href="javascript:');
+});

--- a/tests/security/settings-user-props.test.tsx
+++ b/tests/security/settings-user-props.test.tsx
@@ -1,0 +1,18 @@
+import { expect, it, vi } from 'vitest';
+const raw = vi.hoisted(() => ({ id: 'owner', name: 'Owner', email: 'owner@example.com', image: null,
+  password: 'SECRET-HASH', two_fa_secret: 'SECRET-2FA', two_fa_backup_codes: ['SECRET-BACKUP'], last_login_ip: 'SECRET-IP',
+}));
+vi.mock('@/lib/auth', () => ({ getAuthSession: async () => ({ user: { id: 'owner' } }) }));
+vi.mock('@/db', () => ({ db: { query: { users: { findFirst: async () => raw } } } }));
+vi.mock('@/app/(sidebar-layout)/(container)/settings/actions', () => ({ getConnectedAccounts: async () => [], getUserEmailPreferences: async () => null }));
+vi.mock('@/app/(sidebar-layout)/(container)/settings/components/settings-form', () => ({ SettingsForm: () => null }));
+vi.mock('@/app/(sidebar-layout)/(container)/settings/components/settings-title', () => ({ SettingsTitle: () => null }));
+vi.mock('@/app/(sidebar-layout)/(container)/settings/components/email-preferences-section', () => ({ EmailPreferencesSection: () => null }));
+import SettingsPage from '@/app/(sidebar-layout)/(container)/settings/page';
+it('passes only display fields and a password-presence boolean across the client boundary', async () => {
+  const tree = await SettingsPage();
+  const serialized = JSON.stringify(tree);
+  expect(serialized).not.toContain('SECRET-');
+  expect(serialized).toContain('owner@example.com');
+  expect(serialized).toContain('"hasPassword":true');
+});

--- a/tests/security/shared-server-route-redaction.test.ts
+++ b/tests/security/shared-server-route-redaction.test.ts
@@ -1,0 +1,13 @@
+import { expect, it, vi } from 'vitest';
+vi.mock('@/lib/auth', () => ({ getAuthSession: async () => null }));
+vi.mock('@/db', () => ({ db: { query: { sharedMcpServersTable: { findMany: async () => [{ created_at: new Date(), template: { env: { KEY: 'SECRET-TEMPLATE' } }, server: { uuid: 'server', command: 'npx', args: ['mcp', '--token', 'SECRET-ARG'], url: 'https://example.com/mcp?api_key=SECRET-URL' } }] } } } }));
+import { NextRequest } from 'next/server';
+
+import { GET } from '@/app/api/profile/[profileId]/shared-servers/route';
+it('sanitizes both stored templates and live server connection fields on public reads', async () => {
+ const response = await GET(new NextRequest('https://plugged.in/api/profile/profile/shared-servers'), { params: Promise.resolve({ profileId: 'profile' }) });
+ expect(response.status).toBe(200);
+ const data = await response.json();
+ expect(data[0].server.uuid).toBe('server');
+ expect(JSON.stringify(data)).not.toContain('SECRET-');
+});

--- a/tests/security/user-relation-columns.test.ts
+++ b/tests/security/user-relation-columns.test.ts
@@ -33,6 +33,7 @@ const rowWithFullOwner = (isPublic: boolean) => ({
   template: {},
   profile: {
     project: {
+      user_id: 'owner',
       user: {
         id: 'owner',
         username: 'owner',
@@ -139,7 +140,7 @@ describe('claimCommunityServer does not accept private shares', () => {
   };
 
   beforeEach(() => {
-    getAuthSession.mockResolvedValue({ user: { id: 'claimer' } });
+    getAuthSession.mockResolvedValue({ user: { id: 'owner' } });
   });
 
   it('stops before reading the claimer credentials for a private share', async () => {


### PR DESCRIPTION
Private credentials could escape through settings props, community templates, public shared-server responses and agent exports. This change returns explicit public data, sanitizes both stored and legacy share templates, removes private server relations, and withholds platform model-router credentials. Community claims require the share owner and session GitHub credential; publication identity must match the verified repository URL.

Avatar uploads are decoded as bounded raster images and re-encoded as WebP. Administrative email and release-feed HTML escape or sanitize untrusted text.

Part 2 of the three-part HIGH security stack; based on main after #244. Each root cause has a separate commit and mutation-checked regression fixture. [All 65 verdicts and evidence](https://github.com/VeriTeknik/pluggedin-app/blob/security/high-mcp-isolation/docs/security/high-triage-2026-09-07.md).

Validation of the complete stack: production Next.js build succeeded; the full suite retained exactly the baseline's 189 failed assertion names and 10 suite-load errors, with no new failures. 1,896 assertions passed. No migration or workflow edits. Agent/cluster production counts were zero during the read-only compatibility check.
