### PR TITLE
release: 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,13 @@ Grouped by what was wrong:
   from `package.json`; `APP_VERSION` still overrides. Release-scoped filtering
   in Sentry and Loki was silently wrong before this.
 
+  `/api/health` carried a third value, `2.18.0`, shown only to whitelisted
+  monitoring IPs — so the probe that exists to report the running version
+  reported one that had not existed for months. Found in review after the first
+  two were fixed, which is why
+  `tests/security/app-version-single-source.test.ts` now discovers the pattern
+  rather than trusting that someone looked everywhere.
+
 ### Advisories
 
 All five published advisories were verified against this release rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,97 @@ All notable changes to the Plugged.in platform will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-09-07
+
+The HIGH tier of the 2026-09-06 security scan, plus the fixes that came out of
+reviewing it. 66 commits, 38 of them tagged `security:`. No schema migration and
+no workflow change.
+
+Minor rather than major: no feature was removed and no data model changed.
+Several routes and server actions that were never reachable from the UI were
+deleted, and a few responses now carry fewer fields — see Removed and Changed.
+
+### Security
+
+All 65 active HIGH findings were checked against `623105ae` by reading the code.
+**Scan verdicts were treated as allegations, not evidence** — the scan's own
+revalidation step had been 79% wrong on the CRITICAL tier, confirming findings
+in files that had already been deleted. 58 records described real defects, five
+were already fixed, one was rejected against the upstream Kubernetes controller,
+and one was attributed to the wrong module. Evidence per finding is in
+[docs/security/high-triage-2026-09-07.md](docs/security/high-triage-2026-09-07.md).
+
+Grouped by what was wrong:
+
+- **Missing ownership checks.** Custom instructions, analytics by project uuid,
+  custom MCP server code and env vars, notifications, tools, server ratings, the
+  active-profile lookup, and MCP stream and deletion by session id now verify
+  the caller owns the thing they named.
+- **Server actions that were never meant to be public.** The audit-log writer,
+  trusted MCP discovery, log-retention helpers, the registry OAuth session
+  cleanup and the notification writers moved behind `server-only`. Every export
+  of a `'use server'` module is a public POST endpoint regardless of what calls
+  it, so the fix is to stop the module being one.
+- **Secrets in responses.** Agent GET, PATCH and export no longer return
+  `model_router_token`, `config_values` or metadata. Settings passes five fields
+  to the client instead of the users row. Shared templates omit OAuth
+  credentials and the private project relation.
+- **SSRF.** Model service sync uses `safeFetch`; remote MCP transports pin the
+  connection to the address that was validated, with an opt-in bounded stream so
+  SSE still delivers events before the connection ends.
+- **Admin boundaries.** Admin surfaces rely on the database `is_admin` role;
+  membership of `ADMIN_NOTIFICATION_EMAILS` no longer grants privileges. Cluster
+  registration, collector reads and alerts require that role.
+- **Auth lifecycle.** Password reset sets `password_changed_at`, which activates
+  the existing JWT revocation check. Duplicate registration returns a conflict
+  instead of replacing a pending account and its verification token. The
+  password-reset rate limiter reads the rightmost `X-Forwarded-For` address, so
+  a client-supplied prefix cannot rotate the bucket.
+- **Isolation.** MCP package mounts and runtime caches are per-server, so one
+  server's bubblewrap child cannot read a sibling's credentials.
+- **Uploads and output encoding.** Avatars are decoded under a pixel limit,
+  raster formats allowlisted, and re-encoded as server-named WebP. Admin
+  notification HTML escapes user-controlled fields.
+
+### Removed
+
+- `POST /api/audit-log` — unauthenticated and unused.
+- The global `cleanupExpiredSessions` action, which also carried an inverted
+  deletion predicate.
+- Public log-retention purge and policy mutation actions.
+
+### Fixed
+
+- Decoded AVIF avatars in the HEIF container are accepted.
+- Agent token status is preserved without exposing the credential.
+- The OpenCode backend stays behind the authenticated chamber.
+
+### Changed
+
+- **Log lines now carry the real version.** `lib/observability/logger.ts` and
+  `lib/logging.ts` each had a hardcoded fallback — `2.14.0` and `1.0.0` — and
+  `APP_VERSION` was set nowhere, so every production log claimed 2.14.0 while
+  the app was 4.0.0. Both now read `lib/app-version.ts`, which takes the version
+  from `package.json`; `APP_VERSION` still overrides. Release-scoped filtering
+  in Sentry and Loki was silently wrong before this.
+
+### Advisories
+
+All five published advisories were verified against this release rather than
+assumed: no shell `exec` remains in the pnpm or uv install handlers,
+`testMcpConnection` uses `execFileAsync('which', [command])`, the unshare
+endpoint returns 403 without profile ownership, and both SSRF guards classify
+the parsed address. 50 regression assertions cover them.
+
+Thank you again to Syed Anas Mohiuddin, EQSTLab, tonghuaroot and 0xParth — see
+[Acknowledgements](SECURITY.md#acknowledgements).
+
+### Verification
+
+Baseline at `623105ae` reproduces **189 failing assertions**; this release runs
+**1,897 passed / 189 failed** with the **same 189 names** and zero new failures.
+That is not a green suite — it is an unchanged one. `next build` succeeds.
+
 ## [4.0.0] - 2026-09-04
 
 A major by Semantic Versioning: two features were removed and the data model

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 **Turn your AI conversations into permanent organizational memory**
 
-[![Version](https://img.shields.io/badge/version-4.0.0-blue?style=for-the-badge)](https://github.com/VeriTeknik/pluggedin-app/releases)
+[![Version](https://img.shields.io/badge/version-4.1.0-blue?style=for-the-badge)](https://github.com/VeriTeknik/pluggedin-app/releases)
 [![GitHub Stars](https://img.shields.io/github/stars/VeriTeknik/pluggedin-app?style=for-the-badge)](https://github.com/VeriTeknik/pluggedin-app/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-green?style=for-the-badge)](LICENSE)
 [![Docker](https://img.shields.io/badge/docker-ready-blue?style=for-the-badge&logo=docker)](https://hub.docker.com/r/veriteknik/pluggedin)

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -22,6 +22,7 @@ import { sql } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { db } from '@/db';
+import { appVersion } from '@/lib/app-version';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -108,7 +109,7 @@ export async function GET(request: NextRequest) {
   // Only include detailed info for whitelisted monitoring IPs
   if (isMonitoring) {
     healthStatus.uptime = process.uptime();
-    healthStatus.version = process.env.APP_VERSION || '2.18.0';
+    healthStatus.version = appVersion();
     healthStatus.environment = process.env.NODE_ENV || 'development';
   }
 

--- a/lib/app-version.ts
+++ b/lib/app-version.ts
@@ -1,0 +1,16 @@
+// The one place the running application learns its own version.
+//
+// Two loggers each carried their own hardcoded fallback — '2.14.0' in
+// lib/observability/logger.ts and '1.0.0' in lib/logging.ts — and APP_VERSION
+// was never set in the Dockerfile, in compose or in CI. So every production log
+// line was stamped 2.14.0 while the app was 4.0.0, which makes release-scoped
+// filtering in Sentry or Loki quietly wrong rather than obviously broken.
+//
+// Reading package.json removes the fallback problem instead of updating it:
+// the value cannot drift from the release. Next inlines the import at build
+// time, so this works in the Edge runtime too, where `fs` does not exist.
+//
+// APP_VERSION still wins if set, so a deployment can override it.
+import pkg from '@/package.json';
+
+export const APP_VERSION: string = process.env.APP_VERSION || pkg.version;

--- a/lib/app-version.ts
+++ b/lib/app-version.ts
@@ -10,7 +10,15 @@
 // the value cannot drift from the release. Next inlines the import at build
 // time, so this works in the Edge runtime too, where `fs` does not exist.
 //
-// APP_VERSION still wins if set, so a deployment can override it.
+// APP_VERSION still wins if set, so a deployment can override it. It is read on
+// each call rather than captured at import, which is what the previous inline
+// `process.env.APP_VERSION || '…'` did — the health route reports per request,
+// and tests set the variable after importing the route.
 import pkg from '@/package.json';
 
-export const APP_VERSION: string = process.env.APP_VERSION || pkg.version;
+export function appVersion(): string {
+  return process.env.APP_VERSION || pkg.version;
+}
+
+/** For callers evaluated once at module init, such as a logger's base fields. */
+export const APP_VERSION: string = appVersion();

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -15,6 +15,8 @@
 import { randomUUID } from 'crypto';
 import pino from 'pino';
 
+import { APP_VERSION } from '@/lib/app-version';
+
 // Determine environment
 const isDevelopment = process.env.NODE_ENV === 'development';
 const isProduction = process.env.NODE_ENV === 'production';
@@ -28,7 +30,7 @@ export const logger = pino({
   base: {
     service: process.env.SERVICE_NAME || 'pluggedin-service',
     environment: process.env.NODE_ENV || 'development',
-    version: process.env.APP_VERSION || '1.0.0',
+    version: APP_VERSION,
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     hostname: process.env.HOSTNAME || require('os').hostname(),
   },

--- a/lib/observability/logger.ts
+++ b/lib/observability/logger.ts
@@ -22,6 +22,8 @@
 import { randomUUID } from 'crypto';
 import pino from 'pino';
 
+import { APP_VERSION } from '@/lib/app-version';
+
 // ========================================
 // Environment Detection
 // ========================================
@@ -98,7 +100,7 @@ export const logger = pino({
   base: {
     service: process.env.SERVICE_NAME || 'pluggedin-app',
     environment: process.env.NODE_ENV || 'development',
-    version: process.env.APP_VERSION || '2.14.0',
+    version: APP_VERSION,
     pid: process.pid,
     // Edge Runtime doesn't support the 'os' module
     hostname: (() => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pluggedin-app",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "type": "module",
   "engines": {

--- a/tests/api/health.test.ts
+++ b/tests/api/health.test.ts
@@ -3,8 +3,9 @@
  * Tests health checks, IP-based access control, and error handling
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { GET, HEAD } from '@/app/api/health/route';
 
 // Mock the database
@@ -13,6 +14,9 @@ vi.mock('@/db', () => ({
     execute: vi.fn(),
   },
 }));
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { db } from '@/db';
 
@@ -221,6 +225,10 @@ describe('/api/health', () => {
     });
 
     describe('Environment variable handling', () => {
+      const pkgVersion = JSON.parse(
+        readFileSync(join(process.cwd(), 'package.json'), 'utf8')
+      ).version as string;
+
       it('should use default version when APP_VERSION not set', async () => {
         vi.mocked(db.execute).mockResolvedValueOnce([{ health_check: 1 }] as any);
         delete process.env.APP_VERSION;
@@ -232,7 +240,9 @@ describe('/api/health', () => {
         const response = await GET(request);
         const data = await response.json();
 
-        expect(data.version).toBe('2.18.0'); // Default version
+        // The default is package.json's version, not a literal that goes stale.
+        // Three modules carried three different stale literals before this.
+        expect(data.version).toBe(pkgVersion); // Default version
       });
 
       it('should use custom APP_VERSION when set', async () => {

--- a/tests/security/app-version-single-source.test.ts
+++ b/tests/security/app-version-single-source.test.ts
@@ -25,7 +25,7 @@ import { join } from 'node:path';
 
 import { describe, expect, it } from 'vitest';
 
-import { APP_VERSION } from '@/lib/app-version';
+import { appVersion } from '@/lib/app-version';
 
 const SOURCE = 'lib/app-version.ts';
 
@@ -46,10 +46,32 @@ describe('app version', () => {
     expect(files.length).toBeGreaterThan(100);
   });
 
-  it('matches package.json', async () => {
+  it('falls back to package.json when APP_VERSION is unset', () => {
+    // Through appVersion(), not the constant: the constant is captured at
+    // import, so a machine that happens to have APP_VERSION set would fail this
+    // for a reason that has nothing to do with the code. Raised in review.
     const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+    const original = process.env.APP_VERSION;
+    delete process.env.APP_VERSION;
 
-    expect(APP_VERSION).toBe(pkg.version);
+    try {
+      expect(appVersion()).toBe(pkg.version);
+    } finally {
+      if (original === undefined) delete process.env.APP_VERSION;
+      else process.env.APP_VERSION = original;
+    }
+  });
+
+  it('lets APP_VERSION override', () => {
+    const original = process.env.APP_VERSION;
+    process.env.APP_VERSION = '9.9.9-test';
+
+    try {
+      expect(appVersion()).toBe('9.9.9-test');
+    } finally {
+      if (original === undefined) delete process.env.APP_VERSION;
+      else process.env.APP_VERSION = original;
+    }
   });
 
   it('is read from one module — no file falls back to a literal', () => {

--- a/tests/security/app-version-single-source.test.ts
+++ b/tests/security/app-version-single-source.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The application's own version has one source.
+ *
+ * Three places each carried a different hardcoded fallback, and `APP_VERSION`
+ * was set in none of the Dockerfile, compose or CI:
+ *
+ *   lib/observability/logger.ts   '2.14.0'
+ *   lib/logging.ts                '1.0.0'
+ *   app/api/health/route.ts       '2.18.0'
+ *
+ * …while the app was 4.0.0. Every log line and every monitored health probe
+ * reported a version that had not existed for months, which makes
+ * release-scoped filtering in Sentry or Loki wrong rather than absent.
+ *
+ * I fixed the first two and missed the third; review caught it. Hence this
+ * test: it discovers the pattern instead of trusting that someone looked
+ * everywhere. `lib/app-version.ts` is the only place allowed to decide.
+ *
+ * Not covered, deliberately: `clientInfo.version` in the MCP handshake and the
+ * package-version fallback in registry-servers.ts. Those are other things'
+ * versions, not ours.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { APP_VERSION } from '@/lib/app-version';
+
+const SOURCE = 'lib/app-version.ts';
+
+function sourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.next') continue;
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) sourceFiles(full, acc);
+    else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) acc.push(full);
+  }
+  return acc;
+}
+
+describe('app version', () => {
+  const files = ['app', 'lib'].flatMap((d) => sourceFiles(d));
+
+  it('finds source files to check', () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it('matches package.json', async () => {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf8'));
+
+    expect(APP_VERSION).toBe(pkg.version);
+  });
+
+  it('is read from one module — no file falls back to a literal', () => {
+    // `process.env.APP_VERSION || '<literal>'` is the shape that drifted.
+    const pattern = /APP_VERSION\s*\|\|\s*['"][^'"]+['"]/;
+    const offenders = files
+      .filter((f) => f !== SOURCE && !f.startsWith('tests'))
+      .filter((f) => pattern.test(readFileSync(f, 'utf8')));
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('detects the shape it is meant to catch', () => {
+    const pattern = /APP_VERSION\s*\|\|\s*['"][^'"]+['"]/;
+
+    expect(pattern.test(`version: process.env.APP_VERSION || '2.18.0',`)).toBe(true);
+    expect(pattern.test(`version: APP_VERSION,`)).toBe(false);
+  });
+});


### PR DESCRIPTION
66 commits since 4.0.0, **38 tagged `security:`** — the HIGH tier of the 2026-09-06 scan and the fixes from reviewing it. No schema migration, no workflow change.

**Minor, not major:** no feature removed, no data model changed. Some routes and server actions that were never reachable from the UI were deleted, and a few responses carry fewer fields.

## Why now

The five published advisories name `4.0.0` as patched, and that is accurate. But 66 commits of HIGH-tier fixes have been sitting unreleased, so a self-hoster on 4.0.0 gets the advisory fixes and none of this, with no version to move to. Same gap that prompted 4.0.0.

## Also: every production log line claimed the wrong version

Found while writing the entry. Two loggers each had a hardcoded fallback — `'2.14.0'` in `lib/observability/logger.ts`, `'1.0.0'` in `lib/logging.ts` — and `APP_VERSION` was set **nowhere**: not the Dockerfile, not compose, not CI.

```
{"level":"error","version":"2.14.0", … }     ← while running 4.0.0
```

Release-scoped filtering in Sentry or Loki was wrong in a way nothing surfaces.

Updating the two constants would re-arm the trap for 4.2.0. `lib/app-version.ts` reads `package.json` instead, so the value cannot drift from the release. Next inlines the import at build time, so it works in the Edge runtime where `fs` does not exist. `APP_VERSION` still overrides.

## Verification

| | |
|---|---|
| Suite | **1,897 passed / 189 failed** |
| vs deployed `main` | **same 189 names, zero new** |
| `next build` | exit 0 |
| `eslint` on touched files | 0 errors |

That is not a green suite — it is an unchanged one, and the CHANGELOG says so rather than implying otherwise.

After merge: tag `v4.1.0`, publish the release, deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/VeriTeknik/codesmith/pluggedin-app/pr/251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791676179&installation_model_id=430597&pr_number=251&repository=VeriTeknik%2Fpluggedin-app&return_to=https%3A%2F%2Fgithub.com%2FVeriTeknik%2Fpluggedin-app%2Fpull%2F251&signature=094f6ebc9e238eb2db7f4e05be086afd37903a12e70d7eba38cf126373fd640d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Summary by Sourcery

Release version 4.1.0 with the accumulated HIGH-severity security fixes and consistent application version reporting.

Bug Fixes:
- Address 58 confirmed HIGH-severity security defects across authorization, secret exposure, SSRF, administrative access, authentication lifecycle, isolation, uploads, and output encoding.
- Prevent unauthorized access to resources and server actions, remove sensitive fields from responses, and harden advisory-related endpoints.
- Correct application version reporting across health checks and production logs by deriving it from package metadata with an optional environment override.

Enhancements:
- Remove unused and publicly exposed audit-log, session-cleanup, and log-retention actions.
- Preserve agent token status without returning credentials and improve AVIF avatar handling.

Build:
- Bump the application version to 4.1.0.

Documentation:
- Document the 4.1.0 security fixes, advisory verification, removed and changed endpoints, and unchanged test-suite baseline.
- Update the README version badge to 4.1.0.

Tests:
- Add regression coverage for advisory fixes and enforce a single source of truth for application version reporting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened ownership and authorization checks, authentication lifecycle handling, server isolation, upload protection, output encoding, secret redaction, and SSRF safeguards.
  - Removed insecure endpoints and actions.
  - Verified applicable security advisories and completed high-priority security validation.

- **Bug Fixes**
  - Corrected application version reporting across health monitoring and logs.
  - Fixed several security-related behaviors.

- **Documentation**
  - Added the 4.1.0 changelog entry and updated the displayed application version to 4.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->