### PR TITLE
fix(security): close remaining public-share metadata leaks

### DIFF
--- a/app/api/profile/[profileId]/shared-servers/route.ts
+++ b/app/api/profile/[profileId]/shared-servers/route.ts
@@ -94,7 +94,6 @@ export async function GET(
           columns: {
             uuid: true,
             name: true,
-            project_uuid: true,
           }
         }
       },
@@ -107,6 +106,7 @@ export async function GET(
     
     return NextResponse.json(sortedServers.map(share => ({
       ...share,
+      profile: share.profile ? { uuid: share.profile.uuid, name: share.profile.name } : null,
       template: sanitizeServerTemplate(share.template),
       server: sanitizeServerTemplate(share.server),
     })));

--- a/docs/security/high-triage-2026-09-07.md
+++ b/docs/security/high-triage-2026-09-07.md
@@ -7,7 +7,7 @@ The 65 active HIGH records from the 2026-09-06 scan were checked against baselin
 ## Verification
 
 - Work and builds used an isolated `/tmp` worktree; the live checkout was not used for development.
-- Clean immutable baseline reproduced **189 failed assertions and 10 suite-load errors**, rather than the handoff's 188. Final full run: **1,896 passed, 189 failed, 53 pending**, with the **same 189 failing names and same 10 suite-load failures**. New failures: **zero**. This is not a green full test suite.
+- Clean immutable baseline reproduced **189 failed assertions and 10 suite-load errors**, rather than the handoff's 188. Final full run: **1,897 passed, 189 failed, 53 pending**, with the **same 189 failing names and same 10 suite-load failures**. New failures: **zero**. This is not a green full test suite.
 - [Machine-readable comparison](high-triage-validation-2026-09-07.json) records names, suite failures, new assertions, and the intentional duplicate-registration test rename. Existing assertions were retained; its replacement now requires preservation of the pending account.
 - Every new security regression fixture was run against the defect, the fix, and a reverted/broken fix. The mutation runs failed as expected. Server-only boundary tests inspect exports/directives; route tests exercise authorization and response behavior. They do not prove untested paths.
 - MCP HTTP fixtures use real loopback connections, verify pinned connection selection, streamed delivery before EOF, cancellation and body limits. The installed Streamable HTTP SDK invokes the pinned hook. A real bubblewrap child could write its private cache but could not read a sibling credential fixture; restoring the shared mount at its original position made that test fail. The integration fixture skips only when the host lacks working bubblewrap/user namespaces.
@@ -90,7 +90,7 @@ The known GET/DELETE session-ownership defect was also fixed in [`2c35225d`](htt
 
 ## Review follow-ups
 
-The same full-suite comparison and a fresh production build were repeated after these changes; the final result is 1,896 passed, the original 189 failed names, 53 pending and the original 10 suite-load errors.
+The same full-suite comparison and a fresh production build were repeated after these changes; the final result is 1,897 passed, the original 189 failed names, 53 pending and the original 10 suite-load errors.
 
 - #37: `beb73fd9` closes the legacy JWT gap: null/missing password versions are revoked after a reset, and refreshing legacy user fields cannot overwrite an old password version. `password-reset-jwt-revalidation.test.ts` tests the real callback; restoring the old callback fails three cases. Revocation occurs on the existing user-revalidation interval (up to 15 minutes), not immediately at reset time.
 - #22: `cead3e7a` also constrains the stored active-profile reference by project and repairs a stale cross-project reference. The query-level fixture fails when this predicate is removed. Production contained zero such mismatches.
@@ -101,6 +101,13 @@ The same full-suite comparison and a fresh production build were repeated after 
 - #30/#31: `c7d684f2` preserves the token-status banner using a server-derived `has_model_router_token` boolean while keeping credentials private. GET/PATCH/export assertions pass; restoring the old helper fails all three presence assertions.
 - #60/#61: the streaming-error review allegation was rejected against the real HTTP fixture: `response.text()` rejects on the size limit, and abort/cancellation propagate. A streaming fetch resolves at headers; later failures reject body reads.
 - #2/#52: `8aa59030` accepts AVIF using Sharp's actual `heif` metadata format, retaining bounded raster decoding and WebP output. Restoring the incorrect format name fails the AVIF fixture. Production's four local avatar references all had PNG extensions.
+
+## Late review verification
+
+- #50: `74d3f9fb` removes the complete OAuth object from public shared transport options, including legacy templates. The unauthenticated route fixture fails with the original sanitizer, passes with the fix, and fails when the fix is reverted.
+- #50: `e588b299` limits public profile relations to UUID/name and no longer selects the private project UUID. The public response assertion fails before and under mutation, and passes with the projection.
+- Unclaimed community contributions intentionally support third-party repositories and persist `is_claimed:false`; verified registry claims still require GitHub ownership. Owner agent endpoints constrain the profile and intentionally return owner-supplied configuration; platform-issued credentials remain excluded and exports redact secrets. These late allegations did not demonstrate an authorization bypass.
+- The legacy root `docker-compose.production.yml` references an nginx config absent at baseline. That recipe requires operator-provided proxy configuration; closing its direct public app port does not repair this pre-existing setup gap. A complete legacy nginx recipe remains an operational follow-up. The live deployment uses the separate tracked Traefik/SOPS configuration.
 
 ## Operational scope and remaining work
 

--- a/docs/security/high-triage-validation-2026-09-07.json
+++ b/docs/security/high-triage-validation-2026-09-07.json
@@ -1,7 +1,7 @@
 {
   "baselineCommit": "623105ae6b7adcbaa6755bce15534c80b4a0562a",
-  "verifiedSourceCommit": "39a1e31c6eb7ad5f9d60eb0d1f3896b60e30ec33",
-  "verifiedSourceTree": "0698e3c58a9e9b5fbfde1342adf2891cc83238f9",
+  "verifiedSourceCommit": "e588b299d13d4ddfbef36753163ce5dc78d591be",
+  "verifiedSourceTree": "e33495b0e8e9529f1c55ba90987fee16c407f846",
   "baselineFailedTests": [
     "API Keys Actions trackApiKeyUsage should batch updates for same key within debounce window",
     "API Keys Actions trackApiKeyUsage should debounce usage updates and use atomic timestamp",
@@ -534,7 +534,8 @@
     "authorizes tool schemas for owner": "passed",
     "does not expose the unused client-controlled audit writer endpoint": "passed",
     "does not expose the unused shared long-lived model configuration credential endpoint": "passed",
-    "registration does not delete tokens by address preserves the existing user and their pending verification token": "passed"
+    "registration does not delete tokens by address preserves the existing user and their pending verification token": "passed",
+    "omits the private project relation from public profile details": "passed"
   },
   "removedOrRenamedAssertions": [
     "registration does not delete tokens by address relies on deleting the user instead"

--- a/lib/server-template.ts
+++ b/lib/server-template.ts
@@ -105,7 +105,7 @@ export function sanitizeServerTemplate<T>(template: T): T {
 
   // Transport headers are pure credentials, and a session id is a live handle.
   if (sanitized.streamableHTTPOptions && typeof sanitized.streamableHTTPOptions === 'object') {
-    const { sessionId: _sessionId, headers, ...rest } = sanitized.streamableHTTPOptions;
+    const { sessionId: _sessionId, oauth: _oauth, headers, ...rest } = sanitized.streamableHTTPOptions;
     sanitized.streamableHTTPOptions = { ...rest };
     if (headers && typeof headers === 'object') {
       sanitized.streamableHTTPOptions.headers = Object.fromEntries(

--- a/tests/security/shared-server-route-redaction.test.ts
+++ b/tests/security/shared-server-route-redaction.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from 'vitest';
 vi.mock('@/lib/auth', () => ({ getAuthSession: async () => null }));
-vi.mock('@/db', () => ({ db: { query: { sharedMcpServersTable: { findMany: async () => [{ created_at: new Date(), template: { env: { KEY: 'SECRET-TEMPLATE' }, streamableHTTPOptions: { oauth: { accessToken: 'SECRET-OAUTH', refreshToken: 'SECRET-REFRESH', clientSecret: 'SECRET-CLIENT' }, enableResumption: true } }, server: { uuid: 'server', command: 'npx', args: ['mcp', '--token', 'SECRET-ARG'], url: 'https://example.com/mcp?api_key=SECRET-URL' } }] } } } }));
+vi.mock('@/db', () => ({ db: { query: { sharedMcpServersTable: { findMany: async () => [{ created_at: new Date(), profile: { uuid: 'profile', name: 'Public name', project_uuid: 'private-project' }, template: { env: { KEY: 'SECRET-TEMPLATE' }, streamableHTTPOptions: { oauth: { accessToken: 'SECRET-OAUTH', refreshToken: 'SECRET-REFRESH', clientSecret: 'SECRET-CLIENT' }, enableResumption: true } }, server: { uuid: 'server', command: 'npx', args: ['mcp', '--token', 'SECRET-ARG'], url: 'https://example.com/mcp?api_key=SECRET-URL' } }] } } } }));
 import { NextRequest } from 'next/server';
 
 import { GET } from '@/app/api/profile/[profileId]/shared-servers/route';
@@ -10,4 +10,11 @@ it('sanitizes both stored templates and live server connection fields on public 
  const data = await response.json();
  expect(data[0].server.uuid).toBe('server');
  expect(JSON.stringify(data)).not.toContain('SECRET-');
+});
+
+it('omits the private project relation from public profile details', async () => {
+ const response = await GET(new NextRequest('https://plugged.in/api/profile/profile/shared-servers'), { params: Promise.resolve({ profileId: 'profile' }) });
+ expect(response.status).toBe(200);
+ const data = await response.json();
+ expect(data[0].profile).toEqual({ uuid: 'profile', name: 'Public name' });
 });

--- a/tests/security/shared-server-route-redaction.test.ts
+++ b/tests/security/shared-server-route-redaction.test.ts
@@ -1,6 +1,6 @@
 import { expect, it, vi } from 'vitest';
 vi.mock('@/lib/auth', () => ({ getAuthSession: async () => null }));
-vi.mock('@/db', () => ({ db: { query: { sharedMcpServersTable: { findMany: async () => [{ created_at: new Date(), template: { env: { KEY: 'SECRET-TEMPLATE' } }, server: { uuid: 'server', command: 'npx', args: ['mcp', '--token', 'SECRET-ARG'], url: 'https://example.com/mcp?api_key=SECRET-URL' } }] } } } }));
+vi.mock('@/db', () => ({ db: { query: { sharedMcpServersTable: { findMany: async () => [{ created_at: new Date(), template: { env: { KEY: 'SECRET-TEMPLATE' }, streamableHTTPOptions: { oauth: { accessToken: 'SECRET-OAUTH', refreshToken: 'SECRET-REFRESH', clientSecret: 'SECRET-CLIENT' }, enableResumption: true } }, server: { uuid: 'server', command: 'npx', args: ['mcp', '--token', 'SECRET-ARG'], url: 'https://example.com/mcp?api_key=SECRET-URL' } }] } } } }));
 import { NextRequest } from 'next/server';
 
 import { GET } from '@/app/api/profile/[profileId]/shared-servers/route';


### PR DESCRIPTION
Public shared-server templates could retain credentials nested inside streamableHTTPOptions.oauth, and public profile relations included an unnecessary project UUID. Drop the OAuth object in the shared sanitizer and project profile responses to UUID/name; existing templates are sanitized on read.

Follow-up to #245 for late review comments. Each fix has a separate commit and a route regression that fails before the fix, passes after, and fails with the fix reverted. Complete suite: 1,897 passed, the same baseline 189 failed assertion names and 10 suite-load errors, 53 pending; no new failures. Production Next.js build passed. Lint has no errors and one existing unused-session warning. No migrations or workflow edits. The evidence report records the fixes and disposition of other late review comments.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/247"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791406052&installation_model_id=430597&pr_number=247&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F247&signature=e0c2f208700d901aa11c544f2e1c1671a9214af1cf18d163860dc60bec719aab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Close remaining public metadata leaks from shared-server and profile responses.

Bug Fixes:
- Prevent OAuth credentials nested in public shared-server templates from being exposed.
- Remove private project UUIDs from public profile relations in shared-server responses.

Enhancements:
- Apply credential redaction when existing templates are sanitized on read.
- Add regression coverage and security verification for the public response redactions.

Documentation:
- Document the late security review findings and verification results.

Tests:
- Add route regression coverage for OAuth redaction and public profile relation minimization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Privacy**
  - Public shared-server responses now expose only a profile’s public identifier and name.
  - Private project associations are no longer included in public profile details.
  - OAuth credentials are removed from server template data alongside other sensitive connection information.

- **Documentation**
  - Security verification records now include updated validation results and coverage for profile redaction, OAuth handling, and related endpoint protections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->